### PR TITLE
📝 setup the repo so that we can use hex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -83,7 +83,8 @@ defmodule Lux.MixProject do
         "GitHub" => "https://github.com/Spectral-Finance/lux",
         "Changelog" => "https://github.com/Spectral-Finance/lux/blob/main/CHANGELOG.md"
       },
-      files: ~w(lib priv/python/lux/*.py priv/python/hyperliquid_utils/*.py priv/python/*.py priv/python/*.toml priv/node/*.json priv/node/*.mjs .formatter.exs mix.exs README.md LICENSE CHANGELOG.md)
+      files:
+        ~w(lib priv/python/lux/*.py priv/python/hyperliquid_utils/*.py priv/python/*.py priv/python/*.toml priv/node/*.json priv/node/*.mjs .formatter.exs mix.exs README.md LICENSE CHANGELOG.md)
     ]
   end
 


### PR DESCRIPTION
This create Lux docs in Hex under the spectral_labs org. We have a 7 days free trial :)

I wonder what the process to make it public looks like (public open source repos are hosted for free)

The docs can be seen here: https://spectral_labs.hexdocs.pm/lux

In order to view them as of now, you must have a hex account. Once you've created an account, please share your email with me later so that I can add you to our org.


![image](https://github.com/user-attachments/assets/93183320-2680-4033-8230-b8d0dfb687fb)
