### PR TITLE
✨ Discord Get Notifiaction Settings Lens

### DIFF
--- a/lux/lib/lux/lenses/discord/guilds/get_notification_settings.ex
+++ b/lux/lib/lux/lenses/discord/guilds/get_notification_settings.ex
@@ -1,0 +1,68 @@
+defmodule Lux.Lenses.Discord.Guilds.GetNotificationSettings do
+  @moduledoc """
+  A lens for fetching server-wide notification settings from a Discord guild.
+  This lens provides a simple interface for fetching notification settings with:
+  - Minimal required parameters (guild_id)
+  - Direct Discord API error propagation
+  - Clean response structure
+
+  ## Examples
+      iex> GetNotificationSettings.focus(%{
+      ...>   guild_id: "123456789"
+      ...> })
+      {:ok, %{
+        default_message_notifications: 0,
+        explicit_content_filter: 1,
+        system_channel_flags: 0
+      }}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "Get Discord Guild Notification Settings",
+    description: "Fetches server-wide notification settings from a Discord guild",
+    url: "https://discord.com/api/v10/guilds/:guild_id",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to fetch notification settings from",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id"]
+    }
+
+  @doc """
+  Transforms the Discord API response into a simpler format focusing on notification settings.
+  ## Examples
+      iex> after_focus(%{
+      ...>   "default_message_notifications" => 0,
+      ...>   "explicit_content_filter" => 1,
+      ...>   "system_channel_flags" => 0,
+      ...>   "other_field" => "ignored"
+      ...> })
+      {:ok, %{
+        default_message_notifications: 0,
+        explicit_content_filter: 1,
+        system_channel_flags: 0
+      }}
+  """
+  @impl true
+  def after_focus(%{"default_message_notifications" => default_notifications, "explicit_content_filter" => content_filter, "system_channel_flags" => system_flags} = _response) do
+    {:ok, %{
+      default_message_notifications: default_notifications,
+      explicit_content_filter: content_filter,
+      system_channel_flags: system_flags
+    }}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/guilds/get_notification_settings_test.exs
+++ b/lux/test/unit/lux/lenses/discord/guilds/get_notification_settings_test.exs
@@ -1,0 +1,73 @@
+defmodule Lux.Lenses.Discord.Guilds.GetNotificationSettingsTest do
+  @moduledoc """
+  Test suite for the GetNotificationSettings module.
+  These tests verify the lens's ability to:
+  - Fetch notification settings from a Discord guild
+  - Handle Discord API errors appropriately
+  - Validate input/output schemas
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Guilds.GetNotificationSettings
+
+  @guild_id "123456789012345678"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully fetches notification settings" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "id" => @guild_id,
+          "name" => "Test Server",
+          "default_message_notifications" => 0,
+          "explicit_content_filter" => 1,
+          "system_channel_flags" => 0
+        }))
+      end)
+
+      assert {:ok, %{
+        default_message_notifications: 0,
+        explicit_content_filter: 1,
+        system_channel_flags: 0
+      }} = GetNotificationSettings.focus(%{
+        "guild_id" => @guild_id
+      }, %{})
+    end
+
+    test "handles Discord API error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Missing Permissions"}} = GetNotificationSettings.focus(%{
+        "guild_id" => @guild_id
+      }, %{})
+    end
+  end
+
+  describe "schema validation" do
+    test "validates schema" do
+      lens = GetNotificationSettings.view()
+      assert lens.schema.required == ["guild_id"]
+      assert Map.has_key?(lens.schema.properties, :guild_id)
+    end
+  end
+end


### PR DESCRIPTION

### Request Parameters
| Parameter | Type   | Required | Description                    |
|-----------|--------|----------|--------------------------------|
| guild_id  | string | Yes      | The ID of the Discord guild   |

### Response Structure
```typescript
interface NotificationSettings {
  default_message_notifications: number;
  explicit_content_filter: number;
  system_channel_flags: number;
}
```

### Error Handling
The lens handles common Discord API errors:
- 401: Unauthorized
- 403: Missing Permissions
- 404: Guild Not Found
- 429: Rate Limited

### Performance Considerations
- Lightweight response transformation
- Minimal memory footprint
- No external dependencies beyond core requirements

## Integration Examples

### Basic Integration
```elixir
defmodule MyBot.NotificationManager do
  alias Lux.Lenses.Discord.Guilds.GetNotificationSettings

  def check_guild_settings(guild_id) do
    case GetNotificationSettings.focus(%{guild_id: guild_id}) do
      {:ok, settings} -> handle_settings(settings)
      {:error, error} -> handle_error(error)
    end
  end
end
```

### With Error Handling
```elixir
def fetch_settings(guild_id) do
  GetNotificationSettings.focus(%{guild_id: guild_id})
  |> case do
    {:ok, settings} -> {:ok, transform_settings(settings)}
    {:error, %{"message" => msg}} -> {:error, :api_error, msg}
    _ -> {:error, :unknown}
  end
end
```

## Best Practices
1. Always handle potential API errors
2. Validate guild_id format before making requests
3. Consider implementing rate limiting handling
4. Cache frequently accessed settings when appropriate
5. Log important operations and errors

## Contributing
When contributing to this feature:
1. Follow the established pattern matching style
2. Maintain consistent error handling
3. Add comprehensive tests for new functionality
4. Update documentation for any changes
5. Consider backward compatibility