### PR TITLE
Add topic attribute to Signal struct

### DIFF
--- a/lux/guides/signals.livemd
+++ b/lux/guides/signals.livemd
@@ -92,6 +92,7 @@ MyApp.Signals.Task.new(%{
    payload: %{priority: "low", title: "new signal", assignee: "agent"},
    sender: nil,
    recipient: nil,
+   topic: nil,
    timestamp: ~U[2025-02-12 12:56:51.873770Z],
    metadata: %{},
    schema_id: MyApp.Schemas.TaskSchema
@@ -144,6 +145,7 @@ NullSignal.new(%{payload: nil})
    payload: nil,
    sender: nil,
    recipient: nil,
+   topic: nil,
    timestamp: ~U[2025-02-12 12:56:51.899178Z],
    metadata: %{},
    schema_id: NullSchema
@@ -174,13 +176,14 @@ BooleanSignal.new(%{payload: true})
    payload: true,
    sender: nil,
    recipient: nil,
+   topic: nil,
    timestamp: ~U[2025-02-12 12:56:51.918708Z],
    metadata: %{},
    schema_id: BooleanSchema
  }}
 ```
 
-#### Integer Vlidation
+#### Integer Validation
 
 ```elixir
 defmodule IntegerSchema do
@@ -204,6 +207,7 @@ IntegerSignal.new(%{payload: 1})
    payload: 1,
    sender: nil,
    recipient: nil,
+   topic: nil,
    timestamp: ~U[2025-02-12 12:56:51.938289Z],
    metadata: %{},
    schema_id: IntegerSchema
@@ -234,6 +238,7 @@ StringSignal.new(%{payload: "payload"})
    payload: "payload",
    sender: nil,
    recipient: nil,
+   topic: nil,
    timestamp: ~U[2025-02-12 12:56:51.958540Z],
    metadata: %{},
    schema_id: StringSchema
@@ -268,6 +273,7 @@ ArraySignal.new(%{payload: ["data"]})
    payload: ["data"],
    sender: nil,
    recipient: nil,
+   topic: nil,
    timestamp: ~U[2025-02-12 12:56:51.978059Z],
    metadata: %{},
    schema_id: ArraySchema
@@ -331,6 +337,7 @@ ComplexObjectSignal.new(%{payload: %{
    },
    sender: nil,
    recipient: nil,
+   topic: nil,
    timestamp: ~U[2025-02-12 12:56:51.998781Z],
    metadata: %{},
    schema_id: ComplexObjectSchema
@@ -382,6 +389,7 @@ UserSignal.new(%{payload: %{
    payload: %{server: "lux.io", email: "hello@lux.io", last_login: "2024-03-21T17:32:28Z"},
    sender: nil,
    recipient: nil,
+   topic: nil,
    timestamp: ~U[2025-02-12 12:56:52.026939Z],
    metadata: %{},
    schema_id: UserSchema
@@ -553,6 +561,7 @@ signal
   },
   sender: nil,
   recipient: nil,
+  topic: nil,
   timestamp: ~U[2025-02-12 12:58:06.802667Z],
   metadata: %{},
   schema_id: MyApp.Schemas.TaskSchema
@@ -805,3 +814,11 @@ signal.metadata
 ```
 %{}
 ```
+
+### Signal Destination
+
+In Lux we provide two identifiers for where the signal is sent to.
+
+The first one is `recipient` and the second one is `topic`, in the recipient, a unique identifier of the expected agent to receive the signal is expected.
+On the other hand, a topic is used to indicate that the signal should be shared with a group of agents subscribed to that topic. So far, the routing by topic is
+an implementation detail of the server using Lux and not part of Lux out of the box.

--- a/lux/lib/lux/signal.ex
+++ b/lux/lib/lux/signal.ex
@@ -10,6 +10,7 @@ defmodule Lux.Signal do
           sender: String.t() | nil,
           recipient: String.t() | nil,
           timestamp: DateTime.t(),
+          topic: String.t() | nil,
           metadata: map(),
           schema_id: module() | nil
         }
@@ -19,6 +20,7 @@ defmodule Lux.Signal do
             sender: nil,
             recipient: nil,
             timestamp: nil,
+            topic: nil,
             metadata: %{},
             schema_id: nil
 
@@ -30,6 +32,7 @@ defmodule Lux.Signal do
         :sender,
         :recipient,
         :timestamp,
+        :topic,
         :metadata,
         :schema_id
       ]

--- a/lux/test/unit/lux/signal_test.exs
+++ b/lux/test/unit/lux/signal_test.exs
@@ -11,7 +11,8 @@ defmodule Lux.SignalTest do
         payload: %{message: "Hello"},
         metadata: %{created_at: "2024-01-01"},
         sender: "agent-1",
-        recipient: "agent-2"
+        recipient: "agent-2",
+        topic: "test-topic"
       }
 
       signal = Signal.new(attrs)
@@ -23,6 +24,7 @@ defmodule Lux.SignalTest do
       assert signal.metadata == %{created_at: "2024-01-01"}
       assert signal.sender == "agent-1"
       assert signal.recipient == "agent-2"
+      assert signal.topic == "test-topic"
     end
 
     test "initializes empty metadata when not provided" do
@@ -36,6 +38,7 @@ defmodule Lux.SignalTest do
       assert signal.metadata == %{}
       assert signal.sender == nil
       assert signal.recipient == nil
+      assert signal.topic == nil
     end
   end
 
@@ -56,6 +59,7 @@ defmodule Lux.SignalTest do
       assert signal.metadata == %{}
       assert signal.sender == nil
       assert signal.recipient == nil
+      assert signal.topic == nil
     end
 
     test "creates a signal with sender and recipient" do
@@ -71,6 +75,7 @@ defmodule Lux.SignalTest do
       assert signal.payload.message == "hello"
       assert signal.sender == "agent-1"
       assert signal.recipient == "agent-2"
+      assert signal.topic == nil
     end
 
     defmodule ValidatedSignal do


### PR DESCRIPTION
Adding the optional `topic` attribute to the signal struct so the Lux servers implementations can use this field to broadcast the signal to any interested agents vs. having a single receiver.