### PR TITLE
add setup aliases in mix.ex

### DIFF
--- a/lux/Makefile
+++ b/lux/Makefile
@@ -300,6 +300,7 @@ setup-deps: ## Install project dependencies
 	fi
 	@mix local.hex --force
 	@mix local.rebar --force
+	@mix deps.get
 	@mix setup 
 
 test: ## Run test suite

--- a/lux/mix.exs
+++ b/lux/mix.exs
@@ -52,7 +52,6 @@ defmodule Lux.MixProject do
 
   defp aliases do
     [
-      setup: ["deps.get"],
       "test.unit": "test --include unit",
       "test.integration": "test --include integration",
       coveralls: "coveralls",

--- a/lux/mix.exs
+++ b/lux/mix.exs
@@ -52,6 +52,7 @@ defmodule Lux.MixProject do
 
   defp aliases do
     [
+      setup: ["deps.get"],
       "test.unit": "test --include unit",
       "test.integration": "test --include integration",
       coveralls: "coveralls",


### PR DESCRIPTION
Makefile has `@mix setup` but there was no alias in mix.exs so encountered

```
Unchecked dependencies for environment dev:
* venomous (Hex package)
  the dependency is not available, run "mix deps.get"
* bandit (Hex package)
  the dependency is not available, run "mix deps.get"
* crontab (Hex package)
  the dependency is not available, run "mix deps.get"
* nodejs (Hex package)
  the dependency is not available, run "mix deps.get"
* yaml_elixir (Hex package)
  the dependency is not available, run "mix deps.get"
* ex_json_schema (Hex package)
  the dependency is not available, run "mix deps.get"
* ex_secp256k1 (Hex package)
  the dependency is not available, run "mix deps.get"
* ex_doc (Hex package)
  the dependency is not available, run "mix deps.get"
* ethers (Hex package)
  the dependency is not available, run "mix deps.get"
* dialyxir (Hex package)
  the dependency is not available, run "mix deps.get"
* credo (Hex package)
  the dependency is not available, run "mix deps.get"
* dotenvy (Hex package)
  the dependency is not available, run "mix deps.get"
* req (Hex package)
  the dependency is not available, run "mix deps.get"
* styler (Hex package)
  the dependency is not available, run "mix deps.get"
** (Mix) Can't continue due to errors on dependencies
make[1]: *** [setup-deps] Error 1
make: *** [setup] Error 2
```