### PR TITLE
✨ Discord List Messages Lens

### DIFF
--- a/lux/lib/lux/lenses/discord/messages/list_messages.ex
+++ b/lux/lib/lux/lenses/discord/messages/list_messages.ex
@@ -1,0 +1,83 @@
+defmodule Lux.Lenses.Discord.Messages.ListMessages do
+  @moduledoc """
+  A lens for listing messages from a Discord channel.
+  This lens provides a simple interface for fetching messages with:
+  - Minimal required parameters (channel_id)
+  - Direct Discord API error propagation
+  - Clean response structure
+  ## Examples
+      iex> ListMessages.focus(%{
+      ...>   channel_id: "123456789"
+      ...> })
+      {:ok, [
+        %{
+          content: "First message",
+          author: %{
+            id: "111222333",
+            username: "TestUser1"
+          }
+        },
+        %{
+          content: "Second message",
+          author: %{
+            id: "444555666",
+            username: "TestUser2"
+          }
+        }
+      ]}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "List Discord Messages",
+    description: "Lists messages from a Discord channel",
+    url: "https://discord.com/api/v10/channels/:channel_id/messages",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        channel_id: %{
+          type: :string,
+          description: "The ID of the channel to list messages from",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["channel_id"]
+    }
+
+  @doc """
+  Transforms the Discord API response into a simpler format.
+  ## Examples
+      iex> after_focus([
+      ...>   %{
+      ...>     "content" => "Hello!",
+      ...>     "author" => %{"id" => "123", "username" => "test"}
+      ...>   }
+      ...> ])
+      {:ok, [
+        %{
+          content: "Hello!",
+          author: %{id: "123", username: "test"}
+        }
+      ]}
+  """
+  @impl true
+  def after_focus(messages) when is_list(messages) do
+    {:ok, Enum.map(messages, fn %{"content" => content, "author" => author} ->
+      %{
+        content: content,
+        author: %{
+          id: author["id"],
+          username: author["username"]
+        }
+      }
+    end)}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+end

--- a/lux/lib/lux/lenses/discord/messages/list_messages.ex
+++ b/lux/lib/lux/lenses/discord/messages/list_messages.ex
@@ -3,35 +3,45 @@ defmodule Lux.Lenses.Discord.Messages.ListMessages do
   A lens for listing messages from a Discord channel.
   This lens provides a simple interface for fetching messages with:
   - Minimal required parameters (channel_id)
+  - Pagination support (limit, before, after, around)
   - Direct Discord API error propagation
   - Clean response structure
+
+  ## Pagination
+  The lens supports the following pagination parameters:
+  - limit: Number of messages to return (1-100, default 50)
+  - before: Get messages before this message ID
+  - after: Get messages after this message ID
+  - around: Get messages around this message ID
+
+  Note: Only one of before, after, or around should be specified.
+
   ## Examples
+      # Get latest 50 messages
       iex> ListMessages.focus(%{
       ...>   channel_id: "123456789"
       ...> })
-      {:ok, [
-        %{
-          content: "First message",
-          author: %{
-            id: "111222333",
-            username: "TestUser1"
-          }
-        },
-        %{
-          content: "Second message",
-          author: %{
-            id: "444555666",
-            username: "TestUser2"
-          }
-        }
-      ]}
+
+      # Get 100 messages before a specific message
+      iex> ListMessages.focus(%{
+      ...>   channel_id: "123456789",
+      ...>   limit: 100,
+      ...>   before: "111222333"
+      ...> })
+
+      # Get 25 messages around a specific message
+      iex> ListMessages.focus(%{
+      ...>   channel_id: "123456789",
+      ...>   limit: 25,
+      ...>   around: "111222333"
+      ...> })
   """
 
   alias Lux.Integrations.Discord
 
   use Lux.Lens,
     name: "List Discord Messages",
-    description: "Lists messages from a Discord channel",
+    description: "Lists messages from a Discord channel with pagination support",
     url: "https://discord.com/api/v10/channels/:channel_id/messages",
     method: :get,
     headers: Discord.headers(),
@@ -42,6 +52,28 @@ defmodule Lux.Lenses.Discord.Messages.ListMessages do
         channel_id: %{
           type: :string,
           description: "The ID of the channel to list messages from",
+          pattern: "^[0-9]{17,20}$"
+        },
+        limit: %{
+          type: :integer,
+          description: "Max number of messages to return (1-100)",
+          minimum: 1,
+          maximum: 100,
+          default: 50
+        },
+        before: %{
+          type: :string,
+          description: "Get messages before this message ID",
+          pattern: "^[0-9]{17,20}$"
+        },
+        after: %{
+          type: :string,
+          description: "Get messages after this message ID",
+          pattern: "^[0-9]{17,20}$"
+        },
+        around: %{
+          type: :string,
+          description: "Get messages around this message ID",
           pattern: "^[0-9]{17,20}$"
         }
       },

--- a/lux/test/unit/lux/lenses/discord/messages/list_messages_test.exs
+++ b/lux/test/unit/lux/lenses/discord/messages/list_messages_test.exs
@@ -12,6 +12,7 @@ defmodule Lux.Lenses.Discord.Messages.ListMessagesTest do
   alias Lux.Lenses.Discord.Messages.ListMessages
 
   @channel_id "123456789012345678"
+  @message_id "111111111111111111"
 
   setup do
     Req.Test.verify_on_exit!()
@@ -19,17 +20,22 @@ defmodule Lux.Lenses.Discord.Messages.ListMessagesTest do
   end
 
   describe "focus/2" do
-    test "successfully lists messages" do
+    test "successfully lists messages with default parameters" do
       Req.Test.expect(Lux.Lens, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/api/v10/channels/:channel_id/messages"
         assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
 
+        # Verify only channel_id is present in the query string
+        query = URI.decode_query(conn.query_string)
+        assert Map.keys(query) == ["channel_id"]
+        assert query["channel_id"] == @channel_id
+
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.send_resp(200, Jason.encode!([
           %{
-            "id" => "111111111111111111",
+            "id" => @message_id,
             "content" => "First message",
             "author" => %{
               "id" => "222222222222222222",
@@ -48,7 +54,7 @@ defmodule Lux.Lenses.Discord.Messages.ListMessagesTest do
       end)
 
       assert {:ok, messages} = ListMessages.focus(%{
-        "channel_id" => @channel_id
+        channel_id: @channel_id
       }, %{})
 
       assert length(messages) == 2
@@ -58,6 +64,44 @@ defmodule Lux.Lenses.Discord.Messages.ListMessagesTest do
       assert first.author.username == "TestUser1"
       assert second.content == "Second message"
       assert second.author.username == "TestUser2"
+    end
+
+    test "successfully lists messages with pagination parameters" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/channels/:channel_id/messages"
+
+        # Verify pagination parameters
+        query = URI.decode_query(conn.query_string)
+        assert query["limit"] == "25"
+        assert query["before"] == @message_id
+        assert query["channel_id"] == @channel_id
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([
+          %{
+            "id" => "222222222222222222",
+            "content" => "Previous message",
+            "author" => %{
+              "id" => "333333333333333333",
+              "username" => "TestUser"
+            }
+          }
+        ]))
+      end)
+
+      assert {:ok, messages} = ListMessages.focus(%{
+        channel_id: @channel_id,
+        limit: 25,
+        before: @message_id
+      }, %{})
+
+      assert length(messages) == 1
+      [message] = messages
+
+      assert message.content == "Previous message"
+      assert message.author.username == "TestUser"
     end
 
     test "handles Discord API error" do
@@ -74,16 +118,41 @@ defmodule Lux.Lenses.Discord.Messages.ListMessagesTest do
       end)
 
       assert {:error, %{"message" => "Missing Permissions"}} = ListMessages.focus(%{
-        "channel_id" => @channel_id
+        channel_id: @channel_id
       }, %{})
     end
   end
 
   describe "schema validation" do
-    test "validates schema" do
+    test "validates required fields" do
       lens = ListMessages.view()
       assert lens.schema.required == ["channel_id"]
-      assert Map.has_key?(lens.schema.properties, :channel_id)
+    end
+
+    test "validates pagination parameters" do
+      lens = ListMessages.view()
+
+      # Verify limit parameter
+      limit = lens.schema.properties.limit
+      assert limit.type == :integer
+      assert limit.minimum == 1
+      assert limit.maximum == 100
+      assert limit.default == 50
+
+      # Verify before parameter
+      before = lens.schema.properties.before
+      assert before.type == :string
+      assert before.pattern == "^[0-9]{17,20}$"
+
+      # Verify after parameter
+      after_param = lens.schema.properties.after
+      assert after_param.type == :string
+      assert after_param.pattern == "^[0-9]{17,20}$"
+
+      # Verify around parameter
+      around = lens.schema.properties.around
+      assert around.type == :string
+      assert around.pattern == "^[0-9]{17,20}$"
     end
   end
 end

--- a/lux/test/unit/lux/lenses/discord/messages/list_messages_test.exs
+++ b/lux/test/unit/lux/lenses/discord/messages/list_messages_test.exs
@@ -1,0 +1,89 @@
+defmodule Lux.Lenses.Discord.Messages.ListMessagesTest do
+  @moduledoc """
+  Test suite for the ListMessages module.
+  These tests verify the lens's ability to:
+  - List messages from a Discord channel
+  - Handle pagination parameters
+  - Process Discord API errors appropriately
+  - Validate input/output schemas
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Messages.ListMessages
+
+  @channel_id "123456789012345678"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully lists messages" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/channels/:channel_id/messages"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([
+          %{
+            "id" => "111111111111111111",
+            "content" => "First message",
+            "author" => %{
+              "id" => "222222222222222222",
+              "username" => "TestUser1"
+            }
+          },
+          %{
+            "id" => "333333333333333333",
+            "content" => "Second message",
+            "author" => %{
+              "id" => "444444444444444444",
+              "username" => "TestUser2"
+            }
+          }
+        ]))
+      end)
+
+      assert {:ok, messages} = ListMessages.focus(%{
+        "channel_id" => @channel_id
+      }, %{})
+
+      assert length(messages) == 2
+      [first, second] = messages
+
+      assert first.content == "First message"
+      assert first.author.username == "TestUser1"
+      assert second.content == "Second message"
+      assert second.author.username == "TestUser2"
+    end
+
+    test "handles Discord API error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/channels/:channel_id/messages"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Missing Permissions"}} = ListMessages.focus(%{
+        "channel_id" => @channel_id
+      }, %{})
+    end
+  end
+
+  describe "schema validation" do
+    test "validates schema" do
+      lens = ListMessages.view()
+      assert lens.schema.required == ["channel_id"]
+      assert Map.has_key?(lens.schema.properties, :channel_id)
+    end
+  end
+end


### PR DESCRIPTION
## Overview
Implements a lens for listing messages from a Discord channel, following the patterns established in PR #181.

### Changes
- Implements Discord channel messages listing functionality
- Follows the successful pattern from PR #181
- Direct Discord API error propagation
- Clean response structure with essential message data

### Example Response
```elixir
# Success case
{:ok, [
  %{
    content: "First message",
    author: %{
      id: "111222333",
      username: "TestUser1"
    }
  },
  %{
    content: "Second message",
    author: %{
      id: "444555666",
      username: "TestUser2"
    }
  }
]}

# Error case (direct from Discord API)
{:error, %{"message" => "Missing Permissions"}}
```

### Test Coverage
- Successful message listing
- Discord API error handling
- Schema validation