### PR TITLE
✨discord list guild members lens

### DIFF
--- a/lux/lib/lux/lenses/discord/guilds/list_guild_members.ex
+++ b/lux/lib/lux/lenses/discord/guilds/list_guild_members.ex
@@ -1,0 +1,145 @@
+defmodule Lux.Lenses.Discord.Guilds.ListGuildMembers do
+  @moduledoc """
+  A lens for reading Discord guild members.
+  This lens provides a simple interface for reading guild members with:
+  - Minimal required parameters (guild_id)
+  - Optional pagination support (limit, after)
+  - Direct Discord API error propagation
+  - Clean response structure
+
+  ## Examples
+      iex> ListGuildMembers.focus(%{
+      ...>   "guild_id" => "123456789"
+      ...> })
+      {:ok, [
+        %{
+          user: %{
+            id: "111222333",
+            username: "user1",
+            avatar: "avatar1"
+          },
+          nick: "nickname1",
+          roles: ["role1", "role2"],
+          joined_at: "2023-01-01T00:00:00.000Z"
+        }
+      ]}
+
+      iex> ListGuildMembers.focus(%{
+      ...>   "guild_id" => "123456789",
+      ...>   "limit" => 50,
+      ...>   "after" => "111222333"
+      ...> })
+      {:ok, [
+        %{
+          user: %{
+            id: "444555666",
+            username: "user2",
+            avatar: "avatar2"
+          },
+          nick: "nickname2",
+          roles: ["role2", "role3"],
+          joined_at: "2023-01-02T00:00:00.000Z"
+        }
+      ]}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "List Discord Guild Members",
+    description: "Lists members from a Discord guild",
+    url: "https://discord.com/api/v10/guilds/:guild_id/members",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to fetch members from",
+          pattern: "^[0-9]{17,20}$"
+        },
+        limit: %{
+          type: :integer,
+          description: "Max number of members to return (1-1000)",
+          minimum: 1,
+          maximum: 1000
+        },
+        after: %{
+          type: :string,
+          description: "The highest user ID in the previous page",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id"]
+    }
+
+  @doc """
+  Transforms the Discord API response into a simpler format.
+  ## Examples
+      iex> after_focus([
+      ...>   %{
+      ...>     "user" => %{
+      ...>       "id" => "111222333",
+      ...>       "username" => "user1",
+      ...>       "avatar" => "avatar1"
+      ...>     },
+      ...>     "nick" => "nickname1",
+      ...>     "roles" => ["role1", "role2"],
+      ...>     "joined_at" => "2023-01-01T00:00:00.000Z",
+      ...>     "premium_since" => nil,
+      ...>     "pending" => false,
+      ...>     "communication_disabled_until" => nil
+      ...>   }
+      ...> ])
+      {:ok, [
+        %{
+          user: %{
+            id: "111222333",
+            username: "user1",
+            avatar: "avatar1"
+          },
+          nick: "nickname1",
+          roles: ["role1", "role2"],
+          joined_at: "2023-01-01T00:00:00.000Z",
+          premium_since: nil,
+          pending: false,
+          communication_disabled_until: nil
+        }
+      ]}
+  """
+  @impl true
+  def after_focus(members) when is_list(members) do
+    transformed_members =
+      Enum.map(members, fn %{
+                           "user" => %{"id" => id, "username" => username, "avatar" => avatar},
+                           "nick" => nick,
+                           "roles" => roles,
+                           "joined_at" => joined_at,
+                           "premium_since" => premium_since,
+                           "pending" => pending,
+                           "communication_disabled_until" => communication_disabled_until
+                         } ->
+        %{
+          user: %{
+            id: id,
+            username: username,
+            avatar: avatar
+          },
+          nick: nick,
+          roles: roles,
+          joined_at: joined_at,
+          premium_since: premium_since,
+          pending: pending,
+          communication_disabled_until: communication_disabled_until
+        }
+      end)
+
+    {:ok, transformed_members}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/guilds/list_guild_members_test.exs
+++ b/lux/test/unit/lux/lenses/discord/guilds/list_guild_members_test.exs
@@ -1,0 +1,145 @@
+defmodule Lux.Lenses.Discord.Guilds.ListGuildMembersTest do
+  @moduledoc """
+  Test suite for the ListGuildMembers module.
+  These tests verify the lens's ability to:
+  - List members from a Discord guild
+  - Handle pagination parameters
+  - Process Discord API errors appropriately
+  - Validate input/output schemas
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Guilds.ListGuildMembers
+
+  @guild_id "123456789012345678"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully lists guild members" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id/members"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([
+          %{
+            "user" => %{
+              "id" => "111222333444555666",
+              "username" => "user1",
+              "avatar" => "avatar1"
+            },
+            "nick" => "nickname1",
+            "roles" => ["role1", "role2"],
+            "joined_at" => "2023-01-01T00:00:00.000Z",
+            "premium_since" => nil,
+            "pending" => false,
+            "communication_disabled_until" => nil
+          }
+        ]))
+      end)
+
+      assert {:ok, [member]} = ListGuildMembers.focus(%{
+        "guild_id" => @guild_id
+      }, %{})
+
+      assert member == %{
+        user: %{
+          id: "111222333444555666",
+          username: "user1",
+          avatar: "avatar1"
+        },
+        nick: "nickname1",
+        roles: ["role1", "role2"],
+        joined_at: "2023-01-01T00:00:00.000Z",
+        premium_since: nil,
+        pending: false,
+        communication_disabled_until: nil
+      }
+    end
+
+    test "successfully lists guild members with pagination" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id/members"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        # Verify pagination parameters
+        query = URI.decode_query(conn.query_string)
+        assert query["limit"] == "50"
+        assert query["after"] == "111222333444555666"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([
+          %{
+            "user" => %{
+              "id" => "222333444555666777",
+              "username" => "user2",
+              "avatar" => "avatar2"
+            },
+            "nick" => "nickname2",
+            "roles" => ["role2", "role3"],
+            "joined_at" => "2023-01-02T00:00:00.000Z",
+            "premium_since" => nil,
+            "pending" => false,
+            "communication_disabled_until" => nil
+          }
+        ]))
+      end)
+
+      assert {:ok, [member]} = ListGuildMembers.focus(%{
+        "guild_id" => @guild_id,
+        "limit" => 50,
+        "after" => "111222333444555666"
+      }, %{})
+
+      assert member == %{
+        user: %{
+          id: "222333444555666777",
+          username: "user2",
+          avatar: "avatar2"
+        },
+        nick: "nickname2",
+        roles: ["role2", "role3"],
+        joined_at: "2023-01-02T00:00:00.000Z",
+        premium_since: nil,
+        pending: false,
+        communication_disabled_until: nil
+      }
+    end
+
+    test "handles Discord API error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id/members"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Missing Permissions"}} = ListGuildMembers.focus(%{
+        "guild_id" => @guild_id
+      }, %{})
+    end
+  end
+
+  describe "schema validation" do
+    test "validates schema" do
+      lens = ListGuildMembers.view()
+      assert lens.schema.required == ["guild_id"]
+      assert Map.has_key?(lens.schema.properties, :guild_id)
+      assert Map.has_key?(lens.schema.properties, :limit)
+      assert Map.has_key?(lens.schema.properties, :after)
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the ListGuildMembers lens that provides a clean interface for retrieving member information from Discord guilds. The lens follows the established patterns from other Discord lenses and includes:

Key Features:
- Fetches guild members with minimal required parameters (guild_id)
- Supports pagination through optional limit and after parameters
- Transforms complex Discord API responses into a clean, consistent format
- Includes comprehensive test coverage following the UnitAPICase pattern
- Properly handles Discord API errors with meaningful messages

The lens is particularly useful for agents that need to:
- Get information about guild members for role management
- Implement member listing functionality with pagination
- Monitor guild member status and properties