### PR TITLE
✨ Discord List Emojis Lens

### DIFF
--- a/lux/lib/lux/lenses/discord/guilds/list_emojis.ex
+++ b/lux/lib/lux/lenses/discord/guilds/list_emojis.ex
@@ -1,0 +1,112 @@
+defmodule Lux.Lenses.Discord.Guilds.ListEmojis do
+  @moduledoc """
+  A lens for listing custom emojis in a Discord guild.
+  This lens provides a simple interface for fetching emojis with:
+  - Minimal required parameters (guild_id)
+  - Direct Discord API error propagation
+  - Clean response structure
+
+  ## Examples
+      iex> ListEmojis.focus(%{
+      ...>   guild_id: "123456789"
+      ...> })
+      {:ok, [
+        %{
+          id: "987654321",
+          name: "custom_emoji",
+          roles: ["role1", "role2"],
+          user: %{
+            id: "111222333",
+            username: "creator"
+          },
+          require_colons: true,
+          managed: false,
+          animated: false,
+          available: true
+        }
+      ]}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "List Discord Emojis",
+    description: "Lists custom emojis in a Discord guild",
+    url: "https://discord.com/api/v10/guilds/:guild_id/emojis",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to list emojis from",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id"]
+    }
+
+  @doc """
+  Transforms the Discord API response into a simpler format.
+  ## Examples
+      iex> after_focus([
+      ...>   %{
+      ...>     "id" => "123",
+      ...>     "name" => "custom_emoji",
+      ...>     "roles" => ["role1"],
+      ...>     "user" => %{"id" => "456", "username" => "creator"},
+      ...>     "require_colons" => true,
+      ...>     "managed" => false,
+      ...>     "animated" => false,
+      ...>     "available" => true
+      ...>   }
+      ...> ])
+      {:ok, [
+        %{
+          id: "123",
+          name: "custom_emoji",
+          roles: ["role1"],
+          user: %{id: "456", username: "creator"},
+          require_colons: true,
+          managed: false,
+          animated: false,
+          available: true
+        }
+      ]}
+  """
+  @impl true
+  def after_focus(emojis) when is_list(emojis) do
+    {:ok, Enum.map(emojis, &transform_emoji/1)}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+
+  defp transform_emoji(%{
+    "id" => id,
+    "name" => name,
+    "roles" => roles,
+    "user" => user,
+    "require_colons" => require_colons,
+    "managed" => managed,
+    "animated" => animated,
+    "available" => available
+  }) do
+    %{
+      id: id,
+      name: name,
+      roles: roles,
+      user: %{
+        id: user["id"],
+        username: user["username"]
+      },
+      require_colons: require_colons,
+      managed: managed,
+      animated: animated,
+      available: available
+    }
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/guilds/list_emojis_test.exs
+++ b/lux/test/unit/lux/lenses/discord/guilds/list_emojis_test.exs
@@ -1,0 +1,64 @@
+defmodule Lux.Lenses.Discord.Guilds.ListEmojisTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Guilds.ListEmojis
+
+  @guild_id "123456789"
+
+  describe "focus/2" do
+    test "successfully lists guild emojis" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert String.replace(conn.request_path, ":guild_id", @guild_id) == "/api/v10/guilds/#{@guild_id}/emojis"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([%{
+          "id" => "987654321",
+          "name" => "custom_emoji",
+          "roles" => ["role1", "role2"],
+          "user" => %{
+            "id" => "111222333",
+            "username" => "creator"
+          },
+          "require_colons" => true,
+          "managed" => false,
+          "animated" => false,
+          "available" => true
+        }]))
+      end)
+
+      assert {:ok, [emoji]} = ListEmojis.focus(%{
+        guild_id: @guild_id
+      })
+
+      assert emoji.id == "987654321"
+      assert emoji.name == "custom_emoji"
+      assert emoji.roles == ["role1", "role2"]
+      assert emoji.user.id == "111222333"
+      assert emoji.user.username == "creator"
+      assert emoji.require_colons == true
+      assert emoji.managed == false
+      assert emoji.animated == false
+      assert emoji.available == true
+    end
+
+    test "handles guild not found" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert String.replace(conn.request_path, ":guild_id", "invalid_id") == "/api/v10/guilds/invalid_id/emojis"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{
+          "message" => "Unknown Guild"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Unknown Guild"}} = ListEmojis.focus(%{
+        guild_id: "invalid_id"
+      })
+    end
+  end
+end


### PR DESCRIPTION
Add Discord Guild Emojis Lens

Implements a new lens for retrieving custom emojis from Discord guilds. This lens follows the established patterns of other Discord lenses while maintaining consistency in error handling and response formatting.

Key Features:
- Simple interface requiring only guild_id parameter
- Consistent URL parameter handling using :guild_id format
- Comprehensive response transformation including:
  - Emoji metadata (id, name, animated status)
  - Role restrictions
  - Creator information
  - Availability status
- Robust error handling aligned with Discord API responses
- Thorough test coverage for both success and error cases

Technical Implementation:
- Follows Lux.Lens behavior with Discord integration
- Uses pattern matching for clean response transformation
- Validates guild IDs using regex pattern (17-20 digit format)
- Maintains consistency with other Discord lenses in URL formatting
- Includes detailed documentation with usage examples

Example Usage:
```elixir
ListEmojis.focus(%{guild_id: "123456789"})
```

Response Structure:
- List of emoji objects containing:
  - Basic information (id, name)
  - Role restrictions
  - Creator details (user_id, username)
  - Emoji properties (require_colons, managed, animated)
  - Availability status

Future Improvements:
- Add support for emoji creation/modification
- Implement pagination for guilds with large emoji sets
- Add filtering options (e.g., by name, animated status)
- Cache frequently accessed emoji data