### PR TITLE
✨ Discord Edit Guild Prism

### DIFF
--- a/lux/lib/lux/prisms/discord/guilds/edit_guild.ex
+++ b/lux/lib/lux/prisms/discord/guilds/edit_guild.ex
@@ -1,0 +1,207 @@
+defmodule Lux.Prisms.Discord.Guilds.EditGuild do
+  @moduledoc """
+  A prism for modifying Discord guild (server) settings.
+  Allows updating basic server settings like name, icon, and verification settings.
+
+  ## Examples
+      iex> EditGuild.handler(%{
+      ...>   guild_id: "987654321",
+      ...>   name: "My Cool Server",
+      ...>   icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
+      ...> }, %{name: "Agent"})
+      {:ok, %{
+        modified: true,
+        guild_id: "987654321",
+        guild: %{
+          id: "987654321",
+          name: "My Cool Server",
+          icon: "abcdef123456..."
+        }
+      }}
+  """
+
+  use Lux.Prism,
+    name: "Edit Discord Guild",
+    description: "Modifies basic settings of a Discord server",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to modify",
+          pattern: "^[0-9]{17,20}$"
+        },
+        name: %{
+          type: :string,
+          description: "New name of the guild (2-100 characters)",
+          pattern: "^.{2,100}$"
+        },
+        icon: %{
+          type: :string,
+          description: "Base64 encoded icon image (PNG, GIF, or JPEG)",
+          pattern: "^data:image\\/(png|gif|jpe?g);base64,[A-Za-z0-9+/=]+$"
+        },
+        verification_level: %{
+          type: :integer,
+          description: "Verification level (optional)",
+          enum: [0, 1, 2, 3, 4]
+        },
+        explicit_content_filter: %{
+          type: :integer,
+          description: "Explicit content filter level (optional)",
+          enum: [0, 1, 2]
+        },
+        system_channel_id: %{
+          type: :string,
+          description: "ID of system message channel (optional)",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: [:guild_id]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        modified: %{
+          type: :boolean,
+          description: "Whether the guild was successfully modified"
+        },
+        guild_id: %{
+          type: :string,
+          description: "The ID of the modified guild"
+        },
+        guild: %{
+          type: :object,
+          description: "Information about the modified guild",
+          properties: %{
+            id: %{
+              type: :string,
+              description: "The guild ID"
+            },
+            name: %{
+              type: :string,
+              description: "The guild name"
+            },
+            icon: %{
+              type: :string,
+              description: "The guild icon hash"
+            },
+            verification_level: %{
+              type: :integer,
+              description: "Verification level"
+            },
+            explicit_content_filter: %{
+              type: :integer,
+              description: "Explicit content filter level"
+            },
+            system_channel_id: %{
+              type: :string,
+              description: "ID of system message channel"
+            }
+          }
+        }
+      },
+      required: [:modified, :guild_id, :guild]
+    }
+
+  alias Lux.Integrations.Discord.Client
+  require Logger
+
+  @doc """
+  Handles the request to modify a Discord guild's settings.
+
+  Returns {:ok, %{modified: true, guild_id: guild_id, guild: guild_data}} on success.
+  Returns {:error, reason} on failure.
+  """
+  def handler(params, agent) do
+    with {:ok, guild_id} <- validate_param(params, :guild_id),
+         {:ok, body} <- build_request_body(params) do
+
+      agent_name = agent[:name] || "Unknown Agent"
+      changes = get_change_description(params)
+      Logger.info("Agent #{agent_name} modifying guild #{guild_id} settings: #{changes}")
+
+      path = "/guilds/#{guild_id}"
+      plug = Map.get(params, :plug)
+      opts = %{
+        json: body,
+        plug: plug
+      }
+      |> Map.reject(fn {_k, v} -> is_nil(v) end)
+
+      case Client.request(:patch, path, opts) do
+        {:ok, response} ->
+          Logger.info("Successfully modified guild #{guild_id}")
+          {:ok, %{
+            modified: true,
+            guild_id: guild_id,
+            guild: response
+          }}
+        {:error, error} ->
+          Logger.error("Failed to modify guild #{guild_id}: #{inspect(error)}")
+          {:error, error}
+      end
+    end
+  end
+
+  defp validate_param(params, key) when is_atom(key) do
+    case Map.fetch(params, key) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "Missing or invalid #{key}"}
+    end
+  end
+
+  defp validate_enum_param(params, key, valid_values) when is_atom(key) do
+    case Map.fetch(params, key) do
+      {:ok, value} ->
+        if value in valid_values do
+          {:ok, value}
+        else
+          {:error, "Invalid #{key} value"}
+        end
+      :error -> {:ok, nil}
+    end
+  end
+
+  defp build_request_body(params) do
+    with {:ok, name} <- maybe_add_field(params, "name"),
+         {:ok, icon} <- maybe_add_field(params, "icon"),
+         {:ok, verification_level} <- validate_enum_param(params, :verification_level, [0, 1, 2, 3, 4]),
+         {:ok, explicit_content_filter} <- validate_enum_param(params, :explicit_content_filter, [0, 1, 2]),
+         {:ok, system_channel_id} <- maybe_add_field(params, "system_channel_id") do
+
+      body = %{}
+      |> add_if_present("name", name)
+      |> add_if_present("icon", icon)
+      |> add_if_present("verification_level", verification_level)
+      |> add_if_present("explicit_content_filter", explicit_content_filter)
+      |> add_if_present("system_channel_id", system_channel_id)
+
+      if Enum.empty?(body) do
+        {:error, "No valid fields to update"}
+      else
+        {:ok, body}
+      end
+    end
+  end
+
+  defp add_if_present(body, _field, nil), do: body
+  defp add_if_present(body, field, value), do: Map.put(body, field, value)
+
+  defp maybe_add_field(params, field) do
+    case Map.get(params, String.to_atom(field)) do
+      nil -> {:ok, nil}
+      value -> {:ok, value}
+    end
+  end
+
+  defp get_change_description(params) do
+    params
+    |> Map.drop([:guild_id, :plug])
+    |> Enum.map_join(", ", fn {k, _v} -> "#{k}" end)
+    |> case do
+      "" -> "no changes"
+      changes -> changes
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/discord/guilds/edit_guild_test.exs
+++ b/lux/test/unit/lux/prisms/discord/guilds/edit_guild_test.exs
@@ -1,0 +1,181 @@
+defmodule Lux.Prisms.Discord.Guilds.EditGuildTest do
+  @moduledoc """
+  Test suite for the EditGuild module.
+  These tests verify the prism's ability to:
+  - Modify basic guild settings
+  - Handle icon image updates
+  - Validate input parameters
+  - Handle Discord API errors appropriately
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Prisms.Discord.Guilds.EditGuild
+
+  @guild_id "987654321098765432"
+  @guild_name "Test Server"
+  # 1x1 transparent PNG
+  @test_icon "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+  @agent_ctx %{name: "TestAgent"}
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "handler/2" do
+    test "successfully modifies guild name" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "PATCH"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        body_map = Jason.decode!(body)
+        assert body_map["name"] == @guild_name
+
+        response = %{
+          "id" => @guild_id,
+          "name" => @guild_name,
+          "icon" => nil,
+          "verification_level" => 0,
+          "explicit_content_filter" => 0
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+      end)
+
+      assert {:ok, %{
+        modified: true,
+        guild_id: @guild_id,
+        guild: %{
+          "id" => @guild_id,
+          "name" => @guild_name
+        }
+      }} = EditGuild.handler(
+        %{
+          guild_id: @guild_id,
+          name: @guild_name,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "successfully updates guild icon" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        body_map = Jason.decode!(body)
+        assert body_map["icon"] == @test_icon
+
+        response = %{
+          "id" => @guild_id,
+          "name" => @guild_name,
+          "icon" => "abc123def456",
+          "verification_level" => 0,
+          "explicit_content_filter" => 0
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+      end)
+
+      assert {:ok, %{
+        modified: true,
+        guild: %{"icon" => "abc123def456"}
+      }} = EditGuild.handler(
+        %{
+          guild_id: @guild_id,
+          icon: @test_icon,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "successfully updates multiple settings" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        body_map = Jason.decode!(body)
+        assert body_map["name"] == @guild_name
+        assert body_map["verification_level"] == 2
+        assert body_map["explicit_content_filter"] == 1
+
+        response = %{
+          "id" => @guild_id,
+          "name" => @guild_name,
+          "verification_level" => 2,
+          "explicit_content_filter" => 1
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+      end)
+
+      assert {:ok, %{modified: true}} = EditGuild.handler(
+        %{
+          guild_id: @guild_id,
+          name: @guild_name,
+          verification_level: 2,
+          explicit_content_filter: 1,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "handles Discord API errors" do
+      error_body = %{
+        "message" => "Missing Permissions",
+        "code" => 50_013
+      }
+
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(error_body))
+      end)
+
+      assert {:error, {403, error_body}} = EditGuild.handler(
+        %{
+          guild_id: @guild_id,
+          name: @guild_name,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when guild_id is missing" do
+      assert {:error, "Missing or invalid guild_id"} = EditGuild.handler(
+        %{
+          name: @guild_name
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when no fields to update" do
+      assert {:error, "No valid fields to update"} = EditGuild.handler(
+        %{
+          guild_id: @guild_id
+        },
+        @agent_ctx
+      )
+    end
+
+    test "fails when verification_level is invalid" do
+      assert {:error, error} = EditGuild.handler(
+        %{
+          guild_id: @guild_id,
+          verification_level: 999
+        },
+        @agent_ctx
+      )
+      assert error =~ "verification_level"
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the EditGuild prism, enabling modification of basic Discord server settings. The implementation focuses on core server configuration while keeping notification-related settings separate in the existing ModifyNotificationSettings prism.

Key Features:
- Basic server settings (name, icon)
- Security settings (verification level)
- Content moderation (explicit content filter)
- System message channel configuration
- Comprehensive input validation
- Detailed logging for monitoring changes
- Full test coverage with mock API interactions

The prism follows Discord's API specifications and maintains a clear separation of concerns by delegating notification settings to the dedicated notification prism.