### PR TITLE
✨ Disable Styler formatting in `config` dir

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,6 @@
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  subdirectories: ["config"],
+  inputs: ["{mix,.formatter}.exs", "{lib,test}/**/*.{ex,exs}"],
   line_length: 98,
   plugins: [Styler]
 ]

--- a/config/.formatter.exs
+++ b/config/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  inputs: ["*.exs"],
+  line_length: 98
+]


### PR DESCRIPTION
I've noticed, in a different PR, that some comments were misplaced by the formatter in a config file. This seems to be a [known issue](https://github.com/adobe/elixir-styler/issues/187) in Styler so, here I'm excluding the Styler plugin from the `config/` directory.