### PR TITLE
Include abi files

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,7 @@ defmodule Lux.MixProject do
         "Changelog" => "https://github.com/Spectral-Finance/lux/blob/main/CHANGELOG.md"
       },
       files:
-        ~w(lib priv/python/lux/*.py priv/python/hyperliquid_utils/*.py priv/python/*.py priv/python/*.toml priv/node/*.json priv/node/*.mjs .formatter.exs mix.exs README.md LICENSE CHANGELOG.md)
+        ~w(lib priv/web3/abis/* priv/python/lux/*.py priv/python/hyperliquid_utils/*.py priv/python/*.py priv/python/*.toml priv/node/*.json priv/node/*.mjs .formatter.exs mix.exs README.md LICENSE CHANGELOG.md)
     ]
   end
 


### PR DESCRIPTION
Just found that when installing `lux` from hex, we got following error. (version 0.4.0)

```
== Compilation error in file lib/lux/web3/contracts/agentic_company_factory.ex ==
** (File.Error) could not read file "priv/web3/abis/AgenticCompanyFactory.abi.json": no such file or directory
(elixir 1.18.2) lib/file.ex:385: File.read!/1
(ethers 0.6.4) lib/ethers/contract_helpers.ex:406: Ethers.ContractHelpers.do_read_abi/3
```

![0b57de44086ba5222f00c77aefe3d3dd629f777f0d5ce5ad59b3ba508cf12ae3](https://github.com/user-attachments/assets/fd423f94-d936-4d8c-9bd9-cb30293cb174)

Turns out that we need to include `priv/web3/*.abi.json` to the release binary because of [these files.](https://github.com/Spectral-Finance/lux/tree/cde62fbb2374eec13efdf4d770296bb2e3c405a7/lib/lux/web3/contracts)