### PR TITLE
✨discord get guild member lens

### DIFF
--- a/lux/lib/lux/lenses/discord/guilds/get_guild_member.ex
+++ b/lux/lib/lux/lenses/discord/guilds/get_guild_member.ex
@@ -1,0 +1,95 @@
+defmodule Lux.Lenses.Discord.Guilds.GetGuildMember do
+  @moduledoc """
+  A lens for reading Discord guild member information.
+  This lens provides a simple interface for reading guild member details with:
+  - Required parameters (guild_id, user_id)
+  - Direct Discord API error propagation
+  - Clean response structure
+
+  ## Examples
+      iex> GetGuildMember.focus(%{
+      ...>   guild_id: "123456789",
+      ...>   user_id: "987654321"
+      ...> })
+      {:ok, %{
+        user: %{
+          id: "987654321",
+          username: "example_user"
+        },
+        nick: "Custom Nickname",
+        roles: ["123456789", "234567890"],
+        joined_at: "2021-01-01T00:00:00.000000+00:00"
+      }}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "Read Discord Guild Member",
+    description: "Reads member information from a Discord guild",
+    url: "https://discord.com/api/v10/guilds/:guild_id/members/:user_id",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild",
+          pattern: "^[0-9]{17,20}$"
+        },
+        user_id: %{
+          type: :string,
+          description: "The ID of the user",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id", "user_id"]
+    }
+
+  @doc """
+  Transforms the Discord API response into a simpler format.
+
+  ## Examples
+      iex> after_focus(%{
+      ...>   "user" => %{
+      ...>     "id" => "987654321",
+      ...>     "username" => "example_user"
+      ...>   },
+      ...>   "nick" => "Custom Nickname",
+      ...>   "roles" => ["123456789", "234567890"],
+      ...>   "joined_at" => "2021-01-01T00:00:00.000000+00:00"
+      ...> })
+      {:ok, %{
+        user: %{
+          id: "987654321",
+          username: "example_user"
+        },
+        nick: "Custom Nickname",
+        roles: ["123456789", "234567890"],
+        joined_at: "2021-01-01T00:00:00.000000+00:00"
+      }}
+  """
+  @impl true
+  def after_focus(%{
+    "user" => %{"id" => id, "username" => username} = _user,
+    "nick" => nick,
+    "roles" => roles,
+    "joined_at" => joined_at
+  }) do
+    {:ok, %{
+      user: %{
+        id: id,
+        username: username
+      },
+      nick: nick,
+      roles: roles,
+      joined_at: joined_at
+    }}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/guilds/get_guild_member_test.exs
+++ b/lux/test/unit/lux/lenses/discord/guilds/get_guild_member_test.exs
@@ -1,0 +1,83 @@
+defmodule Lux.Lenses.Discord.Guilds.GetGuildMemberTest do
+  @moduledoc """
+  Test suite for the GetGuildMember module.
+  These tests verify the lens's ability to:
+  - Read guild member information from Discord
+  - Handle Discord API errors appropriately
+  - Validate input/output schemas
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Guilds.GetGuildMember
+
+  @guild_id "123456789012345678"
+  @user_id "987654321098765432"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully reads a guild member" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id/members/:user_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "user" => %{
+            "id" => @user_id,
+            "username" => "TestUser"
+          },
+          "nick" => "Custom Nick",
+          "roles" => ["111111111111111111", "222222222222222222"],
+          "joined_at" => "2021-01-01T00:00:00.000000+00:00"
+        }))
+      end)
+
+      assert {:ok, %{
+        user: %{
+          id: @user_id,
+          username: "TestUser"
+        },
+        nick: "Custom Nick",
+        roles: ["111111111111111111", "222222222222222222"],
+        joined_at: "2021-01-01T00:00:00.000000+00:00"
+      }} = GetGuildMember.focus(%{
+        "guild_id" => @guild_id,
+        "user_id" => @user_id
+      }, %{})
+    end
+
+    test "handles Discord API error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id/members/:user_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Missing Permissions"}} = GetGuildMember.focus(%{
+        "guild_id" => @guild_id,
+        "user_id" => @user_id
+      }, %{})
+    end
+  end
+
+  describe "schema validation" do
+    test "validates schema" do
+      lens = GetGuildMember.view()
+      assert lens.schema.required == ["guild_id", "user_id"]
+      assert Map.has_key?(lens.schema.properties, :guild_id)
+      assert Map.has_key?(lens.schema.properties, :user_id)
+    end
+  end
+end


### PR DESCRIPTION
# Add GetGuildMember Lens

This PR adds a new lens for retrieving specific member information from a Discord guild.

## Key Features
- Uses Discord API v10's `/guilds/{guild_id}/members/{user_id}` endpoint to fetch member information
- Validates required parameters (`guild_id`, `user_id`)
- Transforms Discord API responses into a clean, easy-to-use format
- Handles and propagates errors appropriately

## Implementation Details
- Implements `Lux.Lenses.Discord.Guilds.GetGuildMember` lens
- Adds comprehensive unit tests (success case, error case, schema validation)
- Follows consistent patterns established by existing Discord lenses

## Usage Example
```elixir
Lux.focus(GetGuildMember, %{guild_id: "123", user_id: "456"})
```

## Value
This lens enables agents to easily retrieve specific member information (nickname, roles, join date, etc.) from Discord guilds. This functionality is essential for member management, permission verification, and other guild-related features.