### PR TITLE
✨ Discord Create Emoji Prism

### DIFF
--- a/lux/lib/lux/prisms/discord/guilds/create_emoji.ex
+++ b/lux/lib/lux/prisms/discord/guilds/create_emoji.ex
@@ -1,0 +1,166 @@
+defmodule Lux.Prisms.Discord.Guilds.CreateEmoji do
+  @moduledoc """
+  A prism for uploading a custom emoji to a Discord server (guild).
+  The emoji image must be:
+  - Less than 256KB in size
+  - PNG, JPEG, GIF, or WebP format
+  - Recommended minimum size: 128x128 pixels
+
+  ## Examples
+      iex> CreateEmoji.handler(%{
+      ...>   guild_id: "987654321",
+      ...>   name: "my_cool_emoji",
+      ...>   image: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
+      ...> }, %{name: "Agent"})
+      {:ok, %{
+        created: true,
+        guild_id: "987654321",
+        emoji: %{
+          id: "123456789",
+          name: "my_cool_emoji",
+          animated: false
+        }
+      }}
+  """
+
+  use Lux.Prism,
+    name: "Create Discord Guild Emoji",
+    description: "Uploads a custom emoji to a Discord server",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to create the emoji in",
+          pattern: "^[0-9]{17,20}$"
+        },
+        name: %{
+          type: :string,
+          description: "Name of the emoji (2-32 characters)",
+          pattern: "^[\\w_]{2,32}$"
+        },
+        image: %{
+          type: :string,
+          description: "Base64 encoded image data (PNG, JPEG, GIF, or WebP, max 256KB)",
+          pattern: "^data:image\\/(png|jpeg|gif|webp);base64,[A-Za-z0-9+/=]+$"
+        }
+      },
+      required: ["guild_id", "name", "image"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        created: %{
+          type: :boolean,
+          description: "Whether the emoji was successfully created"
+        },
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild where the emoji was created"
+        },
+        emoji: %{
+          type: :object,
+          description: "Information about the created emoji",
+          properties: %{
+            id: %{
+              type: :string,
+              description: "The ID of the created emoji"
+            },
+            name: %{
+              type: :string,
+              description: "The name of the emoji"
+            },
+            animated: %{
+              type: :boolean,
+              description: "Whether the emoji is animated (GIF)"
+            }
+          }
+        }
+      },
+      required: ["created", "guild_id", "emoji"]
+    }
+
+  alias Lux.Integrations.Discord.Client
+  require Logger
+
+  @max_size 262_144  # 256KB in bytes
+
+  @doc """
+  Handles the request to create a custom emoji in a Discord server.
+
+  Returns {:ok, %{created: true, guild_id: guild_id, emoji: emoji_data}} on success.
+  Returns {:error, reason} on failure.
+  """
+  def handler(params, agent) do
+    with {:ok, guild_id} <- validate_param(params, :guild_id),
+         {:ok, name} <- validate_param(params, :name),
+         {:ok, image} <- validate_param(params, :image),
+         {:ok, image_size} <- validate_image_size(image) do
+
+      agent_name = agent[:name] || "Unknown Agent"
+      Logger.info("Agent #{agent_name} creating emoji '#{name}' in guild #{guild_id} (image size: #{image_size} bytes)")
+
+      path = "/guilds/#{guild_id}/emojis"
+      body = %{name: name, image: image}
+      plug = Map.get(params, :plug)
+
+      opts = %{
+        json: body,
+        plug: plug
+      }
+      |> Map.reject(fn {_k, v} -> is_nil(v) end)
+
+      case Client.request(:post, path, opts) do
+        {:ok, response} ->
+          Logger.info("Successfully created emoji '#{name}' in guild #{guild_id}")
+          {:ok, %{
+            created: true,
+            guild_id: guild_id,
+            emoji: %{
+              id: response["id"],
+              name: response["name"],
+              animated: response["animated"] || false
+            }
+          }}
+        {:error, {status, %{"code" => 50_045}}} ->
+          Logger.error("Failed to create emoji '#{name}' in guild #{guild_id}: Image file size exceeds maximum of 256KB")
+          {:error, "Image file size exceeds maximum of 256KB"}
+        {:error, {status, response}} when is_map(response) ->
+          message = response["message"] || "Unknown error"
+          Logger.error("Failed to create emoji '#{name}' in guild #{guild_id}: #{message}")
+          {:error, message}
+        {:error, :invalid_token} ->
+          Logger.error("Failed to create emoji '#{name}' in guild #{guild_id}: Invalid Discord token")
+          {:error, "Invalid Discord token"}
+        {:error, %{message: message}} when is_binary(message) ->
+          Logger.error("Failed to create emoji '#{name}' in guild #{guild_id}: #{message}")
+          {:error, message}
+        error ->
+          Logger.error("Failed to create emoji '#{name}' in guild #{guild_id}: #{inspect(error)}")
+          {:error, "Unknown error occurred"}
+      end
+    end
+  end
+
+  defp validate_param(params, key) do
+    case Map.fetch(params, key) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "Missing or invalid #{key}"}
+    end
+  end
+
+  defp validate_image_size(image) do
+    # Extract base64 data after the comma
+    case String.split(image, ",") do
+      [_header, base64_data] ->
+        size = byte_size(Base.decode64!(base64_data))
+        if size <= @max_size do
+          {:ok, size}
+        else
+          {:error, "Image size #{size} bytes exceeds maximum of #{@max_size} bytes (256KB)"}
+        end
+      _ ->
+        {:error, "Invalid image data format"}
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/discord/guilds/create_emoji_test.exs
+++ b/lux/test/unit/lux/prisms/discord/guilds/create_emoji_test.exs
@@ -1,0 +1,194 @@
+defmodule Lux.Prisms.Discord.Guilds.CreateEmojiTest do
+  @moduledoc """
+  Test suite for the CreateEmoji module.
+  These tests verify the prism's ability to:
+  - Create custom emojis in a Discord server
+  - Handle different image formats (PNG, JPEG, GIF, WebP) and sizes
+  - Handle Discord API errors appropriately
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Prisms.Discord.Guilds.CreateEmoji
+
+  @guild_id "987654321098765432"
+  @emoji_name "test_emoji"
+  # 1x1 transparent PNG
+  @test_image "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+  # 1x1 transparent WebP
+  @test_webp "data:image/webp;base64,UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA=="
+  # Large image that exceeds 256KB
+  @large_image "data:image/png;base64," <> String.duplicate("A", 350_000)
+  @agent_ctx %{agent: %{name: "TestAgent"}}
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "handler/2" do
+    test "successfully creates an emoji with PNG" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/emojis"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        body_map = Jason.decode!(body)
+        assert body_map["name"] == @emoji_name
+        assert body_map["image"] == @test_image
+
+        response = %{
+          "id" => "123456789012345678",
+          "name" => @emoji_name,
+          "animated" => false
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+      end)
+
+      assert {:ok, %{
+        created: true,
+        guild_id: @guild_id,
+        emoji: %{
+          id: "123456789012345678",
+          name: @emoji_name,
+          animated: false
+        }
+      }} = CreateEmoji.handler(
+        %{
+          guild_id: @guild_id,
+          name: @emoji_name,
+          image: @test_image,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "successfully creates an emoji with WebP" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/emojis"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        body_map = Jason.decode!(body)
+        assert body_map["name"] == @emoji_name
+        assert body_map["image"] == @test_webp
+
+        response = %{
+          "id" => "123456789012345678",
+          "name" => @emoji_name,
+          "animated" => false
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+      end)
+
+      assert {:ok, %{
+        created: true,
+        guild_id: @guild_id,
+        emoji: %{
+          id: "123456789012345678",
+          name: @emoji_name,
+          animated: false
+        }
+      }} = CreateEmoji.handler(
+        %{
+          guild_id: @guild_id,
+          name: @emoji_name,
+          image: @test_webp,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when image is too large" do
+      assert {:error, "Image size " <> _} = CreateEmoji.handler(
+        %{
+          guild_id: @guild_id,
+          name: @emoji_name,
+          image: @large_image
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when guild_id is missing" do
+      assert {:error, "Missing or invalid guild_id"} = CreateEmoji.handler(
+        %{
+          name: @emoji_name,
+          image: @test_image
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when name is missing" do
+      assert {:error, "Missing or invalid name"} = CreateEmoji.handler(
+        %{
+          guild_id: @guild_id,
+          image: @test_image
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when image is missing" do
+      assert {:error, "Missing or invalid image"} = CreateEmoji.handler(
+        %{
+          guild_id: @guild_id,
+          name: @emoji_name
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when Discord returns a file size error" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(400, Jason.encode!(%{
+          "code" => 50_045,
+          "message" => "Image file size exceeds maximum of 256KB"
+        }))
+      end)
+
+      assert {:error, _} = CreateEmoji.handler(
+        %{
+          guild_id: @guild_id,
+          name: @emoji_name,
+          image: @test_image,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when Discord returns an error" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "code" => 50_013,
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, _} = CreateEmoji.handler(
+        %{
+          guild_id: @guild_id,
+          name: @emoji_name,
+          image: @test_image,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new Discord Prism for creating custom emojis in a guild. The prism provides a robust way to upload emojis with proper validation and error handling.

Features:
- Create custom emojis with support for PNG, JPEG, GIF, and WebP formats
- Image size validation (max 256KB)
- Comprehensive error handling for API responses
- Detailed logging for tracking emoji creation process

Technical Details:
- Uses Map.fetch/2 for robust parameter validation
- Validates image size before making API request
- Handles various Discord API error responses (invalid token, size limits, permissions)
- Supports test environment with plug option for API mocking

The implementation follows the same pattern as other Discord prisms, particularly matching the parameter validation approach used in delete_channel.ex for consistency across the codebase.