### PR TITLE
♻️ little cleanup

### DIFF
--- a/test/integration/agent_collaboration_test.exs
+++ b/test/integration/agent_collaboration_test.exs
@@ -32,16 +32,6 @@ defmodule Lux.Integration.AgentCollaborationTest do
         }
       })
     end
-
-    def child_spec(opts) do
-      %{
-        id: {__MODULE__, opts[:name] || make_ref()},
-        start: {__MODULE__, :start_link, [opts]},
-        type: :worker,
-        restart: :temporary,
-        shutdown: 5000
-      }
-    end
   end
 
   defmodule WriterAgent do
@@ -69,16 +59,6 @@ defmodule Lux.Integration.AgentCollaborationTest do
           ]
         }
       })
-    end
-
-    def child_spec(opts) do
-      %{
-        id: {__MODULE__, opts[:name] || make_ref()},
-        start: {__MODULE__, :start_link, [opts]},
-        type: :worker,
-        restart: :temporary,
-        shutdown: 5000
-      }
     end
   end
 

--- a/test/unit/lux/agent_test.exs
+++ b/test/unit/lux/agent_test.exs
@@ -146,14 +146,14 @@ defmodule Lux.AgentTest do
   end
 
   describe "memory operations" do
-    test "initializes memory on start" do
-      {:ok, pid} = MemoryAgent.start_link()
+    test "initializes memory on start", %{test: test_name} do
+      {:ok, pid} = MemoryAgent.start_link(%{name: "Test Agent #{test_name}"})
       agent = :sys.get_state(pid)
       assert is_pid(agent.memory_pid)
     end
 
-    test "stores and retrieves interactions" do
-      {:ok, pid} = MemoryAgent.start_link()
+    test "stores and retrieves interactions", %{test: test_name} do
+      {:ok, pid} = MemoryAgent.start_link(%{name: "Test Agent #{test_name}"})
 
       # Send a message
       {:ok, response} = MemoryAgent.send_message(pid, "Hello")


### PR DESCRIPTION
After I updated agents to take unique names from the agent name, we don't need to override the child_spec in a few older tests. Moreover, this PR fixes some flaky tests that were failing when an existing agent was already started.