### PR TITLE
✨ Discord Remove Reaction Prism

### DIFF
--- a/lux/lib/lux/prisms/discord/message/remove_reaction.ex
+++ b/lux/lib/lux/prisms/discord/message/remove_reaction.ex
@@ -1,0 +1,122 @@
+defmodule Lux.Prisms.Discord.Messages.RemoveReaction do
+  @moduledoc """
+  A prism for removing reactions from messages in a Discord channel.
+  Supports both Unicode emojis and custom emojis.
+
+  ## Examples
+      # Remove Unicode emoji reaction
+      iex> RemoveReaction.handler(%{
+      ...>   channel_id: "123456789",
+      ...>   message_id: "987654321",
+      ...>   user_id: "111111111",
+      ...>   emoji: "👍"
+      ...> }, %{name: "Agent"})
+      {:ok, %{removed: true, emoji: "👍", message_id: "987654321", channel_id: "123456789", user_id: "111111111"}}
+
+      # Remove custom emoji reaction
+      iex> RemoveReaction.handler(%{
+      ...>   channel_id: "123456789",
+      ...>   message_id: "987654321",
+      ...>   user_id: "111111111",
+      ...>   emoji: "custom_emoji:123456789"
+      ...> }, %{name: "Agent"})
+      {:ok, %{removed: true, emoji: "custom_emoji:123456789", message_id: "987654321", channel_id: "123456789", user_id: "111111111"}}
+  """
+
+  use Lux.Prism,
+    name: "Remove Discord Message Reaction",
+    description: "Removes a specific user's reaction from a message in a Discord channel",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        channel_id: %{
+          type: :string,
+          description: "The ID of the channel containing the message",
+          pattern: "^[0-9]{17,20}$"
+        },
+        message_id: %{
+          type: :string,
+          description: "The ID of the message to remove reaction from",
+          pattern: "^[0-9]{17,20}$"
+        },
+        user_id: %{
+          type: :string,
+          description: "The ID of the user whose reaction to remove",
+          pattern: "^[0-9]{17,20}$"
+        },
+        emoji: %{
+          type: :string,
+          description: "The emoji to remove (Unicode emoji or custom emoji ID)",
+          maxLength: 100
+        }
+      },
+      required: ["channel_id", "message_id", "user_id", "emoji"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        removed: %{
+          type: :boolean,
+          description: "Whether the reaction was successfully removed"
+        },
+        emoji: %{
+          type: :string,
+          description: "The emoji that was removed"
+        },
+        message_id: %{
+          type: :string,
+          description: "The ID of the message that had the reaction removed"
+        },
+        channel_id: %{
+          type: :string,
+          description: "The ID of the channel containing the message"
+        },
+        user_id: %{
+          type: :string,
+          description: "The ID of the user whose reaction was removed"
+        }
+      },
+      required: ["removed"]
+    }
+
+  alias Lux.Integrations.Discord.Client
+  require Logger
+
+  @doc """
+  Handles the request to remove a reaction from a message in a Discord channel.
+
+  Returns {:ok, %{removed: true, emoji: emoji, message_id: message_id, channel_id: channel_id, user_id: user_id}} on success.
+  Returns {:error, {status, message}} on failure.
+  """
+  def handler(params, agent) do
+    with {:ok, channel_id} <- validate_param(params, :channel_id),
+         {:ok, message_id} <- validate_param(params, :message_id),
+         {:ok, user_id} <- validate_param(params, :user_id),
+         {:ok, emoji} <- validate_param(params, :emoji) do
+
+      agent_name = agent[:name] || "Unknown Agent"
+      Logger.info("Agent #{agent_name} removing reaction #{emoji} by user #{user_id} from message #{message_id} in channel #{channel_id}")
+
+      encoded_emoji = URI.encode(emoji)
+      case Client.request(:delete, "/channels/#{channel_id}/messages/#{message_id}/reactions/#{encoded_emoji}/#{user_id}") do
+        {:ok, _} ->
+          Logger.info("Successfully removed reaction #{emoji} by user #{user_id} from message #{message_id} in channel #{channel_id}")
+          {:ok, %{removed: true, emoji: emoji, message_id: message_id, channel_id: channel_id, user_id: user_id}}
+        {:error, {status, %{"message" => message}}} ->
+          error = {status, message}
+          Logger.error("Failed to remove reaction #{emoji} by user #{user_id} from message #{message_id} in channel #{channel_id}: #{inspect(error)}")
+          {:error, error}
+        {:error, error} ->
+          Logger.error("Failed to remove reaction #{emoji} by user #{user_id} from message #{message_id} in channel #{channel_id}: #{inspect(error)}")
+          {:error, error}
+      end
+    end
+  end
+
+  defp validate_param(params, key) do
+    case Map.fetch(params, key) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "Missing or invalid #{key}"}
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/discord/message/remove_reaction_test.exs
+++ b/lux/test/unit/lux/prisms/discord/message/remove_reaction_test.exs
@@ -1,0 +1,125 @@
+defmodule Lux.Prisms.Discord.Messages.RemoveReactionTest do
+  use UnitAPICase, async: true
+  alias Lux.Prisms.Discord.Messages.RemoveReaction
+
+  @channel_id "123456789012345678"
+  @message_id "987654321098765432"
+  @user_id "111111111111111111"
+  @unicode_emoji "👍"
+  @custom_emoji "custom_emoji:123456789"
+  @agent_ctx %{agent: %{name: "TestAgent"}}
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "handler/2" do
+    test "successfully removes unicode emoji reaction" do
+      encoded_emoji = URI.encode(@unicode_emoji)
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "DELETE"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}/messages/#{@message_id}/reactions/#{encoded_emoji}/#{@user_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{}))
+      end)
+
+      assert {:ok, %{
+        removed: true,
+        emoji: @unicode_emoji,
+        message_id: @message_id,
+        channel_id: @channel_id,
+        user_id: @user_id
+      }} = RemoveReaction.handler(
+        %{
+          channel_id: @channel_id,
+          message_id: @message_id,
+          user_id: @user_id,
+          emoji: @unicode_emoji,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "successfully removes custom emoji reaction" do
+      encoded_emoji = URI.encode(@custom_emoji)
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "DELETE"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}/messages/#{@message_id}/reactions/#{encoded_emoji}/#{@user_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{}))
+      end)
+
+      assert {:ok, %{
+        removed: true,
+        emoji: @custom_emoji,
+        message_id: @message_id,
+        channel_id: @channel_id,
+        user_id: @user_id
+      }} = RemoveReaction.handler(
+        %{
+          channel_id: @channel_id,
+          message_id: @message_id,
+          user_id: @user_id,
+          emoji: @custom_emoji,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "handles Discord API error" do
+      encoded_emoji = URI.encode(@unicode_emoji)
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "DELETE"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}/messages/#{@message_id}/reactions/#{encoded_emoji}/#{@user_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, {403, "Missing Permissions"}} = RemoveReaction.handler(
+        %{
+          channel_id: @channel_id,
+          message_id: @message_id,
+          user_id: @user_id,
+          emoji: @unicode_emoji,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+  end
+
+  describe "schema validation" do
+    test "validates input schema" do
+      prism = RemoveReaction.view()
+      assert prism.input_schema.required == ["channel_id", "message_id", "user_id", "emoji"]
+      assert Map.has_key?(prism.input_schema.properties, :channel_id)
+      assert Map.has_key?(prism.input_schema.properties, :message_id)
+      assert Map.has_key?(prism.input_schema.properties, :user_id)
+      assert Map.has_key?(prism.input_schema.properties, :emoji)
+    end
+
+    test "validates output schema" do
+      prism = RemoveReaction.view()
+      assert prism.output_schema.required == ["removed"]
+      assert Map.has_key?(prism.output_schema.properties, :removed)
+      assert Map.has_key?(prism.output_schema.properties, :emoji)
+      assert Map.has_key?(prism.output_schema.properties, :message_id)
+      assert Map.has_key?(prism.output_schema.properties, :channel_id)
+      assert Map.has_key?(prism.output_schema.properties, :user_id)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new Discord Prism for removing a specific user's reaction from a message.

Features:
- Remove a specific user's reaction from a Discord message
- Support for both Unicode emojis and custom emojis
- Input validation for channel_id, message_id, user_id and emoji
- Error handling for Discord API errors
- Comprehensive test coverage including success and error cases
- Schema validation for input/output parameters

Test Coverage:
- Successful reaction removal (Unicode and custom emojis)
- Discord API error handling
- Input/Output schema validation