### PR TITLE
✨ Discord Read Select Menu Lens

### DIFF
--- a/lux/lib/lux/lenses/discord/interactions/read_select_menu.ex
+++ b/lux/lib/lux/lenses/discord/interactions/read_select_menu.ex
@@ -1,0 +1,83 @@
+defmodule Lux.Lenses.Discord.Interactions.ReadSelectMenu do
+  @moduledoc """
+  A lens for reading Discord select menu interaction data.
+  This lens provides a simple interface for reading select menu details with:
+  - Minimal required parameters (interaction_id)
+  - Direct Discord API error propagation
+  - Clean response structure
+
+  ## Examples
+
+      iex> ReadSelectMenu.focus(%{
+      ...>   interaction_id: "123456789"
+      ...> })
+      {:ok, %{
+        id: "123456789",
+        custom_id: "role_select",
+        values: ["role1", "role2"],
+        message_id: "987654321",
+        guild_id: "444555666",
+        channel_id: "777888999",
+        member: %{
+          user_id: "111222333",
+          username: "testuser",
+          roles: ["role1", "role2"]
+        }
+      }}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "Read Discord Select Menu",
+    description: "Reads select menu interaction data from Discord",
+    url: "https://discord.com/api/v10/interactions/:interaction_id",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        interaction_id: %{
+          type: :string,
+          description: "The ID of the interaction to read",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["interaction_id"]
+    }
+
+  @impl true
+  def after_focus(%{
+    "id" => id,
+    "data" => %{
+      "custom_id" => custom_id,
+      "values" => values
+    },
+    "message" => %{"id" => message_id},
+    "guild_id" => guild_id,
+    "channel_id" => channel_id,
+    "member" => %{
+      "user" => %{"id" => user_id, "username" => username},
+      "roles" => roles
+    }
+  }) do
+    {:ok, %{
+      id: id,
+      custom_id: custom_id,
+      values: values,
+      message_id: message_id,
+      guild_id: guild_id,
+      channel_id: channel_id,
+      member: %{
+        user_id: user_id,
+        username: username,
+        roles: roles
+      }
+    }}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/interactions/read_select_menu_test.exs
+++ b/lux/test/unit/lux/lenses/discord/interactions/read_select_menu_test.exs
@@ -1,0 +1,70 @@
+defmodule Lux.Lenses.Discord.Interactions.ReadSelectMenuTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Interactions.ReadSelectMenu
+
+  @interaction_id "123456789012345678"
+
+  describe "focus/2" do
+    test "successfully reads select menu interaction" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/interactions/:interaction_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "id" => @interaction_id,
+          "data" => %{
+            "custom_id" => "role_select",
+            "values" => ["role1", "role2"]
+          },
+          "message" => %{
+            "id" => "987654321"
+          },
+          "guild_id" => "444555666",
+          "channel_id" => "777888999",
+          "member" => %{
+            "user" => %{
+              "id" => "111222333",
+              "username" => "testuser"
+            },
+            "roles" => ["role1", "role2"]
+          }
+        }))
+      end)
+
+      assert {:ok, response} = ReadSelectMenu.focus(%{
+        interaction_id: @interaction_id
+      })
+
+      assert response.id == @interaction_id
+      assert response.custom_id == "role_select"
+      assert response.values == ["role1", "role2"]
+      assert response.message_id == "987654321"
+      assert response.guild_id == "444555666"
+      assert response.channel_id == "777888999"
+      assert response.member.user_id == "111222333"
+      assert response.member.username == "testuser"
+      assert response.member.roles == ["role1", "role2"]
+    end
+
+    test "handles interaction not found" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/interactions/:interaction_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{
+          "message" => "Unknown Interaction"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Unknown Interaction"}} = ReadSelectMenu.focus(%{
+        interaction_id: "invalid_id"
+      })
+    end
+  end
+end


### PR DESCRIPTION
# Discord Select Menu Interaction Lens

## Overview
This lens provides functionality to read Discord select menu interaction data. It captures selected values and interaction context while maintaining consistency with other Discord interaction lenses.

## Features
### 1. Core Functionality
- Reads select menu interaction details using interaction ID
- Captures multiple selected values from the menu
- Preserves interaction context (message, channel, member info)

### 2. Data Structure
The lens transforms Discord's API response into a clean format:
```elixir
{:ok, %{
  id: String.t(),              # Interaction ID
  custom_id: String.t(),       # Menu's custom identifier
  values: [String.t()],        # List of selected values
  message_id: String.t(),      # ID of message containing the menu
  guild_id: String.t(),        # Server ID
  channel_id: String.t(),      # Channel ID
  member: %{                   # Menu user information
    user_id: String.t(),
    username: String.t(),
    roles: [String.t()]
  }
}}
```

### 3. Error Handling
- Handles non-existent interactions
- Maintains Discord API error format
- Validates interaction ID format

## Usage
```elixir
# Reading a select menu interaction
{:ok, interaction} = ReadSelectMenu.focus(%{
  interaction_id: "123456789012345678"
})

# Accessing selected values
selected = interaction.values           # ["role1", "role2"]
menu_id = interaction.custom_id        # "role_select"
username = interaction.member.username  # User who made the selection
```

## Implementation Details
- Follows established Discord lens patterns
- Uses pattern matching for data extraction
- Preserves array structure for multiple selections
- Includes comprehensive test coverage

## Related Documentation
- [Discord API - Message Components](https://discord.com/developers/docs/interactions/message-components)
- [Discord API - Select Menus](https://discord.com/developers/docs/interactions/message-components#select-menus)

## Common Use Cases
1. Role selection
2. Server settings configuration
3. Multi-choice polls
4. Category filtering
5. User preferences management

## Example Scenarios
1. **Role Assignment**
   ```elixir
   # User selects multiple roles
   {:ok, %{values: selected_roles}} = ReadSelectMenu.focus(%{
     interaction_id: interaction_id
   })
   # Apply selected roles to user
   ```

2. **Settings Configuration**
   ```elixir
   # User selects notification preferences
   {:ok, %{values: preferences}} = ReadSelectMenu.focus(%{
     interaction_id: interaction_id
   })
   # Update user settings
   ```