### PR TITLE
✨ Discord Read Slash Command Lens

### DIFF
--- a/lux/lib/lux/lenses/discord/interactions/read_slash_command.ex
+++ b/lux/lib/lux/lenses/discord/interactions/read_slash_command.ex
@@ -1,0 +1,108 @@
+defmodule Lux.Lenses.Discord.Interactions.ReadSlashCommand do
+  @moduledoc """
+  A lens for reading Discord slash command interaction data.
+  This lens provides a simple interface for reading slash command details with:
+  - Minimal required parameters (interaction_id)
+  - Direct Discord API error propagation
+  - Clean response structure
+
+  ## Examples
+
+      iex> ReadSlashCommand.focus(%{
+      ...>   interaction_id: "123456789"
+      ...> })
+      {:ok, %{
+        id: "123456789",
+        command_id: "987654321",
+        command_name: "test",
+        options: [%{
+          name: "user",
+          type: 6,
+          value: "111222333"
+        }],
+        guild_id: "444555666",
+        channel_id: "777888999",
+        member: %{
+          user_id: "111222333",
+          username: "testuser",
+          roles: ["role1", "role2"]
+        }
+      }}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "Read Discord Slash Command",
+    description: "Reads slash command interaction data from Discord",
+    url: "https://discord.com/api/v10/interactions/:interaction_id",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        interaction_id: %{
+          type: :string,
+          description: "The ID of the interaction to read",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["interaction_id"]
+    }
+
+  @impl true
+  def after_focus(%{
+    "id" => id,
+    "data" => %{"id" => command_id, "name" => command_name, "options" => options},
+    "guild_id" => guild_id,
+    "channel_id" => channel_id,
+    "member" => %{
+      "user" => %{"id" => user_id, "username" => username},
+      "roles" => roles
+    }
+  }) do
+    {:ok, %{
+      id: id,
+      command_id: command_id,
+      command_name: command_name,
+      options: options,
+      guild_id: guild_id,
+      channel_id: channel_id,
+      member: %{
+        user_id: user_id,
+        username: username,
+        roles: roles
+      }
+    }}
+  end
+
+  def after_focus(%{
+    "id" => id,
+    "data" => %{"id" => command_id, "name" => command_name},
+    "guild_id" => guild_id,
+    "channel_id" => channel_id,
+    "member" => %{
+      "user" => %{"id" => user_id, "username" => username},
+      "roles" => roles
+    }
+  }) do
+    {:ok, %{
+      id: id,
+      command_id: command_id,
+      command_name: command_name,
+      options: [],
+      guild_id: guild_id,
+      channel_id: channel_id,
+      member: %{
+        user_id: user_id,
+        username: username,
+        roles: roles
+      }
+    }}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/interactions/read_slash_command_test.exs
+++ b/lux/test/unit/lux/lenses/discord/interactions/read_slash_command_test.exs
@@ -1,0 +1,121 @@
+defmodule Lux.Lenses.Discord.Interactions.ReadSlashCommandTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Interactions.ReadSlashCommand
+
+  @interaction_id "123456789012345678"
+
+  describe "focus/2" do
+    test "successfully reads slash command with options" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/interactions/:interaction_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "id" => @interaction_id,
+          "data" => %{
+            "id" => "987654321",
+            "name" => "test",
+            "options" => [
+              %{
+                "name" => "user",
+                "type" => 6,
+                "value" => "111222333"
+              }
+            ]
+          },
+          "guild_id" => "444555666",
+          "channel_id" => "777888999",
+          "member" => %{
+            "user" => %{
+              "id" => "111222333",
+              "username" => "testuser"
+            },
+            "roles" => ["role1", "role2"]
+          }
+        }))
+      end)
+
+      assert {:ok, response} = ReadSlashCommand.focus(%{
+        interaction_id: @interaction_id
+      })
+
+      assert response.id == @interaction_id
+      assert response.command_id == "987654321"
+      assert response.command_name == "test"
+      assert length(response.options) == 1
+
+      [option] = response.options
+      assert option["name"] == "user"
+      assert option["type"] == 6
+      assert option["value"] == "111222333"
+
+      assert response.guild_id == "444555666"
+      assert response.channel_id == "777888999"
+      assert response.member.user_id == "111222333"
+      assert response.member.username == "testuser"
+      assert response.member.roles == ["role1", "role2"]
+    end
+
+    test "successfully reads slash command without options" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/interactions/:interaction_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "id" => @interaction_id,
+          "data" => %{
+            "id" => "987654321",
+            "name" => "test"
+          },
+          "guild_id" => "444555666",
+          "channel_id" => "777888999",
+          "member" => %{
+            "user" => %{
+              "id" => "111222333",
+              "username" => "testuser"
+            },
+            "roles" => ["role1", "role2"]
+          }
+        }))
+      end)
+
+      assert {:ok, response} = ReadSlashCommand.focus(%{
+        interaction_id: @interaction_id
+      })
+
+      assert response.id == @interaction_id
+      assert response.command_id == "987654321"
+      assert response.command_name == "test"
+      assert response.options == []
+      assert response.guild_id == "444555666"
+      assert response.channel_id == "777888999"
+      assert response.member.user_id == "111222333"
+      assert response.member.username == "testuser"
+      assert response.member.roles == ["role1", "role2"]
+    end
+
+    test "handles interaction not found" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/interactions/:interaction_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{
+          "message" => "Unknown Interaction"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Unknown Interaction"}} = ReadSlashCommand.focus(%{
+        interaction_id: "invalid_id"
+      })
+    end
+  end
+end


### PR DESCRIPTION
# Discord Slash Command Interaction Lens

## Overview
This lens provides functionality to read Discord slash command interaction data. It follows the standard pattern of other Discord lenses while handling the specific structure of slash command interactions.

## Features
### 1. Core Functionality
- Reads slash command interaction details using interaction ID
- Handles both commands with and without options
- Preserves the original structure of command options

### 2. Data Structure
The lens transforms Discord's API response into a clean format:
```elixir
{:ok, %{
  id: String.t(),              # Interaction ID
  command_id: String.t(),      # Command ID
  command_name: String.t(),    # Command name
  options: [                   # Command options (if any)
    %{
      "name" => String.t(),    # Option name
      "type" => integer(),     # Option type
      "value" => any()         # Option value
    }
  ],
  guild_id: String.t(),        # Server ID
  channel_id: String.t(),      # Channel ID
  member: %{                   # Command executor
    user_id: String.t(),
    username: String.t(),
    roles: [String.t()]
  }
}}
```

### 3. Error Handling
- Handles non-existent interactions
- Maintains Discord API error format
- Validates interaction ID format

## Usage
```elixir
# Reading a slash command interaction
{:ok, interaction} = ReadSlashCommand.focus(%{
  interaction_id: "123456789012345678"
})

# Handling errors
{:error, %{"message" => message}} = ReadSlashCommand.focus(%{
  interaction_id: "invalid_id"
})
```

## Implementation Details
- Follows Discord lens patterns for consistency
- Maintains original option structure from Discord API
- Uses pattern matching for clean data transformation
- Includes comprehensive test coverage for all scenarios

## Related Documentation
- [Discord API - Interactions](https://discord.com/developers/docs/interactions/receiving-and-responding)
- [Discord API - Slash Commands](https://discord.com/developers/docs/interactions/application-commands)