### PR TITLE
✨ Discord List Stickers Lens

### DIFF
--- a/lux/lib/lux/lenses/discord/guilds/list_stickers.ex
+++ b/lux/lib/lux/lenses/discord/guilds/list_stickers.ex
@@ -1,0 +1,117 @@
+defmodule Lux.Lenses.Discord.Guilds.ListStickers do
+  @moduledoc """
+  A lens for listing custom stickers in a Discord guild.
+  This lens provides a simple interface for fetching stickers with:
+  - Minimal required parameters (guild_id)
+  - Direct Discord API error propagation
+  - Clean response structure
+
+  ## Examples
+      iex> ListStickers.focus(%{
+      ...>   guild_id: "123456789"
+      ...> })
+      {:ok, [
+        %{
+          id: "987654321",
+          name: "custom_sticker",
+          description: "A cool sticker",
+          tags: "cool,awesome",
+          type: 1,
+          format_type: 1,
+          available: true,
+          guild_id: "123456789",
+          user: %{
+            id: "111222333",
+            username: "creator"
+          }
+        }
+      ]}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "List Discord Stickers",
+    description: "Lists custom stickers in a Discord guild",
+    url: "https://discord.com/api/v10/guilds/:guild_id/stickers",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to list stickers from",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id"]
+    }
+
+  @doc """
+  Transforms the Discord API response into a simpler format.
+  ## Examples
+      iex> after_focus([
+      ...>   %{
+      ...>     "id" => "123",
+      ...>     "name" => "custom_sticker",
+      ...>     "description" => "A cool sticker",
+      ...>     "tags" => "cool,awesome",
+      ...>     "type" => 1,
+      ...>     "format_type" => 1,
+      ...>     "available" => true,
+      ...>     "guild_id" => "456",
+      ...>     "user" => %{"id" => "789", "username" => "creator"}
+      ...>   }
+      ...> ])
+      {:ok, [
+        %{
+          id: "123",
+          name: "custom_sticker",
+          description: "A cool sticker",
+          tags: "cool,awesome",
+          type: 1,
+          format_type: 1,
+          available: true,
+          guild_id: "456",
+          user: %{id: "789", username: "creator"}
+        }
+      ]}
+  """
+  @impl true
+  def after_focus(stickers) when is_list(stickers) do
+    {:ok, Enum.map(stickers, &transform_sticker/1)}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+
+  defp transform_sticker(%{
+    "id" => id,
+    "name" => name,
+    "description" => description,
+    "tags" => tags,
+    "type" => type,
+    "format_type" => format_type,
+    "available" => available,
+    "guild_id" => guild_id,
+    "user" => user
+  }) do
+    %{
+      id: id,
+      name: name,
+      description: description,
+      tags: tags,
+      type: type,
+      format_type: format_type,
+      available: available,
+      guild_id: guild_id,
+      user: %{
+        id: user["id"],
+        username: user["username"]
+      }
+    }
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/guilds/list_stickers_test.exs
+++ b/lux/test/unit/lux/lenses/discord/guilds/list_stickers_test.exs
@@ -1,0 +1,66 @@
+defmodule Lux.Lenses.Discord.Guilds.ListStickersTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Guilds.ListStickers
+
+  @guild_id "123456789"
+
+  describe "focus/2" do
+    test "successfully lists guild stickers" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert String.replace(conn.request_path, ":guild_id", @guild_id) == "/api/v10/guilds/#{@guild_id}/stickers"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([%{
+          "id" => "987654321",
+          "name" => "custom_sticker",
+          "description" => "A cool sticker",
+          "tags" => "cool,awesome",
+          "type" => 1,
+          "format_type" => 1,
+          "available" => true,
+          "guild_id" => @guild_id,
+          "user" => %{
+            "id" => "111222333",
+            "username" => "creator"
+          }
+        }]))
+      end)
+
+      assert {:ok, [sticker]} = ListStickers.focus(%{
+        guild_id: @guild_id
+      })
+
+      assert sticker.id == "987654321"
+      assert sticker.name == "custom_sticker"
+      assert sticker.description == "A cool sticker"
+      assert sticker.tags == "cool,awesome"
+      assert sticker.type == 1
+      assert sticker.format_type == 1
+      assert sticker.available == true
+      assert sticker.guild_id == @guild_id
+      assert sticker.user.id == "111222333"
+      assert sticker.user.username == "creator"
+    end
+
+    test "handles guild not found" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert String.replace(conn.request_path, ":guild_id", "invalid_id") == "/api/v10/guilds/invalid_id/stickers"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{
+          "message" => "Unknown Guild"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Unknown Guild"}} = ListStickers.focus(%{
+        guild_id: "invalid_id"
+      })
+    end
+  end
+end


### PR DESCRIPTION
✨ Discord Guild Stickers Lens

Implemented a new lens for retrieving custom stickers from Discord guilds. This lens allows fetching all sticker information from a server using just the guild ID, providing detailed information including sticker metadata (name, description, tags) and creator details.

Key Features:
- Simple Interface: Fetch sticker list with just the guild_id parameter
- Sticker Metadata: Provides name, description, tags, type, format, and availability
- Creator Information: Includes user ID and username of sticker creators
- Robust Error Handling: Direct propagation of Discord API errors for easier debugging
- Guild ID Validation: Using regex pattern for parameter validation
- Clean Response Structure: Transforms Discord API response into an intuitive format
- Comprehensive Test Coverage: Validates both success and error scenarios

Technical Implementation:
- Adheres to Lux.Lens behavior
- Utilizes Discord API v10 endpoint
- Pattern matching for response transformation
- Maintains consistency with other Discord lenses

Example Usage:
```elixir
ListStickers.focus(%{guild_id: "123456789"})
```

Response Format:
```elixir
{:ok, [
  %{
    id: "987654321",
    name: "custom_sticker",
    description: "A cool sticker",
    tags: "cool,awesome",
    type: 1,
    format_type: 1,
    available: true,
    guild_id: "123456789",
    user: %{
      id: "111222333",
      username: "creator"
    }
  }
]}
```

Future Improvements:
- Add support for sticker creation/modification/deletion
- Implement pagination support
- Add tag-based filtering options
- Cache frequently accessed sticker data

Related Documentation:
- [Discord Sticker Resource](https://discord.com/developers/docs/resources/sticker)
- [List Guild Stickers Endpoint](https://discord.com/developers/docs/resources/sticker#list-guild-stickers)