### PR TITLE
✨ Discord Create Sticker Prism

### DIFF
--- a/lux/lib/lux/prisms/discord/guilds/create_sticker.ex
+++ b/lux/lib/lux/prisms/discord/guilds/create_sticker.ex
@@ -1,0 +1,206 @@
+defmodule Lux.Prisms.Discord.Guilds.CreateSticker do
+  @moduledoc """
+  A prism for uploading a custom sticker to a Discord server (guild).
+  The sticker file must be:
+  - Less than 512KB in size
+  - PNG, APNG, GIF, or JPG/JPEG format
+  - Recommended size: 320x320 pixels
+
+  ## Examples
+      iex> CreateSticker.handler(%{
+      ...>   guild_id: "987654321",
+      ...>   name: "my_cool_sticker",
+      ...>   description: "A very cool sticker",
+      ...>   tags: "happy,cool",
+      ...>   file: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
+      ...> }, %{name: "Agent"})
+      {:ok, %{
+        created: true,
+        guild_id: "987654321",
+        sticker: %{
+          id: "123456789",
+          name: "my_cool_sticker",
+          description: "A very cool sticker",
+          tags: "happy,cool",
+          format_type: 1
+        }
+      }}
+  """
+
+  use Lux.Prism,
+    name: "Create Discord Guild Sticker",
+    description: "Uploads a custom sticker to a Discord server",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to create the sticker in",
+          pattern: "^[0-9]{17,20}$"
+        },
+        name: %{
+          type: :string,
+          description: "Name of the sticker (2-30 characters)",
+          pattern: "^[\\w-]{2,30}$"
+        },
+        description: %{
+          type: :string,
+          description: "Description of the sticker (optional, empty or 2-100 characters)",
+          pattern: "^$|^.{2,100}$"
+        },
+        tags: %{
+          type: :string,
+          description: "Comma-separated list of tags (keywords) for the sticker",
+          pattern: "^[\\w-,]{1,200}$"
+        },
+        file: %{
+          type: :string,
+          description: "Base64 encoded file data (PNG, APNG, GIF, or JPG/JPEG, max 512KB)",
+          pattern: "^data:image\\/(png|apng|gif|jpe?g);base64,[A-Za-z0-9+/=]+$"
+        }
+      },
+      required: [:guild_id, :name, :tags, :file]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        created: %{
+          type: :boolean,
+          description: "Whether the sticker was successfully created"
+        },
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild where the sticker was created"
+        },
+        sticker: %{
+          type: :object,
+          description: "Information about the created sticker",
+          properties: %{
+            id: %{
+              type: :string,
+              description: "The ID of the created sticker"
+            },
+            name: %{
+              type: :string,
+              description: "The name of the sticker"
+            },
+            description: %{
+              type: :string,
+              description: "The description of the sticker (optional)"
+            },
+            tags: %{
+              type: :string,
+              description: "Comma-separated list of tags"
+            },
+            format_type: %{
+              type: :integer,
+              description: "The format type of the sticker (1: PNG, 2: APNG, 3: GIF, 4: JPG/JPEG)"
+            }
+          }
+        }
+      },
+      required: [:created, :guild_id, :sticker]
+    }
+
+  alias Lux.Integrations.Discord.Client
+  require Logger
+
+  @max_size 524_288  # 512KB in bytes
+
+  @doc """
+  Handles the request to create a custom sticker in a Discord server.
+
+  Returns {:ok, %{created: true, guild_id: guild_id, sticker: sticker_data}} on success.
+  Returns {:error, reason} on failure.
+  """
+  def handler(params, agent) do
+    with {:ok, guild_id} <- validate_param(params, :guild_id),
+         {:ok, name} <- validate_param(params, :name),
+         {:ok, tags} <- validate_param(params, :tags),
+         {:ok, file} <- validate_param(params, :file),
+         {:ok, description} <- validate_optional_param(params, :description),
+         {:ok, file_size} <- validate_file_size(file),
+         {:ok, format_type} <- get_format_type(file) do
+
+      agent_name = agent[:name] || "Unknown Agent"
+      Logger.info("Agent #{agent_name} creating sticker '#{name}' in guild #{guild_id} (file size: #{file_size} bytes)")
+
+      path = "/guilds/#{guild_id}/stickers"
+      body = %{
+        "name" => name,
+        "tags" => tags,
+        "file" => file
+      }
+      |> maybe_add_description(description)
+
+      plug = Map.get(params, :plug)
+      opts = %{
+        json: body,
+        plug: plug
+      }
+      |> Map.reject(fn {_k, v} -> is_nil(v) end)
+
+      case Client.request(:post, path, opts) do
+        {:ok, response} ->
+          Logger.info("Successfully created sticker '#{name}' in guild #{guild_id}")
+          {:ok, %{
+            created: true,
+            guild_id: guild_id,
+            sticker: %{
+              id: response["id"],
+              name: response["name"],
+              description: response["description"],
+              tags: response["tags"],
+              format_type: format_type
+            }
+          }}
+        {:error, error} ->
+          Logger.error("Failed to create sticker '#{name}' in guild #{guild_id}: #{inspect(error)}")
+          {:error, error}
+      end
+    end
+  end
+
+  defp validate_param(params, key) when is_atom(key) do
+    case Map.fetch(params, key) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "Missing or invalid #{key}"}
+    end
+  end
+
+  defp validate_optional_param(params, key) when is_atom(key) do
+    case Map.fetch(params, key) do
+      {:ok, value} when is_binary(value) -> {:ok, value}
+      :error -> {:ok, nil}
+      _ -> {:error, "Invalid #{key}"}
+    end
+  end
+
+  defp maybe_add_description(body, nil), do: body
+  defp maybe_add_description(body, description), do: Map.put(body, "description", description)
+
+  defp validate_file_size(file) do
+    case String.split(file, ",") do
+      [_header, base64_data] ->
+        size = byte_size(Base.decode64!(base64_data))
+        if size <= @max_size do
+          {:ok, size}
+        else
+          {:error, "File size #{size} bytes exceeds maximum of #{@max_size} bytes (512KB)"}
+        end
+      _ ->
+        {:error, "Invalid file data format"}
+    end
+  end
+
+  defp get_format_type(file) do
+    case Regex.run(~r/^data:image\/(png|apng|gif|jpe?g);base64,/, file) do
+      ["data:image/png;base64," | _] -> {:ok, 1}  # PNG
+      ["data:image/apng;base64," | _] -> {:ok, 2}  # APNG
+      ["data:image/gif;base64," | _] -> {:ok, 3}  # GIF
+      ["data:image/jpeg;base64," | _] -> {:ok, 4}  # JPEG
+      ["data:image/jpg;base64," | _] -> {:ok, 4}  # JPG
+      _ -> {:error, "Invalid file format"}
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/discord/guilds/create_sticker_test.exs
+++ b/lux/test/unit/lux/prisms/discord/guilds/create_sticker_test.exs
@@ -1,0 +1,281 @@
+defmodule Lux.Prisms.Discord.Guilds.CreateStickerTest do
+  @moduledoc """
+  Test suite for the CreateSticker module.
+  These tests verify the prism's ability to:
+  - Create custom stickers in a Discord server
+  - Handle different file formats (PNG, APNG, GIF, JPG/JPEG)
+  - Validate file sizes and formats
+  - Handle Discord API errors appropriately
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Prisms.Discord.Guilds.CreateSticker
+
+  @guild_id "987654321098765432"
+  @sticker_name "test_sticker"
+  @sticker_description "A test sticker"
+  @sticker_tags "test,cool"
+  # 1x1 transparent PNG
+  @test_png "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+  # 1x1 transparent APNG
+  @test_apng "data:image/apng;base64,UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA=="
+  # 1x1 transparent GIF
+  @test_gif "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+  # 1x1 white JPEG
+  @test_jpeg "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////wAALCAABAAEBAREA/8QAJgABAAAAAAAAAAAAAAAAAAAAAxABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQAAPwBcAF//2Q=="
+  # Large file that exceeds 512KB
+  @large_file "data:image/png;base64," <> String.duplicate("A", 700_000)
+  @agent_ctx %{name: "TestAgent"}
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "handler/2" do
+    test "successfully creates a sticker with PNG" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/stickers"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        body_map = Jason.decode!(body)
+        assert body_map["name"] == @sticker_name
+        assert body_map["description"] == @sticker_description
+        assert body_map["tags"] == @sticker_tags
+        assert body_map["file"] == @test_png
+
+        response = %{
+          "id" => "123456789012345678",
+          "name" => @sticker_name,
+          "description" => @sticker_description,
+          "tags" => @sticker_tags,
+          "format_type" => 1
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+      end)
+
+      assert {:ok, %{
+        created: true,
+        guild_id: @guild_id,
+        sticker: %{
+          id: "123456789012345678",
+          name: @sticker_name,
+          description: @sticker_description,
+          tags: @sticker_tags,
+          format_type: 1
+        }
+      }} = CreateSticker.handler(
+        %{
+          guild_id: @guild_id,
+          name: @sticker_name,
+          description: @sticker_description,
+          tags: @sticker_tags,
+          file: @test_png,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "successfully creates a sticker with APNG" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        body_map = Jason.decode!(body)
+        assert body_map["file"] == @test_apng
+
+        response = %{
+          "id" => "123456789012345678",
+          "name" => @sticker_name,
+          "description" => @sticker_description,
+          "tags" => @sticker_tags,
+          "format_type" => 2
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+      end)
+
+      assert {:ok, %{sticker: %{format_type: 2}}} = CreateSticker.handler(
+        %{
+          guild_id: @guild_id,
+          name: @sticker_name,
+          description: @sticker_description,
+          tags: @sticker_tags,
+          file: @test_apng,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "successfully creates a sticker with GIF" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        body_map = Jason.decode!(body)
+        assert body_map["file"] == @test_gif
+
+        response = %{
+          "id" => "123456789012345678",
+          "name" => @sticker_name,
+          "description" => @sticker_description,
+          "tags" => @sticker_tags,
+          "format_type" => 3
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+      end)
+
+      assert {:ok, %{sticker: %{format_type: 3}}} = CreateSticker.handler(
+        %{
+          guild_id: @guild_id,
+          name: @sticker_name,
+          description: @sticker_description,
+          tags: @sticker_tags,
+          file: @test_gif,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "successfully creates a sticker with JPEG" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        body_map = Jason.decode!(body)
+        assert body_map["file"] == @test_jpeg
+
+        response = %{
+          "id" => "123456789012345678",
+          "name" => @sticker_name,
+          "description" => @sticker_description,
+          "tags" => @sticker_tags,
+          "format_type" => 4
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+      end)
+
+      assert {:ok, %{sticker: %{format_type: 4}}} = CreateSticker.handler(
+        %{
+          guild_id: @guild_id,
+          name: @sticker_name,
+          description: @sticker_description,
+          tags: @sticker_tags,
+          file: @test_jpeg,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "successfully creates a sticker without description" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        body_map = Jason.decode!(body)
+        refute Map.has_key?(body_map, "description")
+
+        response = %{
+          "id" => "123456789012345678",
+          "name" => @sticker_name,
+          "tags" => @sticker_tags,
+          "format_type" => 1
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+      end)
+
+      assert {:ok, %{sticker: %{description: nil}}} = CreateSticker.handler(
+        %{
+          guild_id: @guild_id,
+          name: @sticker_name,
+          tags: @sticker_tags,
+          file: @test_png,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "handles Discord API errors" do
+      error_body = %{
+        "message" => "Missing Permissions",
+        "code" => 50_013
+      }
+
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(error_body))
+      end)
+
+      assert {:error, {403, error_body}} = CreateSticker.handler(
+        %{
+          guild_id: @guild_id,
+          name: @sticker_name,
+          description: @sticker_description,
+          tags: @sticker_tags,
+          file: @test_png,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when file is too large" do
+      assert {:error, "File size " <> _} = CreateSticker.handler(
+        %{
+          guild_id: @guild_id,
+          name: @sticker_name,
+          tags: @sticker_tags,
+          file: @large_file
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when guild_id is missing" do
+      assert {:error, "Missing or invalid guild_id"} = CreateSticker.handler(
+        %{
+          name: @sticker_name,
+          tags: @sticker_tags,
+          file: @test_png
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when name is missing" do
+      assert {:error, "Missing or invalid name"} = CreateSticker.handler(
+        %{
+          guild_id: @guild_id,
+          tags: @sticker_tags,
+          file: @test_png
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when tags is missing" do
+      assert {:error, "Missing or invalid tags"} = CreateSticker.handler(
+        %{
+          guild_id: @guild_id,
+          name: @sticker_name,
+          file: @test_png
+        },
+        @agent_ctx
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the CreateSticker prism, enabling the creation of custom stickers in Discord guilds. The implementation includes robust file format validation, size checks, and comprehensive error handling.

Key Features:
- Support for multiple image formats (PNG, APNG, GIF, JPG/JPEG)
- File size validation (max 512KB)
- Optional sticker description handling
- Automatic format type detection
- Detailed logging for monitoring and debugging
- Comprehensive test suite covering all supported formats and error cases

The prism follows Discord's API specifications for sticker creation and provides clear feedback for validation errors and API responses.