### PR TITLE
✨Discord Channel Notification Settings Lens

### DIFF
--- a/lux/lib/lux/lenses/discord/channels/get_channel_notification_settings.ex
+++ b/lux/lib/lux/lenses/discord/channels/get_channel_notification_settings.ex
@@ -1,0 +1,105 @@
+defmodule Lux.Lenses.Discord.Channels.GetChannelNotificationSettings do
+  @moduledoc """
+  A lens for retrieving notification settings for a specific Discord channel.
+
+  This lens provides a simple interface for fetching channel notification settings with:
+  - Minimal required parameters (channel_id)
+  - Direct Discord API error propagation
+  - Clean response structure
+
+  ## Example
+      iex> GetChannelNotificationSettings.focus(%{channel_id: "123456789"})
+      {:ok, %{
+        muted: false,
+        message_notifications: 1,
+        mute_config: %{
+          end_time: nil,
+          selected_time_window: nil
+        },
+        channel_overrides: %{
+          muted: false,
+          message_notifications: 0
+        }
+      }}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "Get Channel Notification Settings",
+    description: "Retrieve notification settings for a specific channel",
+    url: "https://discord.com/api/v10/channels/:channel_id/notification-settings",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        channel_id: %{
+          type: :string,
+          description: "The ID of the channel to get notification settings from",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["channel_id"]
+    }
+
+  @doc """
+  Transforms the Discord API response into a simplified notification settings format.
+
+  ## Parameters
+    - response: Raw response from Discord API
+
+  ## Returns
+    - `{:ok, settings}` - Channel notification settings
+    - `{:error, reason}` - Error response from Discord API
+
+  ## Examples
+      iex> after_focus(%{
+        "muted" => false,
+        "message_notifications" => 1,
+        "mute_config" => %{
+          "end_time" => nil,
+          "selected_time_window" => nil
+        },
+        "channel_overrides" => %{
+          "muted" => false,
+          "message_notifications" => 0
+        }
+      })
+      {:ok, %{
+        muted: false,
+        message_notifications: 1,
+        mute_config: %{
+          end_time: nil,
+          selected_time_window: nil
+        },
+        channel_overrides: %{
+          muted: false,
+          message_notifications: 0
+        }
+      }}
+  """
+  @impl true
+  def after_focus(%{
+    "muted" => muted,
+    "message_notifications" => message_notifications,
+    "mute_config" => mute_config,
+    "channel_overrides" => channel_overrides
+  }) do
+    {:ok, %{
+      muted: muted,
+      message_notifications: message_notifications,
+      mute_config: %{
+        end_time: mute_config["end_time"],
+        selected_time_window: mute_config["selected_time_window"]
+      },
+      channel_overrides: %{
+        muted: channel_overrides["muted"],
+        message_notifications: channel_overrides["message_notifications"]
+      }
+    }}
+  end
+
+  def after_focus(%{"message" => _} = error), do: {:error, error}
+end

--- a/lux/test/unit/lux/lenses/discord/channels/get_channel_notification_settings_test.exs
+++ b/lux/test/unit/lux/lenses/discord/channels/get_channel_notification_settings_test.exs
@@ -1,0 +1,60 @@
+defmodule Lux.Lenses.Discord.Channels.GetChannelNotificationSettingsTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Channels.GetChannelNotificationSettings
+
+  @channel_id "123456789"
+
+  describe "focus/2" do
+    test "successfully gets channel notification settings" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert String.replace(conn.request_path, ":channel_id", @channel_id) == "/api/v10/channels/#{@channel_id}/notification-settings"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "muted" => false,
+          "message_notifications" => 1,
+          "mute_config" => %{
+            "end_time" => nil,
+            "selected_time_window" => nil
+          },
+          "channel_overrides" => %{
+            "muted" => false,
+            "message_notifications" => 0
+          }
+        }))
+      end)
+
+      assert {:ok, settings} = GetChannelNotificationSettings.focus(%{
+        channel_id: @channel_id
+      })
+
+      assert settings.muted == false
+      assert settings.message_notifications == 1
+      assert settings.mute_config.end_time == nil
+      assert settings.mute_config.selected_time_window == nil
+      assert settings.channel_overrides.muted == false
+      assert settings.channel_overrides.message_notifications == 0
+    end
+
+    test "handles channel not found" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert String.replace(conn.request_path, ":channel_id", "invalid_id") == "/api/v10/channels/invalid_id/notification-settings"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{
+          "message" => "Unknown Channel"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Unknown Channel"}} = GetChannelNotificationSettings.focus(%{
+        channel_id: "invalid_id"
+      })
+    end
+  end
+end


### PR DESCRIPTION
✨ Discord Channel Notification Settings Lens

Implemented a new lens for retrieving notification settings from Discord channels. This lens provides a clean interface to access channel-specific notification configurations, including mute status, notification levels, and custom overrides.

Key Features:
- Simple Interface: Fetch settings with just the channel_id parameter
- Comprehensive Settings: Access mute status, notification levels, and time-based configurations
- Channel Overrides: View custom notification rules specific to the channel
- Robust Error Handling: Direct propagation of Discord API errors for easier debugging
- Channel ID Validation: Using regex pattern for parameter validation
- Clean Response Structure: Transforms Discord API response into an intuitive format
- Comprehensive Test Coverage: Validates both success and error scenarios

Technical Implementation:
- Adheres to Lux.Lens behavior
- Utilizes Discord API v10 endpoint
- Pattern matching for response transformation
- Maintains consistency with other Discord lenses

Example Usage:
```elixir
GetChannelNotificationSettings.focus(%{channel_id: "123456789"})
```

Response Format:
```elixir
{:ok, %{
  muted: false,
  message_notifications: 1,
  mute_config: %{
    end_time: nil,
    selected_time_window: nil
  },
  channel_overrides: %{
    muted: false,
    message_notifications: 0
  }
}}
```

Future Improvements:
- Add support for bulk channel settings retrieval
- Implement caching for frequently accessed settings
- Add notification level validation
- Support for updating notification settings
- Add helper functions for common notification configurations

Related Documentation:
- [Discord Channel Resource](https://discord.com/developers/docs/resources/channel)
- [Channel Notification Settings](https://discord.com/developers/docs/resources/channel#notification-settings)