### PR TITLE
✨ Discord Pinned Messsages Lens

### DIFF
--- a/lux/lib/lux/lenses/discord/channels/get_pinned_messages.ex
+++ b/lux/lib/lux/lenses/discord/channels/get_pinned_messages.ex
@@ -1,0 +1,108 @@
+defmodule Lux.Lenses.Discord.Channels.GetPinnedMessages do
+  @moduledoc """
+  A lens for retrieving pinned messages from a Discord channel.
+
+  This lens provides a simple interface for fetching pinned messages with:
+  - Minimal required parameters (channel_id)
+  - Direct Discord API error propagation
+  - Clean response structure
+
+  ## Example
+      iex> GetPinnedMessages.focus(%{channel_id: "123456789"})
+      {:ok, [
+        %{
+          id: "987654321",
+          content: "Important announcement!",
+          author: %{
+            id: "111222333",
+            username: "moderator"
+          },
+          timestamp: "2024-04-03T12:00:00.000000+00:00",
+          pinned: true,
+          attachments: [],
+          embeds: []
+        }
+      ]}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "Get Pinned Messages",
+    description: "Fetch pinned messages in a channel",
+    url: "https://discord.com/api/v10/channels/:channel_id/pins",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        channel_id: %{
+          type: :string,
+          description: "The ID of the channel to get pinned messages from",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["channel_id"]
+    }
+
+  @doc """
+  Transforms the Discord API response into a simplified message list format.
+
+  ## Parameters
+    - response: Raw response from Discord API
+
+  ## Returns
+    - `{:ok, messages}` - List of pinned messages
+    - `{:error, reason}` - Error response from Discord API
+
+  ## Examples
+      iex> after_focus([
+        %{
+          "id" => "987654321",
+          "content" => "Important announcement!",
+          "author" => %{
+            "id" => "111222333",
+            "username" => "moderator"
+          },
+          "timestamp" => "2024-04-03T12:00:00.000000+00:00",
+          "pinned" => true,
+          "attachments" => [],
+          "embeds" => []
+        }
+      ])
+      {:ok, [
+        %{
+          id: "987654321",
+          content: "Important announcement!",
+          author: %{
+            id: "111222333",
+            username: "moderator"
+          },
+          timestamp: "2024-04-03T12:00:00.000000+00:00",
+          pinned: true,
+          attachments: [],
+          embeds: []
+        }
+      ]}
+  """
+  @impl true
+  def after_focus(messages) when is_list(messages) do
+    {:ok, Enum.map(messages, fn message ->
+      %{
+        id: message["id"],
+        content: message["content"],
+        author: %{
+          id: message["author"]["id"],
+          username: message["author"]["username"]
+        },
+        timestamp: message["timestamp"],
+        pinned: message["pinned"],
+        attachments: message["attachments"],
+        embeds: message["embeds"]
+      }
+    end)}
+  end
+
+  def after_focus(%{"message" => _} = error), do: {:error, error}
+end

--- a/lux/test/unit/lux/lenses/discord/channels/get_pinned_messages_test.exs
+++ b/lux/test/unit/lux/lenses/discord/channels/get_pinned_messages_test.exs
@@ -1,0 +1,62 @@
+defmodule Lux.Lenses.Discord.Channels.GetPinnedMessagesTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Channels.GetPinnedMessages
+
+  @channel_id "123456789"
+
+  describe "focus/2" do
+    test "successfully gets pinned messages" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert String.replace(conn.request_path, ":channel_id", @channel_id) == "/api/v10/channels/#{@channel_id}/pins"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([%{
+          "id" => "987654321",
+          "content" => "Important announcement!",
+          "author" => %{
+            "id" => "111222333",
+            "username" => "moderator"
+          },
+          "timestamp" => "2024-04-03T12:00:00.000000+00:00",
+          "pinned" => true,
+          "attachments" => [],
+          "embeds" => []
+        }]))
+      end)
+
+      assert {:ok, [message]} = GetPinnedMessages.focus(%{
+        channel_id: @channel_id
+      })
+
+      assert message.id == "987654321"
+      assert message.content == "Important announcement!"
+      assert message.author.id == "111222333"
+      assert message.author.username == "moderator"
+      assert message.timestamp == "2024-04-03T12:00:00.000000+00:00"
+      assert message.pinned == true
+      assert message.attachments == []
+      assert message.embeds == []
+    end
+
+    test "handles channel not found" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert String.replace(conn.request_path, ":channel_id", "invalid_id") == "/api/v10/channels/invalid_id/pins"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{
+          "message" => "Unknown Channel"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Unknown Channel"}} = GetPinnedMessages.focus(%{
+        channel_id: "invalid_id"
+      })
+    end
+  end
+end


### PR DESCRIPTION
✨ Discord Pinned Messages Lens

Implemented a new lens for retrieving pinned messages from Discord channels. This lens provides a streamlined way to access important messages that have been pinned in a channel, including message content, author information, and associated media.

Key Features:
- Simple Interface: Fetch pinned messages with just the channel_id parameter
- Message Details: Includes message content, author info, and timestamp
- Media Support: Handles attachments and embeds
- Robust Error Handling: Direct propagation of Discord API errors for easier debugging
- Channel ID Validation: Using regex pattern for parameter validation
- Clean Response Structure: Transforms Discord API response into an intuitive format
- Comprehensive Test Coverage: Validates both success and error scenarios

Technical Implementation:
- Adheres to Lux.Lens behavior
- Utilizes Discord API v10 endpoint
- Direct response transformation in after_focus
- Maintains consistency with other Discord lenses

Example Usage:
```elixir
GetPinnedMessages.focus(%{channel_id: "123456789"})
```

Response Format:
```elixir
{:ok, [
  %{
    id: "987654321",
    content: "Important announcement!",
    author: %{
      id: "111222333",
      username: "moderator"
    },
    timestamp: "2024-04-03T12:00:00.000000+00:00",
    pinned: true,
    attachments: [],
    embeds: []
  }
]}
```

Future Improvements:
- Add support for pinning/unpinning messages
- Implement pagination for channels with many pins
- Add sorting options (by timestamp, author, etc.)
- Cache frequently accessed pinned messages
- Add helper functions for common pin operations

Related Documentation:
- [Discord Channel Resource](https://discord.com/developers/docs/resources/channel)
- [Channel Pins](https://discord.com/developers/docs/resources/channel#get-pinned-messages)