### PR TITLE
getting_started.md - cd into lux/lux

### DIFF
--- a/lux/guides/getting_started.md
+++ b/lux/guides/getting_started.md
@@ -17,7 +17,7 @@ Before installing Lux, ensure you have:
 
 ```bash
 git clone https://github.com/Spectral-Finance/lux.git
-cd lux
+cd lux/lux
 ```
 
 ### 2. System Dependencies


### PR DESCRIPTION
- Changes the initial cd command in this guide to be `cd lux/lux` so that the later make commands work from the inner lux directory.