### PR TITLE
✨ Discord Guild Presences Lens

### DIFF
--- a/lux/lib/lux/lenses/discord/guilds/list_presences.ex
+++ b/lux/lib/lux/lenses/discord/guilds/list_presences.ex
@@ -1,0 +1,157 @@
+defmodule Lux.Lenses.Discord.Guilds.ListPresences do
+  @moduledoc """
+  A lens for retrieving presence information of all members in a Discord guild.
+
+  This lens provides a simple interface for fetching presence data with:
+  - Required parameter (guild_id)
+  - Optional parameters (limit, after)
+  - Direct Discord API error propagation
+  - Clean response structure
+
+  Presence information includes:
+  - User's online status (online, idle, dnd, offline)
+  - Current activities (gaming, streaming, etc.)
+  - Client status (desktop, mobile, web)
+  - Last activity timestamp
+
+  ## Example
+      iex> ListPresences.focus(%{
+      ...>   guild_id: "123456789",
+      ...>   limit: 100
+      ...> })
+      {:ok, [
+        %{
+          user: %{
+            id: "111222333",
+            username: "user1"
+          },
+          status: "online",
+          activities: [
+            %{
+              name: "Visual Studio Code",
+              type: 0,
+              created_at: 1234567890
+            }
+          ],
+          client_status: %{
+            desktop: "online",
+            mobile: "idle"
+          }
+        }
+      ]}
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "List Guild Member Presences",
+    description: "Retrieves presence information for all members in a Discord guild",
+    url: "https://discord.com/api/v10/guilds/:guild_id/presences",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to get presences from",
+          pattern: "^[0-9]{17,20}$"
+        },
+        limit: %{
+          type: :integer,
+          description: "Maximum number of presences to return (1-1000)",
+          minimum: 1,
+          maximum: 1000,
+          default: 100
+        },
+        after: %{
+          type: :string,
+          description: "Get presences after this user ID",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id"]
+    }
+
+  @doc """
+  Transforms the Discord API response into a simplified presence list format.
+
+  ## Parameters
+    - response: Raw response from Discord API
+
+  ## Returns
+    - `{:ok, presences}` - List of member presences
+    - `{:error, reason}` - Error response from Discord API
+
+  ## Examples
+      iex> after_focus([
+      ...>   %{
+      ...>     "user" => %{
+      ...>       "id" => "111222333",
+      ...>       "username" => "user1"
+      ...>     },
+      ...>     "status" => "online",
+      ...>     "activities" => [
+      ...>       %{
+      ...>         "name" => "Visual Studio Code",
+      ...>         "type" => 0,
+      ...>         "created_at" => 1234567890
+      ...>       }
+      ...>     ],
+      ...>     "client_status" => %{
+      ...>       "desktop" => "online",
+      ...>       "mobile" => "idle"
+      ...>     }
+      ...>   }
+      ...> ])
+      {:ok, [
+        %{
+          user: %{
+            id: "111222333",
+            username: "user1"
+          },
+          status: "online",
+          activities: [
+            %{
+              name: "Visual Studio Code",
+              type: 0,
+              created_at: 1234567890
+            }
+          ],
+          client_status: %{
+            desktop: "online",
+            mobile: "idle"
+          }
+        }
+      ]}
+  """
+  @impl true
+  def after_focus(presences) when is_list(presences) do
+    {:ok, Enum.map(presences, fn presence ->
+      %{
+        user: %{
+          id: presence["user"]["id"],
+          username: presence["user"]["username"]
+        },
+        status: presence["status"],
+        activities: Enum.map(presence["activities"] || [], fn activity ->
+          %{
+            name: activity["name"],
+            type: activity["type"],
+            created_at: activity["created_at"]
+          }
+        end),
+        client_status: transform_client_status(presence["client_status"] || %{})
+      }
+    end)}
+  end
+
+  def after_focus(%{"message" => message}), do: {:error, %{"message" => message}}
+
+  defp transform_client_status(client_status) do
+    Map.new(client_status, fn {platform, status} ->
+      {String.to_existing_atom(platform), status}
+    end)
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/guilds/list_presences_test.exs
+++ b/lux/test/unit/lux/lenses/discord/guilds/list_presences_test.exs
@@ -1,0 +1,180 @@
+defmodule Lux.Lenses.Discord.Guilds.ListPresencesTest do
+  @moduledoc """
+  Test suite for the ListPresences module.
+  These tests verify the lens's ability to:
+  - List member presences from a Discord guild
+  - Handle pagination parameters
+  - Process Discord API errors appropriately
+  - Validate input/output schemas
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Guilds.ListPresences
+
+  @guild_id "123456789012345678"
+  @user_id "111222333444555666"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully lists member presences" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id/presences"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        # Verify query parameters
+        query = URI.decode_query(conn.query_string)
+        assert query["limit"] == "100"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([
+          %{
+            "user" => %{
+              "id" => @user_id,
+              "username" => "test_user"
+            },
+            "status" => "online",
+            "activities" => [
+              %{
+                "name" => "Visual Studio Code",
+                "type" => 0,
+                "created_at" => 1_234_567_890
+              }
+            ],
+            "client_status" => %{
+              "desktop" => "online",
+              "mobile" => "idle"
+            }
+          }
+        ]))
+      end)
+
+      assert {:ok, [presence]} = ListPresences.focus(%{
+        guild_id: @guild_id,
+        limit: 100
+      }, %{})
+
+      assert presence.user.id == @user_id
+      assert presence.user.username == "test_user"
+      assert presence.status == "online"
+      assert [activity] = presence.activities
+      assert activity.name == "Visual Studio Code"
+      assert activity.type == 0
+      assert activity.created_at == 1_234_567_890
+      assert presence.client_status.desktop == "online"
+      assert presence.client_status.mobile == "idle"
+    end
+
+    test "successfully lists presences with pagination" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id/presences"
+
+        # Verify pagination parameters
+        query = URI.decode_query(conn.query_string)
+        assert query["limit"] == "50"
+        assert query["after"] == @user_id
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([
+          %{
+            "user" => %{
+              "id" => "222333444555666777",
+              "username" => "next_user"
+            },
+            "status" => "idle",
+            "activities" => [],
+            "client_status" => %{
+              "web" => "idle"
+            }
+          }
+        ]))
+      end)
+
+      assert {:ok, [presence]} = ListPresences.focus(%{
+        guild_id: @guild_id,
+        limit: 50,
+        after: @user_id
+      }, %{})
+
+      assert presence.user.username == "next_user"
+      assert presence.status == "idle"
+      assert presence.activities == []
+      assert presence.client_status.web == "idle"
+    end
+
+    test "handles empty activities and client status" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id/presences"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([
+          %{
+            "user" => %{
+              "id" => @user_id,
+              "username" => "test_user"
+            },
+            "status" => "offline"
+          }
+        ]))
+      end)
+
+      assert {:ok, [presence]} = ListPresences.focus(%{
+        guild_id: @guild_id
+      }, %{})
+
+      assert presence.user.id == @user_id
+      assert presence.status == "offline"
+      assert presence.activities == []
+      assert presence.client_status == %{}
+    end
+
+    test "handles Discord API error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/:guild_id/presences"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, %{"message" => "Missing Permissions"}} = ListPresences.focus(%{
+        guild_id: @guild_id
+      }, %{})
+    end
+  end
+
+  describe "schema validation" do
+    test "validates required fields" do
+      lens = ListPresences.view()
+      assert lens.schema.required == ["guild_id"]
+    end
+
+    test "validates pagination parameters" do
+      lens = ListPresences.view()
+
+      # Verify limit parameter
+      limit = lens.schema.properties.limit
+      assert limit.type == :integer
+      assert limit.minimum == 1
+      assert limit.maximum == 1000
+      assert limit.default == 100
+
+      # Verify after parameter
+      after_param = lens.schema.properties.after
+      assert after_param.type == :string
+      assert after_param.pattern == "^[0-9]{17,20}$"
+    end
+  end
+end


### PR DESCRIPTION
✨ Discord Guild Presences Lens

Implements a new Discord lens for retrieving real-time presence information of guild members. This lens enables efficient monitoring of member statuses, activities, and platform-specific presence data across different client platforms.

Key Features:
- Real-time presence status tracking (online, idle, dnd, offline)
- Detailed activity information (gaming, streaming, etc.)
- Platform-specific status tracking (desktop, mobile, web)
- Efficient pagination support (1-1000 members per request)
- Comprehensive error handling and validation
- Clean response structure optimized for client usage

Technical Details:
- Implements Discord API v10 endpoint for guild presences
- Handles complex nested response transformation
- Validates guild IDs with regex pattern
- Supports cursor-based pagination with 'after' parameter
- Follows established Lux.Lens patterns
- Includes comprehensive test coverage with UnitAPICase

Example Usage:
```elixir
ListPresences.focus(%{
  guild_id: "123456789",
  limit: 100
})
```

Future Considerations:
- Add presence status change subscriptions via WebSocket
- Implement caching for frequently accessed presence data
- Add filtering options (by status, activity type)
- Support batch presence updates for multiple guilds