### PR TITLE
✨ Discord Edit Channel Prism

### DIFF
--- a/lux/lib/lux/prisms/discord/channels/edit_channel.ex
+++ b/lux/lib/lux/prisms/discord/channels/edit_channel.ex
@@ -1,0 +1,122 @@
+defmodule Lux.Prisms.Discord.Channels.EditChannel do
+  @moduledoc """
+  A prism for modifying Discord channel settings.
+
+  This prism allows you to edit various channel settings including:
+  - Channel name
+  - Channel topic
+  - Bitrate (for voice channels)
+  - User limit (for voice channels)
+  - NSFW flag
+
+  ## Examples
+
+      iex> EditChannel.handler(%{
+      ...>   "channel_id" => "123456789012345678",
+      ...>   "name" => "new-channel-name",
+      ...>   "topic" => "New channel topic"
+      ...> }, %{})
+      {:ok, %{
+        channel_id: "123456789012345678",
+        name: "new-channel-name",
+        topic: "New channel topic",
+        edited: true
+      }}
+
+  """
+
+  use Lux.Prism
+  alias Lux.Integrations.Discord.Client
+  require Logger
+
+  def input_schema do
+    %{
+      "type" => "object",
+      "required" => ["channel_id"],
+      "properties" => %{
+        "channel_id" => %{
+          "type" => "string",
+          "pattern" => "^\\d{17,20}$",
+          "description" => "The ID of the channel to edit"
+        },
+        "name" => %{
+          "type" => "string",
+          "minLength" => 1,
+          "maxLength" => 100,
+          "description" => "New name of the channel"
+        },
+        "topic" => %{
+          "type" => "string",
+          "maxLength" => 1024,
+          "description" => "New topic of the channel"
+        },
+        "bitrate" => %{
+          "type" => "integer",
+          "minimum" => 8000,
+          "description" => "Voice channel bitrate (bits per second)"
+        },
+        "user_limit" => %{
+          "type" => "integer",
+          "minimum" => 0,
+          "description" => "Maximum number of users in a voice channel"
+        },
+        "nsfw" => %{
+          "type" => "boolean",
+          "description" => "Whether the channel is NSFW"
+        }
+      }
+    }
+  end
+
+  def output_schema do
+    %{
+      "type" => "object",
+      "required" => ["channel_id", "edited"],
+      "properties" => %{
+        "channel_id" => %{
+          "type" => "string",
+          "description" => "The ID of the edited channel"
+        },
+        "name" => %{
+          "type" => "string",
+          "description" => "Updated channel name"
+        },
+        "topic" => %{
+          "type" => "string",
+          "description" => "Updated channel topic"
+        },
+        "edited" => %{
+          "type" => "boolean",
+          "description" => "Whether the channel was successfully edited"
+        }
+      }
+    }
+  end
+
+  def handler(%{"channel_id" => channel_id} = params, _context) do
+    Logger.info("Editing Discord channel #{channel_id}")
+
+    json_params =
+      params
+      |> Map.take(["name", "topic", "bitrate", "user_limit", "nsfw"])
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Map.new()
+
+    case Client.request(:patch, "/channels/#{channel_id}", %{json: json_params}) do
+      {:ok, response} ->
+        Logger.info("Successfully edited Discord channel #{channel_id}")
+
+        {:ok,
+         %{
+           channel_id: response["id"],
+           name: response["name"],
+           topic: response["topic"],
+           edited: true
+         }}
+
+      {:error, {status, message}} ->
+        Logger.warning("Failed to edit Discord channel #{channel_id}: #{status} - #{message}")
+        {:error, {status, message}}
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/discord/channels/edit_channel_test.exs
+++ b/lux/test/unit/lux/prisms/discord/channels/edit_channel_test.exs
@@ -1,0 +1,99 @@
+defmodule Lux.Prisms.Discord.Channels.EditChannelTest do
+  @moduledoc """
+  Tests for the EditChannel prism which modifies Discord channel settings.
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Prisms.Discord.Channels.EditChannel
+
+  @channel_id "123456789012345678"
+  @agent_ctx %{agent: %{name: "TestAgent"}}
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "handler/2" do
+    test "successfully edits a channel" do
+      channel_name = "new-channel-name"
+      channel_topic = "New channel topic"
+
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "PATCH"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "id" => @channel_id,
+          "name" => channel_name,
+          "topic" => channel_topic,
+          "type" => 0
+        }))
+      end)
+
+      assert {:ok, response} =
+               EditChannel.handler(%{
+                 "channel_id" => @channel_id,
+                 "name" => channel_name,
+                 "topic" => channel_topic
+               }, @agent_ctx)
+
+      assert response.channel_id == @channel_id
+      assert response.name == channel_name
+      assert response.topic == channel_topic
+      assert response.edited == true
+    end
+
+    test "handles Discord API error" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "PATCH"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "message" => "Missing Permissions",
+          "code" => 50_013
+        }))
+      end)
+
+      assert {:error, {403, "Missing Permissions"}} =
+               EditChannel.handler(%{
+                 "channel_id" => @channel_id,
+                 "name" => "new-name"
+               }, @agent_ctx)
+    end
+  end
+
+  describe "schema validation" do
+    test "validates required properties" do
+      assert %{
+               "type" => "object",
+               "required" => ["channel_id"],
+               "properties" => %{
+                 "channel_id" => %{"type" => "string", "pattern" => "^\\d{17,20}$"},
+                 "name" => %{"type" => "string", "minLength" => 1, "maxLength" => 100},
+                 "topic" => %{"type" => "string", "maxLength" => 1024},
+                 "bitrate" => %{"type" => "integer", "minimum" => 8000},
+                 "user_limit" => %{"type" => "integer", "minimum" => 0},
+                 "nsfw" => %{"type" => "boolean"}
+               }
+             } = EditChannel.input_schema()
+
+      assert %{
+               "type" => "object",
+               "required" => ["channel_id", "edited"],
+               "properties" => %{
+                 "channel_id" => %{"type" => "string"},
+                 "name" => %{"type" => "string"},
+                 "topic" => %{"type" => "string"},
+                 "edited" => %{"type" => "boolean"}
+               }
+             } = EditChannel.output_schema()
+    end
+  end
+end


### PR DESCRIPTION
## Overview Implements a prism for editing Discord channel settings, following the patterns established in PR #180. ## Changes - Adds EditChannel prism for modifying Discord channel settings - Supports editing channel name, topic, bitrate, user limit, and NSFW flag - Includes comprehensive test coverage ## Example Response ```elixir {:ok, %{ channel_id: "123456789012345678", name: "new-channel-name", topic: "New channel topic", edited: true }} ``` ## Test Coverage - Successful channel editing - Discord API error handling - Schema validation