### PR TITLE
✨ Discord Read Context Menu Lens

### DIFF
--- a/lux/lib/lux/lenses/discord/interactions/read_context_menu.ex
+++ b/lux/lib/lux/lenses/discord/interactions/read_context_menu.ex
@@ -1,0 +1,86 @@
+defmodule Lux.Lenses.Discord.Interactions.ReadContextMenu do
+  @moduledoc """
+  A lens for reading Discord context menu interaction data.
+  This lens provides a simple interface for reading context menu details with:
+  - Minimal required parameters (interaction_id)
+  - Direct Discord API error propagation
+  - Clean response structure
+
+  ## Examples
+
+      iex> ReadContextMenu.focus(%{
+      ...>   interaction_id: "123456789"
+      ...> })
+      {:ok, %{
+        id: "123456789",
+        command_id: "987654321",
+        command_name: "Report Message",
+        target_id: "444555666",
+        target_type: 3,
+        guild_id: "444555666",
+        channel_id: "777888999",
+        member: %{
+          user_id: "111222333",
+          username: "testuser",
+          roles: ["role1", "role2"]
+        }
+      }}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "Read Discord Context Menu",
+    description: "Reads context menu interaction data from Discord",
+    url: "https://discord.com/api/v10/interactions/:interaction_id",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        interaction_id: %{
+          type: :string,
+          description: "The ID of the interaction to read",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["interaction_id"]
+    }
+
+  @impl true
+  def after_focus(%{
+    "id" => id,
+    "data" => %{
+      "id" => command_id,
+      "name" => command_name,
+      "target_id" => target_id,
+      "type" => target_type
+    },
+    "guild_id" => guild_id,
+    "channel_id" => channel_id,
+    "member" => %{
+      "user" => %{"id" => user_id, "username" => username},
+      "roles" => roles
+    }
+  }) do
+    {:ok, %{
+      id: id,
+      command_id: command_id,
+      command_name: command_name,
+      target_id: target_id,
+      target_type: target_type,
+      guild_id: guild_id,
+      channel_id: channel_id,
+      member: %{
+        user_id: user_id,
+        username: username,
+        roles: roles
+      }
+    }}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/interactions/read_context_menu_test.exs
+++ b/lux/test/unit/lux/lenses/discord/interactions/read_context_menu_test.exs
@@ -1,0 +1,70 @@
+defmodule Lux.Lenses.Discord.Interactions.ReadContextMenuTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Interactions.ReadContextMenu
+
+  @interaction_id "123456789012345678"
+
+  describe "focus/2" do
+    test "successfully reads context menu interaction" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/interactions/:interaction_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "id" => @interaction_id,
+          "data" => %{
+            "id" => "987654321",
+            "name" => "Report Message",
+            "target_id" => "444555666",
+            "type" => 3
+          },
+          "guild_id" => "444555666",
+          "channel_id" => "777888999",
+          "member" => %{
+            "user" => %{
+              "id" => "111222333",
+              "username" => "testuser"
+            },
+            "roles" => ["role1", "role2"]
+          }
+        }))
+      end)
+
+      assert {:ok, response} = ReadContextMenu.focus(%{
+        interaction_id: @interaction_id
+      })
+
+      assert response.id == @interaction_id
+      assert response.command_id == "987654321"
+      assert response.command_name == "Report Message"
+      assert response.target_id == "444555666"
+      assert response.target_type == 3
+      assert response.guild_id == "444555666"
+      assert response.channel_id == "777888999"
+      assert response.member.user_id == "111222333"
+      assert response.member.username == "testuser"
+      assert response.member.roles == ["role1", "role2"]
+    end
+
+    test "handles interaction not found" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/interactions/:interaction_id"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{
+          "message" => "Unknown Interaction"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Unknown Interaction"}} = ReadContextMenu.focus(%{
+        interaction_id: "invalid_id"
+      })
+    end
+  end
+end


### PR DESCRIPTION
Add Discord Context Menu Interaction Lens

Implements a new lens for reading Discord context menu interaction data, providing a clean interface to fetch and process context menu interactions. This lens follows the established patterns of other Discord interaction lenses while maintaining consistency in error handling and response formatting.

Key Features:
- Simple parameter validation requiring only interaction_id
- Structured response format including command details, target information, and member data
- Consistent error handling aligned with Discord API responses
- Comprehensive test coverage for successful and error scenarios

Technical Implementation:
- Uses Lux.Lens behavior with Discord integration settings
- Implements after_focus/1 for transforming API responses into a clean structure
- Validates interaction IDs using regex pattern matching
- Includes detailed documentation with usage examples
- Test suite covers successful interaction reading and error cases

Example Usage:
```elixir
ReadContextMenu.focus(%{interaction_id: "123456789"})
```

Response includes:
- Interaction ID and command details (id, name)
- Target information (id, type)
- Guild and channel context
- Member details (user info, roles)

Future Improvements:
- Add support for application command permissions
- Implement caching for frequently accessed interactions
- Add support for component interactions in the same pattern