### PR TITLE
✨ Discord Add Role to Member Prism

### DIFF
--- a/lux/lib/lux/prisms/discord/guilds/add_role_to_member.ex
+++ b/lux/lib/lux/prisms/discord/guilds/add_role_to_member.ex
@@ -1,0 +1,105 @@
+defmodule Lux.Prisms.Discord.Guilds.AddRoleToMember do
+  @moduledoc """
+  A prism for assigning roles to members in a Discord guild.
+
+  This prism provides a simple interface for adding roles to guild members with:
+  - Required parameters (guild_id, user_id, role_id)
+  - Direct Discord API error propagation
+  - Simple success/failure response structure
+
+  ## Examples
+      iex> AddRoleToMember.handler(%{
+      ...>   guild_id: "123456789",
+      ...>   user_id: "987654321",
+      ...>   role_id: "111222333"
+      ...> }, %{name: "Agent"})
+      {:ok, %{
+        assigned: true,
+        role_id: "111222333",
+        user_id: "987654321",
+        guild_id: "123456789"
+      }}
+  """
+
+  use Lux.Prism,
+    name: "Add Role to Discord Member",
+    description: "Assigns a role to a member in a Discord guild",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild",
+          pattern: "^[0-9]{17,20}$"
+        },
+        user_id: %{
+          type: :string,
+          description: "The ID of the user to assign the role to",
+          pattern: "^[0-9]{17,20}$"
+        },
+        role_id: %{
+          type: :string,
+          description: "The ID of the role to assign",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: [:guild_id, :user_id, :role_id]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        assigned: %{
+          type: :boolean,
+          description: "Whether the role was successfully assigned"
+        },
+        role_id: %{
+          type: :string,
+          description: "The ID of the assigned role"
+        },
+        user_id: %{
+          type: :string,
+          description: "The ID of the user who received the role"
+        },
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild where the role was assigned"
+        }
+      },
+      required: [:assigned]
+    }
+
+  alias Lux.Integrations.Discord.Client
+  require Logger
+
+  @doc """
+  Handles the request to assign a role to a member in a Discord guild.
+
+  Returns {:ok, %{assigned: true, role_id: role_id, user_id: user_id, guild_id: guild_id}} on success.
+  Returns {:error, {status, message}} on failure.
+  """
+  def handler(params, agent) do
+    with {:ok, guild_id} <- validate_param(params, :guild_id),
+         {:ok, user_id} <- validate_param(params, :user_id),
+         {:ok, role_id} <- validate_param(params, :role_id) do
+
+      agent_name = agent[:name] || "Unknown Agent"
+      Logger.info("Agent #{agent_name} assigning role #{role_id} to user #{user_id} in guild #{guild_id}")
+
+      case Client.request(:put, "/guilds/#{guild_id}/members/#{user_id}/roles/#{role_id}") do
+        {:ok, _} ->
+          Logger.info("Successfully assigned role #{role_id} to user #{user_id} in guild #{guild_id}")
+          {:ok, %{assigned: true, role_id: role_id, user_id: user_id, guild_id: guild_id}}
+        {:error, {status, message}} ->
+          Logger.error("Failed to assign role #{role_id} to user #{user_id} in guild #{guild_id}: #{inspect({status, message})}")
+          {:error, {status, message}}
+      end
+    end
+  end
+
+  defp validate_param(params, key) do
+    case Map.get(params, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "Missing or invalid #{key}"}
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/discord/guilds/add_role_to_member_test.exs
+++ b/lux/test/unit/lux/prisms/discord/guilds/add_role_to_member_test.exs
@@ -1,0 +1,133 @@
+defmodule Lux.Prisms.Discord.Guilds.AddRoleToMemberTest do
+  @moduledoc """
+  Test suite for the AddRoleToMember module.
+  These tests verify the prism's ability to:
+  - Assign roles to members in a Discord guild
+  - Handle Discord API errors appropriately
+  - Validate input parameters
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Prisms.Discord.Guilds.AddRoleToMember
+
+  @guild_id "123456789012345678"
+  @user_id "876543210987654321"
+  @role_id "111222333444555666"
+  @agent_ctx %{agent: %{name: "TestAgent"}}
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "handler/2" do
+    test "successfully assigns role to member" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "PUT"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/members/#{@user_id}/roles/#{@role_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(204, "")
+      end)
+
+      assert {:ok, response} = AddRoleToMember.handler(
+        %{
+          guild_id: @guild_id,
+          user_id: @user_id,
+          role_id: @role_id,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+
+      assert response == %{
+        assigned: true,
+        role_id: @role_id,
+        user_id: @user_id,
+        guild_id: @guild_id
+      }
+    end
+
+    test "handles missing permissions error" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "PUT"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/members/#{@user_id}/roles/#{@role_id}"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{
+          "message" => "Missing Permissions"
+        }))
+      end)
+
+      assert {:error, {403, "Missing Permissions"}} = AddRoleToMember.handler(
+        %{
+          guild_id: @guild_id,
+          user_id: @user_id,
+          role_id: @role_id,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "handles unknown member error" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "PUT"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/members/#{@user_id}/roles/#{@role_id}"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{
+          "message" => "Unknown Member"
+        }))
+      end)
+
+      assert {:error, {404, "Unknown Member"}} = AddRoleToMember.handler(
+        %{
+          guild_id: @guild_id,
+          user_id: @user_id,
+          role_id: @role_id,
+          plug: {Req.Test, DiscordClientMock}
+        },
+        @agent_ctx
+      )
+    end
+
+    test "validates required parameters" do
+      assert {:error, "Missing or invalid guild_id"} = AddRoleToMember.handler(
+        %{user_id: @user_id, role_id: @role_id},
+        @agent_ctx
+      )
+
+      assert {:error, "Missing or invalid user_id"} = AddRoleToMember.handler(
+        %{guild_id: @guild_id, role_id: @role_id},
+        @agent_ctx
+      )
+
+      assert {:error, "Missing or invalid role_id"} = AddRoleToMember.handler(
+        %{guild_id: @guild_id, user_id: @user_id},
+        @agent_ctx
+      )
+    end
+
+    test "validates non-empty parameters" do
+      assert {:error, "Missing or invalid guild_id"} = AddRoleToMember.handler(
+        %{guild_id: "", user_id: @user_id, role_id: @role_id},
+        @agent_ctx
+      )
+
+      assert {:error, "Missing or invalid user_id"} = AddRoleToMember.handler(
+        %{guild_id: @guild_id, user_id: "", role_id: @role_id},
+        @agent_ctx
+      )
+
+      assert {:error, "Missing or invalid role_id"} = AddRoleToMember.handler(
+        %{guild_id: @guild_id, user_id: @user_id, role_id: ""},
+        @agent_ctx
+      )
+    end
+  end
+end


### PR DESCRIPTION
feat(discord): Add role assignment functionality

Implements a new prism for assigning roles to Discord guild members. This prism provides a clean interface for role management with:

- Simple parameter validation (guild_id, user_id, role_id)
- Consistent error handling aligned with other Discord prisms
- Comprehensive test coverage including success and error scenarios

Key features:
- Input validation for required Discord IDs (17-20 digit format)
- Proper error propagation from Discord API
- Detailed logging for monitoring and debugging
- Unit tests covering:
  - Successful role assignment
  - Permission error handling
  - Unknown member handling
  - Parameter validation

Example usage:
```elixir
AddRoleToMember.handler(
  %{
    guild_id: "123456789012345678",
    user_id: "876543210987654321",
    role_id: "111222333444555666"
  },
  %{name: "Agent"}
)
```

Part of the Discord integration module, following established patterns for consistency and maintainability.