### PR TITLE
Add livebook button

### DIFF
--- a/lux/guides/agents.livemd
+++ b/lux/guides/agents.livemd
@@ -34,11 +34,13 @@ Application.put_env(:venomous, :snake_manager, %{
 Application.ensure_all_started([:lux, :ex_unit, :kino])
 ```
 
-## Section
+## Overview
+
+<a href="https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2FSpectral-Finance%2Flux%2Fblob%2Fmain%2Flux%2Fguides%2Fagents.livemd" style="display: none">
+  <img src="https://livebook.dev/badge/v1/blue.svg" alt="Run in Livebook" />
+</a>
 
 Agents are autonomous components in Lux that can interact with LLMs, process signals, and execute workflows. They combine intelligence with execution capabilities, making them perfect for building conversational and agentic applications.
-
-## Overview
 
 An Agent consists of:
 

--- a/lux/guides/beams.livemd
+++ b/lux/guides/beams.livemd
@@ -27,6 +27,10 @@ Application.ensure_all_started([:lux, :kino, :ex_unit])
 
 ## Overview
 
+<a href="https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2FSpectral-Finance%2Flux%2Fblob%2Fmain%2Flux%2Fguides%2Fbeams.livemd" style="display: none">
+  <img src="https://livebook.dev/badge/v1/blue.svg" alt="Run in Livebook" />
+</a>
+
 Beams are the orchestration layer of Lux, allowing you to compose Prisms, Lenses, and other components into complex workflows. They support sequential, parallel, and conditional execution with rich error handling and logging.
 
 A Beam consists of:

--- a/lux/guides/core_concepts.md
+++ b/lux/guides/core_concepts.md
@@ -189,8 +189,8 @@ Lux supports multiple programming languages:
 - **Node.js**: Web integration and text processing
 
 Each language has specific guidelines and best practices detailed in:
-- [Python Guide](python.md)
-- [Node.js Guide](nodejs.md)
+- [Python Guide](language_support/python.livemd)
+- [Node.js Guide](language_support/nodejs.livemd)
 - Additional language support coming soon!
 
 ## Next Steps

--- a/lux/guides/getting_started.md
+++ b/lux/guides/getting_started.md
@@ -113,8 +113,8 @@ Lux supports multiple programming languages:
 - **Node.js**: Web integration and text processing
 
 Each language has its own guide:
-- [Python Guide](python.md)
-- [Node.js Guide](nodejs.md)
+- [Python Guide](language_support/python.livemd)
+- [Node.js Guide](language_support/nodejs.livemd)
 - Additional language support coming soon!
 
 ## Development Tools

--- a/lux/guides/language_support/nodejs.livemd
+++ b/lux/guides/language_support/nodejs.livemd
@@ -11,6 +11,10 @@ Application.ensure_all_started([:lux])
 
 ## Overview
 
+<a href="https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2FSpectral-Finance%2Flux%2Fblob%2Fmain%2Flux%2Fguides%2Flanguage_support%2Fnodejs.livemd" style="display: none">
+  <img src="https://livebook.dev/badge/v1/blue.svg" alt="Run in Livebook" />
+</a>
+
 Lux provides robust support for Node.js, allowing you to leverage the vast JavaScript ecosystem in your agents. This guide explains how to use Node.js effectively with Lux.
 
 ## Writing JavaScript Code

--- a/lux/guides/language_support/python.livemd
+++ b/lux/guides/language_support/python.livemd
@@ -11,6 +11,10 @@ Application.ensure_all_started([:lux])
 
 ## Overview
 
+<a href="https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2FSpectral-Finance%2Flux%2Fblob%2Fmain%2Flux%2Fguides%2Flanguage_support%2Fpython.livemd" style="display: none">
+  <img src="https://livebook.dev/badge/v1/blue.svg" alt="Run in Livebook" />
+</a>
+
 Lux provides first-class support for Python, allowing you to leverage Python's rich ecosystem of libraries and tools in your agents. This guide explains how to use Python effectively with Lux.
 
 ## Writing Python Code

--- a/lux/guides/lenses.livemd
+++ b/lux/guides/lenses.livemd
@@ -11,6 +11,10 @@ Application.ensure_all_started([:ex_unit])
 
 ## Overview
 
+<a href="https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2FSpectral-Finance%2Flux%2Fblob%2Fmain%2Flux%2Fguides%2Flenses.livemd" style="display: none">
+  <img src="https://livebook.dev/badge/v1/blue.svg" alt="Run in Livebook" />
+</a>
+
 Lenses provide a way to interact with external systems and APIs in a structured, composable way. They handle authentication, data transformation, and error handling for external integrations.
 
 A Lens consists of:

--- a/lux/guides/multi_agent_collaboration.livemd
+++ b/lux/guides/multi_agent_collaboration.livemd
@@ -21,6 +21,10 @@ Mix.install(
 
 ## Introduction
 
+<a href="https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2FSpectral-Finance%2Flux%2Fblob%2Fmain%2Flux%2Fguides%2Fmulti_agent_collaboration.livemd" style="display: none">
+  <img src="https://livebook.dev/badge/v1/blue.svg" alt="Run in Livebook" />
+</a>
+
 This guide demonstrates how to create and coordinate multiple agents working together in Lux.
 
 ## Basic Concepts

--- a/lux/guides/prisms.livemd
+++ b/lux/guides/prisms.livemd
@@ -30,6 +30,10 @@ Application.ensure_all_started([:lux, :ex_unit])
 
 ## Overview
 
+<a href="https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2FSpectral-Finance%2Flux%2Fblob%2Fmain%2Flux%2Fguides%2Fprisms.livemd" style="display: none">
+  <img src="https://livebook.dev/badge/v1/blue.svg" alt="Run in Livebook" />
+</a>
+
 Prisms are modular units of functionality that can be composed into workflows. They provide a way to encapsulate business logic, transformations, and integrations into reusable components.
 
 A Prism consists of:

--- a/lux/guides/running_a_company.livemd
+++ b/lux/guides/running_a_company.livemd
@@ -2,6 +2,10 @@
 
 ## Introduction
 
+<a href="https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2FSpectral-Finance%2Flux%2Fblob%2Fmain%2Flux%2Fguides%2Frunning_a_company.livemd" style="display: none">
+  <img src="https://livebook.dev/badge/v1/blue.svg" alt="Run in Livebook" />
+</a>
+
 In this guide, we'll create and run a complete Lux company that creates blog content. We'll:
 
 1. Define the company structure

--- a/lux/guides/signals.livemd
+++ b/lux/guides/signals.livemd
@@ -15,6 +15,10 @@ Application.ensure_all_started([:ex_unit])
 
 ## Overview
 
+<a href="https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2FSpectral-Finance%2Flux%2Fblob%2Fmain%2Flux%2Fguides%2Fsignals.livemd" style="display: none">
+  <img src="https://livebook.dev/badge/v1/blue.svg" alt="Run in Livebook" />
+</a>
+
 Signals are the fundamental units of communication in Lux. They provide a type-safe, schema-validated way for components to exchange information.
 
 A Signal consists of:

--- a/lux/guides/trading_system.livemd
+++ b/lux/guides/trading_system.livemd
@@ -56,6 +56,10 @@ When you run this notebook for the first time, you can get an error and see `Add
 
 ## Overview
 
+<a href="https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2FSpectral-Finance%2Flux%2Fblob%2Fmain%2Flux%2Fguides%2Ftrading_system.livemd" style="display: none">
+  <img src="https://livebook.dev/badge/v1/blue.svg" alt="Run in Livebook" />
+</a>
+
 This example demonstrates a simple trading system built with Lux agents. The system consists of:
 
 * A Market Researcher agent that analyzes market conditions and proposes trades


### PR DESCRIPTION
Added `Run in Livebook` buttons in every `*.livemd` files. They only can be rendered in the GitHub. The added button is only exposed on GitHub, not on Hex doc or livebook. Now lux users can easily access Livebook from both GitHub and Hex Doc.

Unfortunately, I couldn't completely unify the position of the button. In Livebook, due to the Markdown rendering constraints, there was a problem where the structure of the document changed when another element was inserted between h1 and the first code block, so I had to place the button under h2.

| GitHub | Hex Doc | Livebook |
|--------|--------|--------|
| ![CleanShot 2025-03-07 at 15 32 53@2x](https://github.com/user-attachments/assets/d12f864f-09d6-4a8e-a0d6-6da00f1132ef) | ![CleanShot 2025-03-07 at 15 33 39@2x](https://github.com/user-attachments/assets/432d3233-1bfd-4bd1-b033-09d84ccf5d42) | ![CleanShot 2025-03-07 at 15 36 42@2x](https://github.com/user-attachments/assets/f0aa2fe4-dfcf-4b91-8a10-28b56ce387cb) |
