### PR TITLE
✨discord create thread prism

### DIFF
--- a/lux/lib/lux/prisms/discord/thread/create_thread.ex
+++ b/lux/lib/lux/prisms/discord/thread/create_thread.ex
@@ -1,0 +1,161 @@
+defmodule Lux.Prisms.Discord.Thread.CreateThread do
+  @moduledoc """
+  A prism for creating threads in a Discord channel.
+
+  This prism provides a simple interface for creating Discord threads with:
+  - Required parameters (channel_id, name)
+  - Optional parameters (message_id, auto_archive_duration, rate_limit_per_user)
+  - Direct Discord API error propagation
+  - Simple success/failure response structure
+
+  ## Examples
+      # Create a thread from a message
+      iex> CreateThread.handler(%{
+      ...>   channel_id: "123456789",
+      ...>   message_id: "987654321",
+      ...>   name: "Discussion Thread",
+      ...>   auto_archive_duration: 60
+      ...> }, %{name: "Agent"})
+      {:ok, %{
+        created: true,
+        thread_id: "111111111111111111",
+        name: "Discussion Thread",
+        channel_id: "123456789"
+      }}
+
+      # Create a thread without a message
+      iex> CreateThread.handler(%{
+      ...>   channel_id: "123456789",
+      ...>   name: "General Discussion",
+      ...>   auto_archive_duration: 1440,
+      ...>   rate_limit_per_user: 10
+      ...> }, %{name: "Agent"})
+      {:ok, %{
+        created: true,
+        thread_id: "111111111111111111",
+        name: "General Discussion",
+        channel_id: "123456789"
+      }}
+  """
+
+  use Lux.Prism,
+    name: "Create Discord Thread",
+    description: "Creates a thread in a Discord channel",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        channel_id: %{
+          type: :string,
+          description: "The ID of the channel to create the thread in",
+          pattern: "^[0-9]{17,20}$"
+        },
+        message_id: %{
+          type: :string,
+          description: "The ID of the message to create the thread from (optional)",
+          pattern: "^[0-9]{17,20}$"
+        },
+        name: %{
+          type: :string,
+          description: "The name of the thread",
+          minLength: 1,
+          maxLength: 100
+        },
+        auto_archive_duration: %{
+          type: :integer,
+          description: "Duration in minutes to automatically archive the thread (60, 1440, 4320, 10_080)",
+          enum: [60, 1440, 4320, 10_080],
+          default: 1440
+        },
+        rate_limit_per_user: %{
+          type: :integer,
+          description: "Amount of seconds a user has to wait before sending another message (0-21_600)",
+          minimum: 0,
+          maximum: 21_600,
+          default: 0
+        }
+      },
+      required: ["channel_id", "name"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        created: %{
+          type: :boolean,
+          description: "Whether the thread was successfully created"
+        },
+        thread_id: %{
+          type: :string,
+          description: "The ID of the created thread"
+        },
+        name: %{
+          type: :string,
+          description: "The name of the created thread"
+        },
+        channel_id: %{
+          type: :string,
+          description: "The ID of the channel where the thread was created"
+        }
+      },
+      required: ["created"]
+    }
+
+  alias Lux.Integrations.Discord.Client
+  require Logger
+
+  @doc """
+  Handles the request to create a thread in a Discord channel.
+
+  Returns {:ok, %{created: true, thread_id: id, name: name, channel_id: channel_id}} on success.
+  Returns {:error, reason} on failure.
+  """
+  def handler(params, agent) do
+    with {:ok, channel_id} <- validate_param(params, :channel_id),
+         {:ok, name} <- validate_param(params, :name),
+         {:ok, message_id} <- validate_optional_param(params, :message_id),
+         {:ok, auto_archive_duration} <- validate_optional_param(params, :auto_archive_duration, 1440),
+         {:ok, rate_limit_per_user} <- validate_optional_param(params, :rate_limit_per_user, 0) do
+
+      agent_name = agent[:name] || "Unknown Agent"
+      thread_type = if message_id, do: "from message #{message_id}", else: "without message"
+      Logger.info("Agent #{agent_name} creating thread #{thread_type} in channel #{channel_id}")
+
+      request_path = build_request_path(channel_id, message_id)
+      request_body = build_request_body(name, auto_archive_duration, rate_limit_per_user)
+
+      case Client.request(:post, request_path, %{json: request_body}) do
+        {:ok, %{"id" => thread_id}} ->
+          Logger.info("Successfully created thread #{thread_id} in channel #{channel_id}")
+          {:ok, %{created: true, thread_id: thread_id, name: name, channel_id: channel_id}}
+        error ->
+          Logger.error("Failed to create thread in channel #{channel_id}: #{inspect(error)}")
+          error
+      end
+    end
+  end
+
+  defp validate_param(params, key) do
+    case Map.fetch(params, key) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "Missing or invalid #{key}"}
+    end
+  end
+
+  defp validate_optional_param(params, key, default \\ nil) do
+    case Map.get(params, key, default) do
+      nil -> {:ok, nil}
+      value -> {:ok, value}
+    end
+  end
+
+  defp build_request_path(channel_id, nil), do: "/channels/#{channel_id}/threads"
+  defp build_request_path(channel_id, message_id), do: "/channels/#{channel_id}/messages/#{message_id}/threads"
+
+  defp build_request_body(name, auto_archive_duration, rate_limit_per_user) do
+    %{name: name}
+    |> maybe_add_param(:auto_archive_duration, auto_archive_duration)
+    |> maybe_add_param(:rate_limit_per_user, rate_limit_per_user)
+  end
+
+  defp maybe_add_param(map, _key, nil), do: map
+  defp maybe_add_param(map, key, value), do: Map.put(map, key, value)
+end

--- a/lux/test/unit/lux/prisms/discord/thread/create_thread_test.exs
+++ b/lux/test/unit/lux/prisms/discord/thread/create_thread_test.exs
@@ -1,0 +1,135 @@
+defmodule Lux.Prisms.Discord.Thread.CreateThreadTest do
+  use UnitAPICase, async: true
+  alias Lux.Prisms.Discord.Thread.CreateThread
+
+  @channel_id "123456789012345678"
+  @message_id "987654321098765432"
+  @thread_name "Test Thread"
+  @agent_ctx %{agent: %{name: "TestAgent"}}
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "handler/2" do
+    test "successfully creates a thread from a message" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}/messages/#{@message_id}/threads"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert Jason.decode!(body) == %{
+          "name" => @thread_name,
+          "auto_archive_duration" => 1440,
+          "rate_limit_per_user" => 0
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "id" => "111111111111111111",
+          "name" => @thread_name
+        }))
+      end)
+
+      assert {:ok, %{
+        created: true,
+        thread_id: "111111111111111111",
+        name: @thread_name,
+        channel_id: @channel_id
+      }} = CreateThread.handler(
+        %{
+          channel_id: @channel_id,
+          message_id: @message_id,
+          name: @thread_name,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "successfully creates a thread without a message" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}/threads"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert Jason.decode!(body) == %{
+          "name" => @thread_name,
+          "auto_archive_duration" => 60,
+          "rate_limit_per_user" => 10
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "id" => "111111111111111111",
+          "name" => @thread_name
+        }))
+      end)
+
+      assert {:ok, %{
+        created: true,
+        thread_id: "111111111111111111",
+        name: @thread_name,
+        channel_id: @channel_id
+      }} = CreateThread.handler(
+        %{
+          channel_id: @channel_id,
+          name: @thread_name,
+          auto_archive_duration: 60,
+          rate_limit_per_user: 10,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "handles Discord API error" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}/threads"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, {403, "Missing Permissions"}} = CreateThread.handler(
+        %{
+          channel_id: @channel_id,
+          name: @thread_name,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+  end
+
+  describe "schema validation" do
+    test "validates input schema" do
+      prism = CreateThread.view()
+      assert prism.input_schema.required == ["channel_id", "name"]
+      assert Map.has_key?(prism.input_schema.properties, :channel_id)
+      assert Map.has_key?(prism.input_schema.properties, :message_id)
+      assert Map.has_key?(prism.input_schema.properties, :name)
+      assert Map.has_key?(prism.input_schema.properties, :auto_archive_duration)
+      assert Map.has_key?(prism.input_schema.properties, :rate_limit_per_user)
+    end
+
+    test "validates output schema" do
+      prism = CreateThread.view()
+      assert prism.output_schema.required == ["created"]
+      assert Map.has_key?(prism.output_schema.properties, :created)
+      assert Map.has_key?(prism.output_schema.properties, :thread_id)
+      assert Map.has_key?(prism.output_schema.properties, :name)
+      assert Map.has_key?(prism.output_schema.properties, :channel_id)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new Prism for creating threads in Discord channels with the following features:

- Support for both standalone threads and message-based threads
- Configurable thread settings:
  - Auto-archive duration (60min, 24h, 3d, 7d)
  - Rate limiting for user messages (0-6h)
- Comprehensive input validation
- Detailed logging for thread creation operations
- Full test coverage including:
  - Message-based thread creation
  - Standalone thread creation
  - Error handling scenarios