### PR TITLE
✨ Discord Get Guild Lens

### DIFF
--- a/lux/lib/lux/lenses/discord/guilds/get_guild.ex
+++ b/lux/lib/lux/lenses/discord/guilds/get_guild.ex
@@ -1,0 +1,91 @@
+defmodule Lux.Lenses.Discord.Guilds.GetGuild do
+  @moduledoc """
+  A lens for reading Discord guild (server) information.
+  This lens provides a simple interface for reading Discord guild details with:
+  - Minimal required parameters (guild_id)
+  - Direct Discord API error propagation
+  - Clean response structure
+
+  ## Examples
+      iex> GetGuild.focus(%{
+      ...>   guild_id: "123456789012345678"
+      ...> })
+      {:ok, %{
+        id: "123456789012345678",
+        name: "My Server",
+        icon: "1234567890abcdef",
+        owner_id: "876543210987654321",
+        permissions: "1071698529857",
+        features: ["COMMUNITY", "NEWS"],
+        member_count: 42
+      }}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "Get Discord Guild",
+    description: "Reads guild information from Discord",
+    url: "https://discord.com/api/v10/guilds/:guild_id",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to read",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id"]
+    }
+
+  @doc """
+  Transforms the Discord API response into a simpler format.
+  ## Examples
+      iex> after_focus(%{
+      ...>   "id" => "123456789012345678",
+      ...>   "name" => "My Server",
+      ...>   "icon" => "1234567890abcdef",
+      ...>   "owner_id" => "876543210987654321",
+      ...>   "permissions" => "1071698529857",
+      ...>   "features" => ["COMMUNITY", "NEWS"],
+      ...>   "member_count" => 42
+      ...> })
+      {:ok, %{
+        id: "123456789012345678",
+        name: "My Server",
+        icon: "1234567890abcdef",
+        owner_id: "876543210987654321",
+        permissions: "1071698529857",
+        features: ["COMMUNITY", "NEWS"],
+        member_count: 42
+      }}
+  """
+  @impl true
+  def after_focus(%{
+        "id" => id,
+        "name" => name,
+        "icon" => icon,
+        "owner_id" => owner_id,
+        "permissions" => permissions,
+        "features" => features,
+        "member_count" => member_count
+      }) do
+    {:ok, %{
+      id: id,
+      name: name,
+      icon: icon,
+      owner_id: owner_id,
+      permissions: permissions,
+      features: features,
+      member_count: member_count
+    }}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/guilds/get_guild_test.exs
+++ b/lux/test/unit/lux/lenses/discord/guilds/get_guild_test.exs
@@ -1,0 +1,79 @@
+defmodule Lux.Lenses.Discord.Guilds.GetGuildTest do
+  @moduledoc """
+  Test suite for the GetGuild module.
+  These tests verify the lens's ability to:
+  - Read guild information from Discord
+  - Handle Discord API errors appropriately
+  - Validate input/output schemas
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Guilds.GetGuild
+
+  @guild_id "123456789012345678"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully reads a guild" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "id" => @guild_id,
+          "name" => "Test Server",
+          "icon" => "1234567890abcdef",
+          "owner_id" => "876543210987654321",
+          "permissions" => "1071698529857",
+          "features" => ["COMMUNITY", "NEWS"],
+          "member_count" => 42
+        }))
+      end)
+
+      assert {:ok, %{
+        id: @guild_id,
+        name: "Test Server",
+        icon: "1234567890abcdef",
+        owner_id: "876543210987654321",
+        permissions: "1071698529857",
+        features: ["COMMUNITY", "NEWS"],
+        member_count: 42
+      }} = GetGuild.focus(%{
+        "guild_id" => @guild_id
+      }, %{})
+    end
+
+    test "handles Discord API error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Missing Permissions"}} = GetGuild.focus(%{
+        "guild_id" => @guild_id
+      }, %{})
+    end
+  end
+
+  describe "schema validation" do
+    test "validates schema" do
+      lens = GetGuild.view()
+      assert lens.schema.required == ["guild_id"]
+      assert Map.has_key?(lens.schema.properties, :guild_id)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new Lens for retrieving Discord guild (server) information. The GetGuild lens provides a simple interface to:
- Fetch guild details including name, icon, owner, permissions, features, and member count
- Follow consistent patterns with other Discord lenses
- Include comprehensive test coverage for success and error cases

Key components:
- GetGuild lens implementation with proper schema validation
- Unit tests following the established Discord lens testing patterns
- Documentation with usage examples