### PR TITLE
✨ Discord Channel Read Lens

### DIFF
--- a/lux/lib/lux/lenses/discord/channels/read_channel.ex
+++ b/lux/lib/lux/lenses/discord/channels/read_channel.ex
@@ -1,0 +1,70 @@
+defmodule Lux.Lenses.Discord.Channels.ReadChannel do
+  @moduledoc """
+  A lens for reading Discord channel information.
+  This lens provides a simple interface for reading Discord channel details with:
+  - Minimal required parameters (channel_id)
+  - Direct Discord API error propagation
+  - Clean response structure
+  ## Examples
+      iex> ReadChannel.focus(%{
+      ...>   channel_id: "123456789"
+      ...> })
+      {:ok, %{
+        id: "123456789",
+        name: "general",
+        type: 0,
+        guild_id: "987654321"
+      }}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "Read Discord Channel",
+    description: "Reads channel information from Discord",
+    url: "https://discord.com/api/v10/channels/:channel_id",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        channel_id: %{
+          type: :string,
+          description: "The ID of the channel to read",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["channel_id"]
+    }
+
+  @doc """
+  Transforms the Discord API response into a simpler format.
+  ## Examples
+      iex> after_focus(%{
+      ...>   "id" => "123456789",
+      ...>   "name" => "general",
+      ...>   "type" => 0,
+      ...>   "guild_id" => "987654321"
+      ...> })
+      {:ok, %{
+        id: "123456789",
+        name: "general",
+        type: 0,
+        guild_id: "987654321"
+      }}
+  """
+  @impl true
+  def after_focus(%{"id" => id, "name" => name, "type" => type, "guild_id" => guild_id}) do
+    {:ok, %{
+      id: id,
+      name: name,
+      type: type,
+      guild_id: guild_id
+    }}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/channels/read_channel_test.exs
+++ b/lux/test/unit/lux/lenses/discord/channels/read_channel_test.exs
@@ -1,0 +1,74 @@
+defmodule Lux.Lenses.Discord.Channels.ReadChannelTest do
+  @moduledoc """
+  Test suite for the ReadChannel module.
+  These tests verify the lens's ability to:
+  - Read channel information from Discord
+  - Handle Discord API errors appropriately
+  - Validate input/output schemas
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Channels.ReadChannel
+
+  @channel_id "123456789012345678"
+  @guild_id "987654321098765432"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully reads a channel" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/channels/:channel_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "id" => @channel_id,
+          "guild_id" => @guild_id,
+          "name" => "general",
+          "type" => 0
+        }))
+      end)
+
+      assert {:ok, %{
+        id: @channel_id,
+        guild_id: @guild_id,
+        name: "general",
+        type: 0
+      }} = ReadChannel.focus(%{
+        "channel_id" => @channel_id
+      }, %{})
+    end
+
+    test "handles Discord API error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/channels/:channel_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Missing Permissions"}} = ReadChannel.focus(%{
+        "channel_id" => @channel_id
+      }, %{})
+    end
+  end
+
+  describe "schema validation" do
+    test "validates schema" do
+      lens = ReadChannel.view()
+      assert lens.schema.required == ["channel_id"]
+      assert Map.has_key?(lens.schema.properties, :channel_id)
+    end
+  end
+end


### PR DESCRIPTION
## Overview
Refactored Discord channel read lens to follow the patterns established in PR #181.

### Changes
- Removed unnecessary `before_focus` override
- Added `@impl true` annotation for explicit interface implementation
- Simplified error handling by removing catch-all case
- Implemented direct Discord API error propagation

### Example Response
```elixir
# Success case
{:ok, %{
  id: "123456789",
  name: "general",
  type: 0,
  guild_id: "987654321"
}}

# Error case (direct from Discord API)
{:error, %{"message" => "Missing Permissions"}}
```

### Test Coverage
- Successful channel read
- Discord API error handling
- Schema validation