### PR TITLE
✨ Discord Kick Member Prism

### DIFF
--- a/lux/lib/lux/prisms/discord/guilds/kick_member.ex
+++ b/lux/lib/lux/prisms/discord/guilds/kick_member.ex
@@ -1,0 +1,88 @@
+defmodule Lux.Prisms.Discord.Guilds.KickMember do
+  @moduledoc """
+  A prism for kicking a member from a Discord server (guild).
+
+  ## Examples
+      iex> KickMember.handler(%{
+      ...>   guild_id: "987654321",
+      ...>   user_id: "123456789"
+      ...> }, %{name: "Agent"})
+      {:ok, %{kicked: true, guild_id: "987654321", user_id: "123456789"}}
+  """
+
+  use Lux.Prism,
+    name: "Kick Discord Guild Member",
+    description: "Kicks a member from a Discord server",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to kick the member from",
+          pattern: "^[0-9]{17,20}$"
+        },
+        user_id: %{
+          type: :string,
+          description: "The ID of the user to kick",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id", "user_id"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        kicked: %{
+          type: :boolean,
+          description: "Whether the member was successfully kicked"
+        },
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild the member was kicked from"
+        },
+        user_id: %{
+          type: :string,
+          description: "The ID of the user that was kicked"
+        }
+      },
+      required: ["kicked", "guild_id", "user_id"]
+    }
+
+  alias Lux.Integrations.Discord.Client
+  require Logger
+
+  @doc """
+  Handles the request to kick a member from a Discord server.
+
+  Returns {:ok, %{kicked: true, guild_id: guild_id, user_id: user_id}} on success.
+  Returns {:error, reason} on failure.
+  """
+  def handler(params, agent) do
+    with {:ok, guild_id} <- validate_param(params, :guild_id),
+         {:ok, user_id} <- validate_param(params, :user_id) do
+
+      agent_name = agent[:name] || "Unknown Agent"
+      Logger.info("Agent #{agent_name} kicking user #{user_id} from guild #{guild_id}")
+
+      case Client.request(:delete, "/guilds/#{guild_id}/members/#{user_id}") do
+        {:ok, _response} ->
+          Logger.info("Successfully kicked user #{user_id} from guild #{guild_id}")
+          {:ok, %{
+            kicked: true,
+            guild_id: guild_id,
+            user_id: user_id
+          }}
+        error ->
+          Logger.error("Failed to kick user #{user_id} from guild #{guild_id}: #{inspect(error)}")
+          error
+      end
+    end
+  end
+
+  defp validate_param(params, key) do
+    case Map.fetch(params, key) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "Missing or invalid #{key}"}
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/discord/guilds/kick_member_test.exs
+++ b/lux/test/unit/lux/prisms/discord/guilds/kick_member_test.exs
@@ -1,0 +1,81 @@
+defmodule Lux.Prisms.Discord.Guilds.KickMemberTest do
+  @moduledoc """
+  Test suite for the KickMember module.
+  These tests verify the prism's ability to:
+  - Kick a member from a Discord server
+  - Handle Discord API errors appropriately
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Prisms.Discord.Guilds.KickMember
+
+  @guild_id "987654321098765432"
+  @user_id "123456789012345678"
+  @agent_ctx %{agent: %{name: "TestAgent"}}
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "handler/2" do
+    test "successfully kicks a member" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "DELETE"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/members/#{@user_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(204, "")
+      end)
+
+      assert {:ok, %{
+        kicked: true,
+        guild_id: @guild_id,
+        user_id: @user_id
+      }} = KickMember.handler(
+        %{
+          guild_id: @guild_id,
+          user_id: @user_id,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when guild_id is missing" do
+      assert {:error, "Missing or invalid guild_id"} = KickMember.handler(
+        %{user_id: @user_id},
+        @agent_ctx
+      )
+    end
+
+    test "fails when user_id is missing" do
+      assert {:error, "Missing or invalid user_id"} = KickMember.handler(
+        %{guild_id: @guild_id},
+        @agent_ctx
+      )
+    end
+
+    test "fails when Discord returns an error" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "code" => 50_013,
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, _} = KickMember.handler(
+        %{
+          guild_id: @guild_id,
+          user_id: @user_id,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new Discord Prism for kicking members from a guild. The prism provides a simple and straightforward way to remove members from a Discord server with proper error handling and validation.

Features:
- Kick members from a Discord server using guild_id and user_id
- Input validation for Discord IDs (17-20 digit format)
- Comprehensive error handling for missing parameters and API errors
- Detailed logging for tracking kick operations

Test Coverage:
- Successful member kick
- Parameter validation (missing guild_id/user_id)
- Discord API error handling (e.g. missing permissions)