### PR TITLE
✨ Discord Mute Channel Prism

### DIFF
--- a/lux/lib/lux/prisms/discord/channels/mute_channel.ex
+++ b/lux/lib/lux/prisms/discord/channels/mute_channel.ex
@@ -1,0 +1,123 @@
+defmodule Lux.Prisms.Discord.Channels.MuteChannel do
+  @moduledoc """
+  A prism for muting notifications from a Discord channel.
+  Supports both temporary and indefinite muting.
+
+  ## Examples
+      # Mute channel for 1 hour (3600 seconds)
+      iex> MuteChannel.handler(%{
+      ...>   channel_id: "123456789",
+      ...>   guild_id: "987654321",
+      ...>   duration: 3600
+      ...> }, %{name: "Agent"})
+      {:ok, %{muted: true, channel_id: "123456789", guild_id: "987654321", duration: 3600}}
+
+      # Mute channel indefinitely
+      iex> MuteChannel.handler(%{
+      ...>   channel_id: "123456789",
+      ...>   guild_id: "987654321",
+      ...>   duration: nil
+      ...> }, %{name: "Agent"})
+      {:ok, %{muted: true, channel_id: "123456789", guild_id: "987654321", duration: nil}}
+  """
+
+  use Lux.Prism,
+    name: "Mute Discord Channel",
+    description: "Mutes notifications for a Discord channel for a specified duration",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        channel_id: %{
+          type: :string,
+          description: "The ID of the channel to mute",
+          pattern: "^[0-9]{17,20}$"
+        },
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild containing the channel",
+          pattern: "^[0-9]{17,20}$"
+        },
+        duration: %{
+          type: [:integer, :null],
+          description: "Duration to mute the channel for in seconds. Use nil for indefinite muting",
+          minimum: 0
+        }
+      },
+      required: ["channel_id", "guild_id"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        muted: %{
+          type: :boolean,
+          description: "Whether the channel was successfully muted"
+        },
+        channel_id: %{
+          type: :string,
+          description: "The ID of the muted channel"
+        },
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild containing the channel"
+        },
+        duration: %{
+          type: [:integer, :null],
+          description: "Duration the channel was muted for in seconds, or nil if muted indefinitely"
+        }
+      },
+      required: ["muted"]
+    }
+
+  alias Lux.Integrations.Discord.Client
+  require Logger
+
+  @doc """
+  Handles the request to mute a Discord channel.
+
+  Returns {:ok, %{muted: true, channel_id: channel_id, guild_id: guild_id, duration: duration}} on success.
+  Returns {:error, {status, message}} on failure.
+  """
+  def handler(params, agent) do
+    with {:ok, channel_id} <- validate_param(params, :channel_id),
+         {:ok, guild_id} <- validate_param(params, :guild_id),
+         {:ok, duration} <- validate_duration(params) do
+
+      agent_name = agent[:name] || "Unknown Agent"
+      duration_text = if duration, do: "for #{duration} seconds", else: "indefinitely"
+      Logger.info("Agent #{agent_name} muting channel #{channel_id} in guild #{guild_id} #{duration_text}")
+
+      mute_end_time = if duration do
+        DateTime.add(DateTime.utc_now(), duration, :second) |> DateTime.to_iso8601()
+      else
+        nil
+      end
+
+      case Client.request(:patch, "/users/@me/guilds/#{guild_id}/channels/#{channel_id}", %{json: %{
+        muted: true,
+        mute_end_time: mute_end_time
+      }}) do
+        {:ok, _} ->
+          Logger.info("Successfully muted channel #{channel_id} in guild #{guild_id} #{duration_text}")
+          {:ok, %{muted: true, channel_id: channel_id, guild_id: guild_id, duration: duration}}
+        error ->
+          Logger.error("Failed to mute channel #{channel_id} in guild #{guild_id}: #{inspect(error)}")
+          error
+      end
+    end
+  end
+
+  defp validate_param(params, key) do
+    case Map.fetch(params, key) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "Missing or invalid #{key}"}
+    end
+  end
+
+  defp validate_duration(params) do
+    case Map.get(params, :duration) do
+      nil -> {:ok, nil}
+      duration when is_integer(duration) and duration >= 0 -> {:ok, duration}
+      _ -> {:error, "Duration must be a non-negative integer or nil"}
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/discord/channels/mute_channel_test.exs
+++ b/lux/test/unit/lux/prisms/discord/channels/mute_channel_test.exs
@@ -1,0 +1,139 @@
+defmodule Lux.Prisms.Discord.Channels.MuteChannelTest do
+  @moduledoc """
+  Test suite for the MuteChannel module.
+  These tests verify the prism's ability to:
+  - Mute notifications for a Discord channel
+  - Handle different mute durations
+  - Handle Discord API errors appropriately
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Prisms.Discord.Channels.MuteChannel
+
+  @channel_id "123456789012345678"
+  @guild_id "987654321098765432"
+  @agent_ctx %{agent: %{name: "TestAgent"}}
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "handler/2" do
+    test "successfully mutes a channel for 1 hour" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "PATCH"
+        assert conn.request_path == "/api/v10/users/@me/guilds/#{@guild_id}/channels/#{@channel_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        body_map = Jason.decode!(body)
+
+        # Compare only up to seconds to avoid microsecond differences
+        assert %{"muted" => true} = body_map
+        assert String.match?(body_map["mute_end_time"], ~r/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+
+        # Verify the mute_end_time is approximately 1 hour from now
+        {:ok, mute_end, _} = DateTime.from_iso8601(body_map["mute_end_time"])
+        now = DateTime.utc_now()
+        diff = DateTime.diff(mute_end, now)
+        assert_in_delta diff, 3600, 1
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:ok, %{
+        muted: true,
+        channel_id: @channel_id,
+        guild_id: @guild_id,
+        duration: 3600
+      }} = MuteChannel.handler(
+        %{
+          channel_id: @channel_id,
+          guild_id: @guild_id,
+          duration: 3600,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "successfully mutes a channel indefinitely" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "PATCH"
+        assert conn.request_path == "/api/v10/users/@me/guilds/#{@guild_id}/channels/#{@channel_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert Jason.decode!(body) == %{
+          "muted" => true,
+          "mute_end_time" => nil
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:ok, %{
+        muted: true,
+        channel_id: @channel_id,
+        guild_id: @guild_id,
+        duration: nil
+      }} = MuteChannel.handler(
+        %{
+          channel_id: @channel_id,
+          guild_id: @guild_id,
+          duration: nil,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "handles Discord API error" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "PATCH"
+        assert conn.request_path == "/api/v10/users/@me/guilds/#{@guild_id}/channels/#{@channel_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, {403, "Missing Permissions"}} = MuteChannel.handler(
+        %{
+          channel_id: @channel_id,
+          guild_id: @guild_id,
+          duration: 3600,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+  end
+
+  describe "schema validation" do
+    test "validates input schema" do
+      prism = MuteChannel.view()
+      assert prism.input_schema.required == ["channel_id", "guild_id"]
+      assert Map.has_key?(prism.input_schema.properties, :channel_id)
+      assert Map.has_key?(prism.input_schema.properties, :guild_id)
+      assert Map.has_key?(prism.input_schema.properties, :duration)
+    end
+
+    test "validates output schema" do
+      prism = MuteChannel.view()
+      assert prism.output_schema.required == ["muted"]
+      assert Map.has_key?(prism.output_schema.properties, :muted)
+      assert Map.has_key?(prism.output_schema.properties, :channel_id)
+      assert Map.has_key?(prism.output_schema.properties, :guild_id)
+      assert Map.has_key?(prism.output_schema.properties, :duration)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new Discord Prism for muting channel notifications.

Features:
- Mute notifications for a specific Discord channel
- Support for both temporary (duration in seconds) and indefinite muting
- Input validation for channel_id, guild_id and duration
- Error handling for Discord API errors
- Comprehensive test coverage including success and error cases
- Schema validation for input/output parameters

Test Coverage:
- Successful channel muting (temporary and indefinite)
- Discord API error handling
- Input/Output schema validation