### PR TITLE
♻️ Add handle response in client

### DIFF
--- a/lux/lib/lux/integrations/discord/client.ex
+++ b/lux/lib/lux/integrations/discord/client.ex
@@ -81,6 +81,34 @@ defmodule Lux.Integrations.Discord.Client do
     end
   end
 
+  @doc """
+  Handles the response from a Discord API request and logs appropriate messages.
+
+  ## Parameters
+
+    * `result` - The result tuple from the request
+    * `caller_module` - The module that made the request (used for logging context)
+
+  ## Examples
+
+      iex> handle_response({:ok, %{"id" => "123"}}, __MODULE__)
+      {:ok, %{"id" => "123"}}
+  """
+  @spec handle_response(
+    {:ok, map()} | {:error, term()},
+    module()
+  ) :: {:ok, map()} | {:error, term()}
+  def handle_response(result, caller_module) do
+    case result do
+      {:ok, response} ->
+        Logger.info("[#{inspect(caller_module)}] Discord API request successful")
+        {:ok, response}
+      error ->
+        Logger.error("[#{inspect(caller_module)}] Discord API request failed: #{inspect(error)}")
+        error
+    end
+  end
+
   defp build_auth_header(token, token_type) do
     case token_type do
       :bot -> "Bot #{token}"

--- a/lux/lib/lux/prisms/discord/message/send_message.ex
+++ b/lux/lib/lux/prisms/discord/message/send_message.ex
@@ -79,17 +79,12 @@ defmodule Lux.Prisms.Discord.Messages.SendMessage do
       agent_name = agent[:name] || "Unknown Agent"
       Logger.info("Agent #{agent_name} sending message to channel #{channel_id}: #{content}")
 
-      case Client.request(:post, "/channels/#{channel_id}/messages", %{json: %{content: content}}) do
+      Client.request(:post, "/channels/#{channel_id}/messages", %{json: %{content: content}})
+      |> Client.handle_response(__MODULE__)
+      |> case do
         {:ok, %{"id" => message_id}} ->
-          Logger.info("Successfully sent message #{message_id} to channel #{channel_id}")
           {:ok, %{sent: true, message_id: message_id, content: content, channel_id: channel_id}}
-        {:error, {status, %{"message" => message}}} ->
-          error = {status, message}
-          Logger.error("Failed to send message to channel #{channel_id}: #{inspect(error)}")
-          {:error, error}
-        {:error, error} ->
-          Logger.error("Failed to send message to channel #{channel_id}: #{inspect(error)}")
-          {:error, error}
+        error -> error
       end
     end
   end


### PR DESCRIPTION
Centralize Discord API logging in Client module

- Simplified logging by moving common logging logic to Client.handle_response
- Removed duplicate logging code from Discord prisms
- Made logging format more consistent with "[ModuleName] Discord API request successful/failed"
- Tested with SendMessage prism as initial implementation

If this approach looks good, will apply the same pattern to other Discord prisms to maintain consistency across the codebase.