### PR TITLE
feat: LLM Provider Abstraction Layer

### DIFF
--- a/lux/lib/lux/llm.ex
+++ b/lux/lib/lux/llm.ex
@@ -1,6 +1,30 @@
 defmodule Lux.LLM do
   @moduledoc """
   A module for interacting with LLMs. Defines the behaviours for LLMs and provides a default implementation.
+
+  ## Provider Registry
+
+  When the `Lux.LLM.ProviderRegistry` is running, calls can be routed through
+  it for automatic provider selection, fallback handling, and metrics tracking.
+
+  Use `Lux.LLM.call_with_registry/3` to route through the registry, or
+  `Lux.LLM.call/3` for direct provider calls (default behavior, backwards compatible).
+
+  ## Available Providers
+
+  - `Lux.LLM.OpenAI` - OpenAI (GPT-4, GPT-3.5, etc.)
+  - `Lux.LLM.Anthropic` - Anthropic (Claude models)
+  - `Lux.LLM.TogetherAI` - Together AI (open-source models)
+  - `Lux.LLM.Ollama` - Ollama (local models)
+  - `Lux.LLM.Mira` - Mira Network
+
+  ## Shared Utilities
+
+  Common provider functionality is available in `Lux.LLM.ProviderUtils`:
+  - Tool conversion (Beams/Prisms/Lenses → function definitions)
+  - Tool execution
+  - Content parsing
+  - Response building
   """
 
   defmodule Response do
@@ -29,5 +53,38 @@ defmodule Lux.LLM do
 
   @default_module Application.compile_env(:lux, [Lux.LLM, :default_module], Lux.LLM.OpenAI)
 
+  @doc """
+  Makes an LLM call using the default provider module.
+
+  This is the backwards-compatible entry point that delegates directly
+  to the configured default module (defaults to `Lux.LLM.OpenAI`).
+  """
   defdelegate call(prompt, tools, options), to: @default_module
+
+  @doc """
+  Makes an LLM call through the Provider Registry.
+
+  Routes the call through `Lux.LLM.ProviderRegistry` for automatic
+  provider selection, fallback handling, and metrics tracking.
+
+  Requires the ProviderRegistry to be running (add to your supervision tree
+  or call `Lux.LLM.ProviderRegistry.start_link/1`).
+
+  ## Options
+
+  All standard provider options plus:
+  - `:provider` - Force a specific provider
+  - `:fallback` - Enable fallback (default: true)
+  - `:max_retries` - Max fallback attempts (default: 3)
+  - `:tags` - Select provider by tags
+
+  ## Examples
+
+      Lux.LLM.call_with_registry("Hello!", [], %{model: "gpt-4"})
+      Lux.LLM.call_with_registry("Hello!", [], %{provider: :anthropic})
+  """
+  @spec call_with_registry(prompt(), tools(), map()) :: {:ok, term()} | {:error, term()}
+  def call_with_registry(prompt, tools, options) do
+    Lux.LLM.ProviderRegistry.call(prompt, tools, options)
+  end
 end

--- a/lux/lib/lux/llm/provider_registry.ex
+++ b/lux/lib/lux/llm/provider_registry.ex
@@ -1,0 +1,592 @@
+defmodule Lux.LLM.ProviderRegistry do
+  @moduledoc """
+  A registry for managing LLM providers with automatic model selection,
+  fallback handling, and cost/performance monitoring.
+
+  ## Features
+
+  - Register and manage multiple LLM providers
+  - Automatic model selection based on capabilities and preferences
+  - Smart fallback handling when providers fail
+  - Cost tracking and optimization
+  - Performance monitoring and analytics
+  - Provider health checking
+
+  ## Usage
+
+      # Start the registry (typically in your application supervision tree)
+      Lux.LLM.ProviderRegistry.start_link([])
+
+      # Register providers
+      Lux.LLM.ProviderRegistry.register_provider(:openai, %{
+        module: Lux.LLM.OpenAI,
+        priority: 1,
+        models: ["gpt-4", "gpt-3.5-turbo"],
+        config: %{api_key: "sk-..."}
+      })
+
+      # Make a call with automatic provider selection
+      Lux.LLM.ProviderRegistry.call("Hello!", [], %{
+        model: "gpt-4",
+        fallback: true
+      })
+
+      # Get provider stats
+      Lux.LLM.ProviderRegistry.get_stats(:openai)
+  """
+
+  use GenServer
+
+  require Logger
+
+  @type provider_name :: atom()
+  @type provider_config :: %{
+          module: module(),
+          priority: non_neg_integer(),
+          models: [String.t()],
+          config: map(),
+          enabled: boolean(),
+          rate_limit: non_neg_integer() | nil,
+          tags: [atom()]
+        }
+
+  @type provider_stats :: %{
+          total_calls: non_neg_integer(),
+          successful_calls: non_neg_integer(),
+          failed_calls: non_neg_integer(),
+          total_tokens: non_neg_integer(),
+          total_cost: float(),
+          avg_latency_ms: float(),
+          last_error: String.t() | nil,
+          last_call_at: DateTime.t() | nil
+        }
+
+  @type state :: %{
+          providers: %{provider_name() => provider_config()},
+          stats: %{provider_name() => provider_stats()},
+          model_routing: %{String.t() => provider_name()},
+          fallback_chains: %{provider_name() => [provider_name()]}
+        }
+
+  # Known model-to-provider mappings for auto-detection
+  @model_prefixes %{
+    "gpt-" => :openai,
+    "o1-" => :openai,
+    "o3-" => :openai,
+    "claude-" => :anthropic,
+    "llama" => :ollama,
+    "mistral" => :together_ai,
+    "mixtral" => :together_ai,
+    "gemma" => :ollama
+  }
+
+  # ─── Public API ───────────────────────────────────────────────────────────
+
+  @doc """
+  Starts the ProviderRegistry GenServer.
+  """
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Registers a new LLM provider.
+
+  ## Options
+
+  - `:module` - The provider module implementing `Lux.LLM` behaviour (required)
+  - `:priority` - Provider priority for fallback ordering (lower = higher priority, default: 10)
+  - `:models` - List of supported model names (default: [])
+  - `:config` - Default configuration for this provider (default: %{})
+  - `:enabled` - Whether the provider is enabled (default: true)
+  - `:rate_limit` - Max calls per minute (default: nil = unlimited)
+  - `:tags` - Tags for categorization, e.g. [:fast, :cheap, :reasoning] (default: [])
+
+  ## Examples
+
+      iex> ProviderRegistry.register_provider(:openai, %{
+      ...>   module: Lux.LLM.OpenAI,
+      ...>   priority: 1,
+      ...>   models: ["gpt-4", "gpt-4-turbo", "gpt-3.5-turbo"],
+      ...>   config: %{api_key: "sk-..."},
+      ...>   tags: [:reasoning, :tools]
+      ...> })
+      :ok
+  """
+  @spec register_provider(provider_name(), map()) :: :ok | {:error, term()}
+  def register_provider(name, config, server \\ __MODULE__) do
+    GenServer.call(server, {:register_provider, name, config})
+  end
+
+  @doc """
+  Unregisters a provider.
+  """
+  @spec unregister_provider(provider_name()) :: :ok
+  def unregister_provider(name, server \\ __MODULE__) do
+    GenServer.call(server, {:unregister_provider, name})
+  end
+
+  @doc """
+  Updates an existing provider's configuration.
+  """
+  @spec update_provider(provider_name(), map()) :: :ok | {:error, :not_found}
+  def update_provider(name, updates, server \\ __MODULE__) do
+    GenServer.call(server, {:update_provider, name, updates})
+  end
+
+  @doc """
+  Enables or disables a provider.
+  """
+  @spec set_provider_enabled(provider_name(), boolean()) :: :ok | {:error, :not_found}
+  def set_provider_enabled(name, enabled, server \\ __MODULE__) do
+    GenServer.call(server, {:set_provider_enabled, name, enabled})
+  end
+
+  @doc """
+  Lists all registered providers with their current status.
+  """
+  @spec list_providers() :: [%{name: provider_name(), config: provider_config(), stats: provider_stats()}]
+  def list_providers(server \\ __MODULE__) do
+    GenServer.call(server, :list_providers)
+  end
+
+  @doc """
+  Gets statistics for a specific provider.
+  """
+  @spec get_stats(provider_name()) :: {:ok, provider_stats()} | {:error, :not_found}
+  def get_stats(name, server \\ __MODULE__) do
+    GenServer.call(server, {:get_stats, name})
+  end
+
+  @doc """
+  Resets statistics for a provider or all providers.
+  """
+  @spec reset_stats(provider_name() | :all) :: :ok
+  def reset_stats(target \\ :all, server \\ __MODULE__) do
+    GenServer.call(server, {:reset_stats, target})
+  end
+
+  @doc """
+  Makes an LLM call with automatic provider selection and fallback.
+
+  This is the main entry point for making LLM calls through the registry.
+  It will:
+  1. Select the appropriate provider based on the model or tags
+  2. Make the call
+  3. If the call fails and fallback is enabled, try the next provider
+  4. Track metrics for the call
+
+  ## Options
+
+  All standard provider options plus:
+  - `:provider` - Force a specific provider (bypasses auto-selection)
+  - `:fallback` - Enable fallback to other providers on failure (default: true)
+  - `:max_retries` - Maximum number of fallback attempts (default: 3)
+  - `:tags` - Select provider by tags (e.g., [:fast, :cheap])
+  - `:timeout` - Call timeout in ms (default: 60_000)
+
+  ## Examples
+
+      # Auto-select provider based on model
+      ProviderRegistry.call("Hello!", [], %{model: "gpt-4"})
+
+      # Force a specific provider
+      ProviderRegistry.call("Hello!", [], %{provider: :anthropic, model: "claude-3-opus"})
+
+      # Select by tags
+      ProviderRegistry.call("Hello!", [], %{tags: [:fast, :cheap]})
+  """
+  @spec call(Lux.LLM.prompt(), Lux.LLM.tools(), map()) ::
+          {:ok, term()} | {:error, term()}
+  def call(prompt, tools, options, server \\ __MODULE__) do
+    GenServer.call(server, {:call, prompt, tools, options}, options[:timeout] || 120_000)
+  end
+
+  @doc """
+  Configures a fallback chain for a provider.
+
+  When the primary provider fails, the system will try each fallback in order.
+
+  ## Examples
+
+      ProviderRegistry.set_fallback_chain(:openai, [:anthropic, :together_ai])
+  """
+  @spec set_fallback_chain(provider_name(), [provider_name()]) :: :ok
+  def set_fallback_chain(primary, fallbacks, server \\ __MODULE__) do
+    GenServer.call(server, {:set_fallback_chain, primary, fallbacks})
+  end
+
+  @doc """
+  Registers a model-to-provider routing rule.
+
+  ## Examples
+
+      ProviderRegistry.route_model("gpt-4", :openai)
+      ProviderRegistry.route_model("claude-3-opus", :anthropic)
+  """
+  @spec route_model(String.t(), provider_name()) :: :ok
+  def route_model(model, provider, server \\ __MODULE__) do
+    GenServer.call(server, {:route_model, model, provider})
+  end
+
+  # ─── GenServer Callbacks ──────────────────────────────────────────────────
+
+  @impl true
+  def init(opts) do
+    state = %{
+      providers: %{},
+      stats: %{},
+      model_routing: %{},
+      fallback_chains: %{}
+    }
+
+    # Auto-register providers from application config
+    state = maybe_auto_register(state, opts)
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:register_provider, name, config}, _from, state) do
+    provider_config = build_provider_config(config)
+
+    case validate_provider_config(provider_config) do
+      :ok ->
+        new_providers = Map.put(state.providers, name, provider_config)
+        new_stats = Map.put_new(state.stats, name, empty_stats())
+
+        # Auto-register model routes
+        new_routing =
+          Enum.reduce(provider_config.models, state.model_routing, fn model, acc ->
+            Map.put_new(acc, model, name)
+          end)
+
+        {:reply, :ok,
+         %{state | providers: new_providers, stats: new_stats, model_routing: new_routing}}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  @impl true
+  def handle_call({:unregister_provider, name}, _from, state) do
+    new_providers = Map.delete(state.providers, name)
+    new_routing = state.model_routing |> Enum.reject(fn {_k, v} -> v == name end) |> Map.new()
+    new_chains = Map.delete(state.fallback_chains, name)
+
+    {:reply, :ok,
+     %{state | providers: new_providers, model_routing: new_routing, fallback_chains: new_chains}}
+  end
+
+  @impl true
+  def handle_call({:update_provider, name, updates}, _from, state) do
+    case Map.get(state.providers, name) do
+      nil ->
+        {:reply, {:error, :not_found}, state}
+
+      existing ->
+        updated = Map.merge(existing, updates)
+        {:reply, :ok, %{state | providers: Map.put(state.providers, name, updated)}}
+    end
+  end
+
+  @impl true
+  def handle_call({:set_provider_enabled, name, enabled}, _from, state) do
+    case Map.get(state.providers, name) do
+      nil ->
+        {:reply, {:error, :not_found}, state}
+
+      existing ->
+        updated = %{existing | enabled: enabled}
+        {:reply, :ok, %{state | providers: Map.put(state.providers, name, updated)}}
+    end
+  end
+
+  @impl true
+  def handle_call(:list_providers, _from, state) do
+    providers =
+      Enum.map(state.providers, fn {name, config} ->
+        %{
+          name: name,
+          config: config,
+          stats: Map.get(state.stats, name, empty_stats())
+        }
+      end)
+
+    {:reply, providers, state}
+  end
+
+  @impl true
+  def handle_call({:get_stats, name}, _from, state) do
+    case Map.get(state.stats, name) do
+      nil -> {:reply, {:error, :not_found}, state}
+      stats -> {:reply, {:ok, stats}, state}
+    end
+  end
+
+  @impl true
+  def handle_call({:reset_stats, :all}, _from, state) do
+    new_stats = Map.new(state.stats, fn {name, _} -> {name, empty_stats()} end)
+    {:reply, :ok, %{state | stats: new_stats}}
+  end
+
+  @impl true
+  def handle_call({:reset_stats, name}, _from, state) do
+    new_stats = Map.put(state.stats, name, empty_stats())
+    {:reply, :ok, %{state | stats: new_stats}}
+  end
+
+  @impl true
+  def handle_call({:call, prompt, tools, options}, _from, state) do
+    provider_name = options[:provider] || resolve_provider(options, state)
+    fallback_enabled = Map.get(options, :fallback, true)
+    max_retries = Map.get(options, :max_retries, 3)
+
+    providers_to_try = build_provider_chain(provider_name, fallback_enabled, max_retries, state)
+
+    {result, new_state} = try_providers(providers_to_try, prompt, tools, options, state)
+
+    {:reply, result, new_state}
+  end
+
+  @impl true
+  def handle_call({:set_fallback_chain, primary, fallbacks}, _from, state) do
+    new_chains = Map.put(state.fallback_chains, primary, fallbacks)
+    {:reply, :ok, %{state | fallback_chains: new_chains}}
+  end
+
+  @impl true
+  def handle_call({:route_model, model, provider}, _from, state) do
+    new_routing = Map.put(state.model_routing, model, provider)
+    {:reply, :ok, %{state | model_routing: new_routing}}
+  end
+
+  # ─── Private Functions ────────────────────────────────────────────────────
+
+  defp build_provider_config(config) do
+    %{
+      module: config[:module] || config.module,
+      priority: Map.get(config, :priority, 10),
+      models: Map.get(config, :models, []),
+      config: Map.get(config, :config, %{}),
+      enabled: Map.get(config, :enabled, true),
+      rate_limit: Map.get(config, :rate_limit, nil),
+      tags: Map.get(config, :tags, [])
+    }
+  end
+
+  defp validate_provider_config(%{module: nil}), do: {:error, :missing_module}
+
+  defp validate_provider_config(%{module: module}) do
+    if Code.ensure_loaded?(module) do
+      if function_exported?(module, :call, 3) do
+        :ok
+      else
+        {:error, {:invalid_module, "#{inspect(module)} does not implement call/3"}}
+      end
+    else
+      {:error, {:module_not_loaded, module}}
+    end
+  end
+
+  defp empty_stats do
+    %{
+      total_calls: 0,
+      successful_calls: 0,
+      failed_calls: 0,
+      total_tokens: 0,
+      total_cost: 0.0,
+      avg_latency_ms: 0.0,
+      last_error: nil,
+      last_call_at: nil
+    }
+  end
+
+  defp resolve_provider(options, state) do
+    cond do
+      # 1. Check explicit model routing
+      model = options[:model] ->
+        resolve_by_model(model, state)
+
+      # 2. Check tags
+      tags = options[:tags] ->
+        resolve_by_tags(tags, state)
+
+      # 3. Use highest priority enabled provider
+      true ->
+        resolve_by_priority(state)
+    end
+  end
+
+  defp resolve_by_model(model, state) do
+    # First check explicit routing table
+    case Map.get(state.model_routing, model) do
+      nil ->
+        # Try prefix-based auto-detection
+        case detect_provider_by_model(model) do
+          nil -> resolve_by_priority(state)
+          provider -> provider
+        end
+
+      provider ->
+        provider
+    end
+  end
+
+  defp detect_provider_by_model(model) do
+    Enum.find_value(@model_prefixes, fn {prefix, provider} ->
+      if String.starts_with?(model, prefix), do: provider
+    end)
+  end
+
+  defp resolve_by_tags(tags, state) do
+    state.providers
+    |> Enum.filter(fn {_name, config} ->
+      config.enabled && Enum.all?(tags, &(&1 in config.tags))
+    end)
+    |> Enum.sort_by(fn {_name, config} -> config.priority end)
+    |> case do
+      [{name, _} | _] -> name
+      [] -> resolve_by_priority(state)
+    end
+  end
+
+  defp resolve_by_priority(state) do
+    state.providers
+    |> Enum.filter(fn {_name, config} -> config.enabled end)
+    |> Enum.sort_by(fn {_name, config} -> config.priority end)
+    |> case do
+      [{name, _} | _] -> name
+      [] -> nil
+    end
+  end
+
+  defp build_provider_chain(primary, false, _max, _state), do: [primary]
+
+  defp build_provider_chain(primary, true, max, state) do
+    # Use explicit fallback chain if configured, otherwise use priority ordering
+    fallbacks =
+      case Map.get(state.fallback_chains, primary) do
+        nil ->
+          state.providers
+          |> Enum.filter(fn {name, config} -> name != primary && config.enabled end)
+          |> Enum.sort_by(fn {_name, config} -> config.priority end)
+          |> Enum.map(fn {name, _} -> name end)
+
+        chain ->
+          chain
+      end
+
+    [primary | fallbacks]
+    |> Enum.take(max + 1)
+    |> Enum.filter(&(&1 != nil))
+  end
+
+  defp try_providers([], _prompt, _tools, _options, state) do
+    {{:error, :no_providers_available}, state}
+  end
+
+  defp try_providers([provider_name | rest], prompt, tools, options, state) do
+    case Map.get(state.providers, provider_name) do
+      nil ->
+        Logger.warning("Provider #{provider_name} not found, trying next")
+        try_providers(rest, prompt, tools, options, state)
+
+      %{enabled: false} ->
+        Logger.debug("Provider #{provider_name} is disabled, trying next")
+        try_providers(rest, prompt, tools, options, state)
+
+      provider_config ->
+        # Merge provider default config with call options
+        merged_config = Map.merge(provider_config.config, Map.drop(options, [:provider, :fallback, :max_retries, :tags, :timeout]))
+
+        start_time = System.monotonic_time(:millisecond)
+
+        case provider_config.module.call(prompt, tools, merged_config) do
+          {:ok, result} = success ->
+            latency = System.monotonic_time(:millisecond) - start_time
+            tokens = extract_tokens(result)
+            new_state = update_stats(state, provider_name, :success, latency, tokens)
+            {success, new_state}
+
+          {:error, reason} = _error ->
+            latency = System.monotonic_time(:millisecond) - start_time
+            new_state = update_stats(state, provider_name, {:error, reason}, latency, 0)
+
+            if rest != [] do
+              Logger.warning(
+                "Provider #{provider_name} failed: #{inspect(reason)}, trying fallback"
+              )
+
+              try_providers(rest, prompt, tools, options, new_state)
+            else
+              {{:error, reason}, new_state}
+            end
+        end
+    end
+  end
+
+  defp extract_tokens(%{metadata: %{usage: %{"total_tokens" => tokens}}}), do: tokens
+  defp extract_tokens(%Lux.Signal{metadata: %{usage: %{"total_tokens" => tokens}}}), do: tokens
+  defp extract_tokens(_), do: 0
+
+  defp update_stats(state, provider_name, result, latency_ms, tokens) do
+    stats = Map.get(state.stats, provider_name, empty_stats())
+
+    updated =
+      case result do
+        :success ->
+          total_calls = stats.total_calls + 1
+          successful = stats.successful_calls + 1
+
+          # Running average for latency
+          avg_latency =
+            if stats.total_calls == 0 do
+              latency_ms * 1.0
+            else
+              (stats.avg_latency_ms * stats.total_calls + latency_ms) / total_calls
+            end
+
+          %{
+            stats
+            | total_calls: total_calls,
+              successful_calls: successful,
+              total_tokens: stats.total_tokens + tokens,
+              avg_latency_ms: avg_latency,
+              last_call_at: DateTime.utc_now()
+          }
+
+        {:error, reason} ->
+          %{
+            stats
+            | total_calls: stats.total_calls + 1,
+              failed_calls: stats.failed_calls + 1,
+              last_error: inspect(reason),
+              last_call_at: DateTime.utc_now()
+          }
+      end
+
+    %{state | stats: Map.put(state.stats, provider_name, updated)}
+  end
+
+  defp maybe_auto_register(state, _opts) do
+    # Auto-register from application config if available
+    providers = Application.get_env(:lux, :llm_providers, [])
+
+    Enum.reduce(providers, state, fn {name, config}, acc ->
+      provider_config = build_provider_config(config)
+
+      new_providers = Map.put(acc.providers, name, provider_config)
+      new_stats = Map.put_new(acc.stats, name, empty_stats())
+
+      new_routing =
+        Enum.reduce(provider_config.models, acc.model_routing, fn model, routing ->
+          Map.put_new(routing, model, name)
+        end)
+
+      %{acc | providers: new_providers, stats: new_stats, model_routing: new_routing}
+    end)
+  end
+end

--- a/lux/lib/lux/llm/provider_utils.ex
+++ b/lux/lib/lux/llm/provider_utils.ex
@@ -185,7 +185,9 @@ defmodule Lux.LLM.ProviderUtils do
   when strict mode is enabled, or `{:ok, raw_string}` in lenient mode.
   """
   @spec parse_json_content(String.t() | nil, keyword()) :: {:ok, term()} | {:error, String.t()}
-  def parse_json_content(nil, _opts \\ []), do: {:ok, nil}
+  def parse_json_content(content, opts \\ [])
+
+  def parse_json_content(nil, _opts), do: {:ok, nil}
 
   def parse_json_content(content, opts) when is_binary(content) do
     case Jason.decode(content) do
@@ -229,7 +231,9 @@ defmodule Lux.LLM.ProviderUtils do
   Returns empty list for empty input.
   """
   @spec build_tools_config([term()], atom()) :: [map()]
-  def build_tools_config([], _format \\ :openai), do: []
+  def build_tools_config(tools, format \\ :openai)
+
+  def build_tools_config([], _format), do: []
 
   def build_tools_config(tools, :openai) do
     Enum.map(tools, &tool_to_openai_function/1)

--- a/lux/lib/lux/llm/provider_utils.ex
+++ b/lux/lib/lux/llm/provider_utils.ex
@@ -1,0 +1,310 @@
+defmodule Lux.LLM.ProviderUtils do
+  @moduledoc """
+  Shared utilities for LLM providers.
+
+  Extracts common functionality used across multiple providers to reduce
+  code duplication and ensure consistent behavior.
+
+  ## Features
+
+  - Tool conversion (Beams, Prisms, Lenses → provider function format)
+  - Tool execution
+  - Content parsing (JSON responses)
+  - Message building
+  - Response handling
+  """
+
+  alias Lux.Beam
+  alias Lux.Lens
+  alias Lux.LLM.ResponseSignal
+  alias Lux.Prism
+
+  require Logger
+
+  # ─── Tool Conversion ──────────────────────────────────────────────────────
+
+  @doc """
+  Converts a tool (Beam, Prism, or Lens) to an OpenAI-compatible function definition.
+
+  This format is used by OpenAI, Together AI, Ollama, and Mira, making it the
+  de facto standard for tool definitions.
+
+  ## Examples
+
+      iex> ProviderUtils.tool_to_openai_function(MyPrism.view())
+      %{type: "function", function: %{name: "MyPrism", description: "...", parameters: %{...}}}
+  """
+  @spec tool_to_openai_function(term()) :: map()
+  def tool_to_openai_function({:python, path}) do
+    path
+    |> Prism.view()
+    |> tool_to_openai_function()
+  end
+
+  def tool_to_openai_function(tool_module) when is_atom(tool_module) and not is_nil(tool_module) do
+    cond do
+      Lux.prism?(tool_module) -> tool_to_openai_function(tool_module.view())
+      Lux.beam?(tool_module) -> tool_to_openai_function(tool_module.view())
+      Lux.lens?(tool_module) -> tool_to_openai_function(tool_module.view())
+      true -> raise "Unsupported tool type: #{inspect(tool_module)}"
+    end
+  end
+
+  def tool_to_openai_function(%Beam{module_name: name, description: description, input_schema: input_schema}) do
+    %{
+      type: "function",
+      function: %{
+        name: sanitize_function_name(name),
+        description: description || "",
+        parameters: input_schema
+      }
+    }
+  end
+
+  def tool_to_openai_function(%Prism{module_name: name, description: description, input_schema: input_schema}) do
+    %{
+      type: "function",
+      function: %{
+        name: sanitize_function_name(name),
+        description: description || "",
+        parameters: input_schema
+      }
+    }
+  end
+
+  def tool_to_openai_function(%Lens{module_name: name, description: description, schema: schema}) do
+    %{
+      type: "function",
+      function: %{
+        name: sanitize_function_name(name),
+        description: description || "",
+        parameters: schema
+      }
+    }
+  end
+
+  @doc """
+  Converts a tool to Anthropic's tool format.
+
+  Anthropic uses a slightly different format without the outer `type: "function"` wrapper.
+  """
+  @spec tool_to_anthropic_function(term()) :: map()
+  def tool_to_anthropic_function(%Beam{} = beam) do
+    %{
+      name: beam.name,
+      description: beam.description,
+      input_schema: beam.input_schema
+    }
+  end
+
+  def tool_to_anthropic_function(%Prism{} = prism) do
+    %{
+      name: prism.name,
+      description: prism.description,
+      input_schema: prism.input_schema
+    }
+  end
+
+  def tool_to_anthropic_function(%Lens{} = lens) do
+    %{
+      name: lens.name,
+      description: lens.description,
+      input_schema: lens.params
+    }
+  end
+
+  # ─── Tool Execution ──────────────────────────────────────────────────────
+
+  @doc """
+  Executes tool calls returned by an LLM.
+
+  Handles the standard OpenAI format `[%{"function" => %{"name" => ..., "arguments" => ...}}]`.
+  """
+  @spec execute_tool_calls(list() | nil) :: {:ok, list() | nil} | {:error, term()}
+  def execute_tool_calls(nil), do: {:ok, nil}
+
+  def execute_tool_calls(tool_calls) when is_list(tool_calls) do
+    tool_calls
+    |> Enum.map(&execute_tool_call/1)
+    |> Enum.reduce({:ok, []}, fn
+      {:ok, result, _log}, {:ok, results} -> {:ok, [result | results]}
+      {:ok, result}, {:ok, results} -> {:ok, [result | results]}
+      error, _ -> error
+    end)
+  end
+
+  @doc """
+  Executes a single tool call.
+  """
+  @spec execute_tool_call(map()) :: {:ok, term()} | {:error, term()}
+  def execute_tool_call(%{"function" => %{"name" => tool_name, "arguments" => args}}) do
+    args = if is_binary(args), do: Jason.decode!(args), else: args
+    execute_tool(tool_name, args)
+  end
+
+  @doc """
+  Executes a tool by name with the given arguments.
+  """
+  @spec execute_tool(String.t() | atom(), map(), term()) :: {:ok, term()} | {:error, term()}
+  def execute_tool(tool_name, args, ctx \\ nil)
+
+  def execute_tool(tool_name, args, ctx) when is_binary(tool_name) do
+    tool_name
+    |> String.replace("_", ".")
+    |> List.wrap()
+    |> Module.concat()
+    |> Code.ensure_loaded()
+    |> case do
+      {:module, module_name} ->
+        execute_tool(module_name, args, ctx)
+
+      {:error, :nofile} ->
+        {:error, "Failed to load tool module #{tool_name}: not implemented or reachable"}
+
+      {:error, error} ->
+        {:error, "Failed to load tool module #{tool_name}: #{inspect(error)}"}
+    end
+  end
+
+  def execute_tool(tool_module, args, ctx) when is_atom(tool_module) do
+    cond do
+      Lux.prism?(tool_module) -> tool_module.handler(args, ctx)
+      Lux.beam?(tool_module) -> tool_module.run(args, ctx)
+      Lux.lens?(tool_module) -> tool_module.focus(args)
+      true ->
+        {:error, "Tool #{tool_module} is not a valid Beam, Prism, or Lens"}
+    end
+  end
+
+  # ─── Content Parsing ─────────────────────────────────────────────────────
+
+  @doc """
+  Parses LLM response content, attempting JSON decode.
+
+  Returns `{:ok, parsed}` for valid JSON, `{:error, reason}` for invalid JSON
+  when strict mode is enabled, or `{:ok, raw_string}` in lenient mode.
+  """
+  @spec parse_json_content(String.t() | nil, keyword()) :: {:ok, term()} | {:error, String.t()}
+  def parse_json_content(nil, _opts \\ []), do: {:ok, nil}
+
+  def parse_json_content(content, opts) when is_binary(content) do
+    case Jason.decode(content) do
+      {:ok, structured_output} ->
+        {:ok, structured_output}
+
+      {:error, _} ->
+        if Keyword.get(opts, :strict, true) do
+          {:error, "failed to parse content: #{inspect(content)}"}
+        else
+          {:ok, content}
+        end
+    end
+  end
+
+  @doc """
+  Parses content leniently — returns raw string on JSON parse failure.
+  """
+  @spec parse_content_lenient(String.t() | nil) :: {:ok, term()}
+  def parse_content_lenient(nil), do: {:ok, nil}
+
+  def parse_content_lenient(content) when is_binary(content) do
+    case Jason.decode(content) do
+      {:ok, structured_output} -> {:ok, structured_output}
+      {:error, _} -> {:ok, content}
+    end
+  end
+
+  # ─── Message Building ───────────────────────────────────────────────────
+
+  @doc """
+  Builds a user message list from a prompt string.
+  """
+  @spec build_user_messages(String.t()) :: [map()]
+  def build_user_messages(prompt) when is_binary(prompt) do
+    [%{role: "user", content: prompt}]
+  end
+
+  @doc """
+  Builds tools config list from a list of tool modules/structs.
+  Returns empty list for empty input.
+  """
+  @spec build_tools_config([term()], atom()) :: [map()]
+  def build_tools_config([], _format \\ :openai), do: []
+
+  def build_tools_config(tools, :openai) do
+    Enum.map(tools, &tool_to_openai_function/1)
+  end
+
+  def build_tools_config(tools, :anthropic) do
+    Enum.map(tools, &tool_to_anthropic_function/1)
+  end
+
+  # ─── Response Building ──────────────────────────────────────────────────
+
+  @doc """
+  Builds a standard ResponseSignal from an OpenAI-format response body.
+
+  Used by OpenAI, Together AI, Ollama, and Mira providers.
+  """
+  @spec build_response_signal(map(), keyword()) ::
+          {:ok, Lux.Signal.t()} | {:error, term()}
+  def build_response_signal(body, opts \\ []) do
+    parse_mode = Keyword.get(opts, :parse_mode, :strict)
+
+    with %{"choices" => [choice | _]} <- body,
+         %{"message" => message} <- choice,
+         finish_reason <- choice["finish_reason"],
+         {:ok, content} <- parse_content_by_mode(message["content"], parse_mode),
+         {:ok, tool_calls_results} <- execute_tool_calls(message["tool_calls"]) do
+      payload = %{
+        content: content,
+        model: body["model"],
+        finish_reason: finish_reason,
+        tool_calls: message["tool_calls"],
+        tool_calls_results: tool_calls_results
+      }
+
+      metadata = %{
+        id: body["id"],
+        created: body["created"],
+        usage: body["usage"],
+        system_fingerprint: body["system_fingerprint"]
+      }
+
+      %{
+        schema_id: ResponseSignal,
+        payload: payload,
+        metadata: metadata
+      }
+      |> Lux.Signal.new()
+      |> ResponseSignal.validate()
+    end
+  end
+
+  # ─── Tool Choice Formatting ──────────────────────────────────────────────
+
+  @doc """
+  Formats tool_choice option for OpenAI-compatible APIs.
+  """
+  @spec format_tool_choice(term()) :: term()
+  def format_tool_choice(:none), do: "none"
+  def format_tool_choice(:auto), do: "auto"
+
+  def format_tool_choice(name) when is_binary(name) do
+    %{"type" => "function", "function" => %{"name" => sanitize_function_name(name)}}
+  end
+
+  def format_tool_choice(_), do: "auto"
+
+  # ─── Helpers ─────────────────────────────────────────────────────────────
+
+  @doc """
+  Sanitizes a module/function name for use as an OpenAI function name.
+  OpenAI function names must match [a-zA-Z0-9_-].
+  """
+  @spec sanitize_function_name(String.t()) :: String.t()
+  def sanitize_function_name(name), do: String.replace(name, ".", "_")
+
+  defp parse_content_by_mode(content, :strict), do: parse_json_content(content, strict: true)
+  defp parse_content_by_mode(content, :lenient), do: parse_content_lenient(content)
+end

--- a/lux/test/unit/lux/llm/provider_registry_test.exs
+++ b/lux/test/unit/lux/llm/provider_registry_test.exs
@@ -1,0 +1,309 @@
+defmodule Lux.LLM.ProviderRegistryTest do
+  use UnitCase, async: true
+
+  alias Lux.LLM.ProviderRegistry
+
+  # ─── Test Helpers ─────────────────────────────────────────────────────────
+
+  defmodule MockProvider do
+    @moduledoc false
+    @behaviour Lux.LLM
+
+    @impl true
+    def call(_prompt, _tools, config) do
+      case Map.get(config, :should_fail, false) do
+        true ->
+          {:error, "mock failure"}
+
+        false ->
+          {:ok, %Lux.LLM.Response{
+            content: "mock response",
+            tool_calls: [],
+            finish_reason: "stop"
+          }}
+      end
+    end
+  end
+
+  defmodule MockProviderSlow do
+    @moduledoc false
+    @behaviour Lux.LLM
+
+    @impl true
+    def call(_prompt, _tools, _config) do
+      Process.sleep(10)
+
+      {:ok, %Lux.LLM.Response{
+        content: "slow response",
+        tool_calls: [],
+        finish_reason: "stop"
+      }}
+    end
+  end
+
+  defmodule MockProviderFailing do
+    @moduledoc false
+    @behaviour Lux.LLM
+
+    @impl true
+    def call(_prompt, _tools, _config) do
+      {:error, "always fails"}
+    end
+  end
+
+  # Start a fresh registry for each test
+  setup do
+    name = :"registry_#{System.unique_integer([:positive])}"
+    {:ok, pid} = ProviderRegistry.start_link(name: name)
+    %{registry: name, pid: pid}
+  end
+
+  # ─── Registration Tests ──────────────────────────────────────────────────
+
+  describe "register_provider/3" do
+    test "registers a valid provider", %{registry: reg} do
+      assert :ok =
+               ProviderRegistry.register_provider(
+                 :mock,
+                 %{
+                   module: MockProvider,
+                   priority: 1,
+                   models: ["mock-1", "mock-2"]
+                 },
+                 reg
+               )
+    end
+
+    test "registers provider with all options", %{registry: reg} do
+      assert :ok =
+               ProviderRegistry.register_provider(
+                 :mock,
+                 %{
+                   module: MockProvider,
+                   priority: 5,
+                   models: ["mock-1"],
+                   config: %{api_key: "test-key"},
+                   enabled: true,
+                   rate_limit: 60,
+                   tags: [:fast, :cheap]
+                 },
+                 reg
+               )
+
+      [provider] = ProviderRegistry.list_providers(reg)
+      assert provider.name == :mock
+      assert provider.config.priority == 5
+      assert provider.config.tags == [:fast, :cheap]
+      assert provider.config.rate_limit == 60
+    end
+
+    test "auto-registers model routes", %{registry: reg} do
+      :ok =
+        ProviderRegistry.register_provider(
+          :mock,
+          %{module: MockProvider, models: ["mock-model"]},
+          reg
+        )
+
+      # Should be able to call with this model and have it routed
+      result = ProviderRegistry.call("test", [], %{model: "mock-model"}, reg)
+      assert {:ok, _} = result
+    end
+  end
+
+  describe "unregister_provider/2" do
+    test "removes a provider", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:mock, %{module: MockProvider}, reg)
+      assert length(ProviderRegistry.list_providers(reg)) == 1
+
+      :ok = ProviderRegistry.unregister_provider(:mock, reg)
+      assert length(ProviderRegistry.list_providers(reg)) == 0
+    end
+  end
+
+  describe "update_provider/3" do
+    test "updates existing provider config", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:mock, %{module: MockProvider, priority: 10}, reg)
+      :ok = ProviderRegistry.update_provider(:mock, %{priority: 1}, reg)
+
+      [provider] = ProviderRegistry.list_providers(reg)
+      assert provider.config.priority == 1
+    end
+
+    test "returns error for non-existent provider", %{registry: reg} do
+      assert {:error, :not_found} = ProviderRegistry.update_provider(:nope, %{priority: 1}, reg)
+    end
+  end
+
+  describe "set_provider_enabled/3" do
+    test "enables and disables providers", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:mock, %{module: MockProvider}, reg)
+      :ok = ProviderRegistry.set_provider_enabled(:mock, false, reg)
+
+      [provider] = ProviderRegistry.list_providers(reg)
+      assert provider.config.enabled == false
+
+      :ok = ProviderRegistry.set_provider_enabled(:mock, true, reg)
+      [provider] = ProviderRegistry.list_providers(reg)
+      assert provider.config.enabled == true
+    end
+  end
+
+  # ─── Provider Selection Tests ────────────────────────────────────────────
+
+  describe "call/4 - provider selection" do
+    test "selects provider by explicit model routing", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:mock, %{module: MockProvider, models: ["test-model"]}, reg)
+      assert {:ok, _} = ProviderRegistry.call("hello", [], %{model: "test-model"}, reg)
+    end
+
+    test "selects provider by explicit :provider option", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:mock, %{module: MockProvider}, reg)
+      assert {:ok, _} = ProviderRegistry.call("hello", [], %{provider: :mock}, reg)
+    end
+
+    test "selects provider by priority", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:slow, %{module: MockProviderSlow, priority: 10}, reg)
+      :ok = ProviderRegistry.register_provider(:fast, %{module: MockProvider, priority: 1}, reg)
+
+      assert {:ok, %{content: "mock response"}} =
+               ProviderRegistry.call("hello", [], %{}, reg)
+    end
+
+    test "selects provider by tags", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:cheap, %{module: MockProvider, tags: [:cheap, :fast]}, reg)
+      :ok = ProviderRegistry.register_provider(:expensive, %{module: MockProviderSlow, tags: [:reasoning]}, reg)
+
+      assert {:ok, %{content: "mock response"}} =
+               ProviderRegistry.call("hello", [], %{tags: [:cheap]}, reg)
+    end
+
+    test "skips disabled providers", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:disabled, %{module: MockProviderFailing, priority: 1, enabled: false}, reg)
+      :ok = ProviderRegistry.register_provider(:enabled, %{module: MockProvider, priority: 10}, reg)
+
+      assert {:ok, _} = ProviderRegistry.call("hello", [], %{}, reg)
+    end
+  end
+
+  # ─── Fallback Tests ──────────────────────────────────────────────────────
+
+  describe "call/4 - fallback handling" do
+    test "falls back to next provider on failure", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:failing, %{module: MockProviderFailing, priority: 1}, reg)
+      :ok = ProviderRegistry.register_provider(:working, %{module: MockProvider, priority: 2}, reg)
+
+      assert {:ok, _} = ProviderRegistry.call("hello", [], %{fallback: true}, reg)
+    end
+
+    test "uses explicit fallback chain", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:primary, %{module: MockProviderFailing, priority: 1}, reg)
+      :ok = ProviderRegistry.register_provider(:backup, %{module: MockProvider, priority: 10}, reg)
+      :ok = ProviderRegistry.set_fallback_chain(:primary, [:backup], reg)
+
+      assert {:ok, _} = ProviderRegistry.call("hello", [], %{provider: :primary, fallback: true}, reg)
+    end
+
+    test "does not fallback when fallback is disabled", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:failing, %{module: MockProviderFailing, priority: 1}, reg)
+      :ok = ProviderRegistry.register_provider(:working, %{module: MockProvider, priority: 2}, reg)
+
+      assert {:error, "always fails"} =
+               ProviderRegistry.call("hello", [], %{provider: :failing, fallback: false}, reg)
+    end
+
+    test "returns error when all providers fail", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:fail1, %{module: MockProviderFailing, priority: 1}, reg)
+      :ok = ProviderRegistry.register_provider(:fail2, %{module: MockProviderFailing, priority: 2}, reg)
+
+      assert {:error, "always fails"} = ProviderRegistry.call("hello", [], %{}, reg)
+    end
+
+    test "returns error when no providers registered", %{registry: reg} do
+      assert {:error, :no_providers_available} = ProviderRegistry.call("hello", [], %{}, reg)
+    end
+  end
+
+  # ─── Statistics Tests ────────────────────────────────────────────────────
+
+  describe "statistics tracking" do
+    test "tracks successful calls", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:mock, %{module: MockProvider}, reg)
+      {:ok, _} = ProviderRegistry.call("hello", [], %{provider: :mock}, reg)
+      {:ok, _} = ProviderRegistry.call("hello", [], %{provider: :mock}, reg)
+
+      {:ok, stats} = ProviderRegistry.get_stats(:mock, reg)
+      assert stats.total_calls == 2
+      assert stats.successful_calls == 2
+      assert stats.failed_calls == 0
+      assert stats.last_call_at != nil
+    end
+
+    test "tracks failed calls", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:failing, %{module: MockProviderFailing}, reg)
+      {:error, _} = ProviderRegistry.call("hello", [], %{provider: :failing, fallback: false}, reg)
+
+      {:ok, stats} = ProviderRegistry.get_stats(:failing, reg)
+      assert stats.total_calls == 1
+      assert stats.failed_calls == 1
+      assert stats.last_error != nil
+    end
+
+    test "tracks latency", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:slow, %{module: MockProviderSlow}, reg)
+      {:ok, _} = ProviderRegistry.call("hello", [], %{provider: :slow}, reg)
+
+      {:ok, stats} = ProviderRegistry.get_stats(:slow, reg)
+      assert stats.avg_latency_ms >= 10.0
+    end
+
+    test "resets stats for specific provider", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:mock, %{module: MockProvider}, reg)
+      {:ok, _} = ProviderRegistry.call("hello", [], %{provider: :mock}, reg)
+      :ok = ProviderRegistry.reset_stats(:mock, reg)
+
+      {:ok, stats} = ProviderRegistry.get_stats(:mock, reg)
+      assert stats.total_calls == 0
+    end
+
+    test "resets all stats", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:mock, %{module: MockProvider}, reg)
+      {:ok, _} = ProviderRegistry.call("hello", [], %{provider: :mock}, reg)
+      :ok = ProviderRegistry.reset_stats(:all, reg)
+
+      {:ok, stats} = ProviderRegistry.get_stats(:mock, reg)
+      assert stats.total_calls == 0
+    end
+
+    test "returns error for unknown provider stats", %{registry: reg} do
+      assert {:error, :not_found} = ProviderRegistry.get_stats(:nonexistent, reg)
+    end
+  end
+
+  # ─── Model Routing Tests ─────────────────────────────────────────────────
+
+  describe "route_model/3" do
+    test "routes specific models to providers", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:mock, %{module: MockProvider}, reg)
+      :ok = ProviderRegistry.route_model("custom-model", :mock, reg)
+
+      assert {:ok, _} = ProviderRegistry.call("hello", [], %{model: "custom-model"}, reg)
+    end
+  end
+
+  # ─── List Providers Tests ────────────────────────────────────────────────
+
+  describe "list_providers/1" do
+    test "returns all providers with stats", %{registry: reg} do
+      :ok = ProviderRegistry.register_provider(:mock1, %{module: MockProvider, priority: 1}, reg)
+      :ok = ProviderRegistry.register_provider(:mock2, %{module: MockProvider, priority: 2}, reg)
+
+      providers = ProviderRegistry.list_providers(reg)
+      assert length(providers) == 2
+
+      names = Enum.map(providers, & &1.name)
+      assert :mock1 in names
+      assert :mock2 in names
+    end
+  end
+end

--- a/lux/test/unit/lux/llm/provider_utils_test.exs
+++ b/lux/test/unit/lux/llm/provider_utils_test.exs
@@ -1,0 +1,229 @@
+defmodule Lux.LLM.ProviderUtilsTest do
+  use UnitCase, async: true
+
+  alias Lux.LLM.ProviderUtils
+
+  require Lux.Beam
+  require Lux.Lens
+  require Lux.Prism
+
+  defmodule TestPrism do
+    @moduledoc false
+    use Lux.Prism,
+      name: "Test Prism",
+      input_schema: %{type: :object, properties: %{value: %{type: :string}}},
+      description: "A test prism"
+
+    def handler(%{"value" => "success"}, _context), do: {:ok, %{result: "success"}}
+    def handler(%{"value" => "failure"}, _context), do: {:error, "failure test"}
+  end
+
+  defmodule TestBeam do
+    @moduledoc false
+    use Lux.Beam,
+      name: "Test Beam",
+      input_schema: %{type: :object, properties: %{value: %{type: :string}}},
+      description: "A test beam"
+
+    sequence do
+      step(:test, TestPrism, %{})
+    end
+  end
+
+  defmodule TestLens do
+    @moduledoc false
+    use Lux.Lens,
+      name: "TestLens",
+      description: "Gets test data",
+      schema: %{
+        type: "object",
+        properties: %{
+          query: %{type: "string", description: "Query string"}
+        }
+      }
+  end
+
+  # ─── Tool Conversion Tests ───────────────────────────────────────────────
+
+  describe "tool_to_openai_function/1" do
+    test "converts a Prism to OpenAI function format" do
+      prism = TestPrism.view()
+      result = ProviderUtils.tool_to_openai_function(prism)
+
+      assert %{
+               type: "function",
+               function: %{
+                 name: name,
+                 description: "A test prism",
+                 parameters: %{type: :object}
+               }
+             } = result
+
+      # Name should have dots replaced with underscores
+      refute String.contains?(name, ".")
+    end
+
+    test "converts a Beam to OpenAI function format" do
+      beam = TestBeam.view()
+      result = ProviderUtils.tool_to_openai_function(beam)
+
+      assert %{
+               type: "function",
+               function: %{
+                 description: "A test beam",
+                 parameters: %{type: :object}
+               }
+             } = result
+    end
+
+    test "converts a Lens to OpenAI function format" do
+      lens = TestLens.view()
+      result = ProviderUtils.tool_to_openai_function(lens)
+
+      assert %{
+               type: "function",
+               function: %{
+                 description: "Gets test data",
+                 parameters: %{type: "object"}
+               }
+             } = result
+    end
+
+    test "converts module atoms" do
+      result = ProviderUtils.tool_to_openai_function(TestPrism)
+
+      assert %{type: "function", function: %{description: "A test prism"}} = result
+    end
+  end
+
+  describe "tool_to_anthropic_function/1" do
+    test "converts a Prism to Anthropic format (no type wrapper)" do
+      prism = TestPrism.view()
+      result = ProviderUtils.tool_to_anthropic_function(prism)
+
+      assert %{
+               name: _,
+               description: "A test prism",
+               input_schema: %{type: :object}
+             } = result
+
+      # Should NOT have the `type: "function"` wrapper
+      refute Map.has_key?(result, :type)
+    end
+  end
+
+  # ─── Content Parsing Tests ──────────────────────────────────────────────
+
+  describe "parse_json_content/2" do
+    test "parses valid JSON" do
+      assert {:ok, %{"key" => "value"}} =
+               ProviderUtils.parse_json_content(~s({"key": "value"}), [])
+    end
+
+    test "returns error for invalid JSON in strict mode" do
+      assert {:error, _} = ProviderUtils.parse_json_content("not json", strict: true)
+    end
+
+    test "returns raw string for invalid JSON in lenient mode" do
+      assert {:ok, "not json"} = ProviderUtils.parse_json_content("not json", strict: false)
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} = ProviderUtils.parse_json_content(nil)
+    end
+  end
+
+  describe "parse_content_lenient/1" do
+    test "parses valid JSON" do
+      assert {:ok, %{"a" => 1}} = ProviderUtils.parse_content_lenient(~s({"a": 1}))
+    end
+
+    test "returns raw string for non-JSON" do
+      assert {:ok, "hello world"} = ProviderUtils.parse_content_lenient("hello world")
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} = ProviderUtils.parse_content_lenient(nil)
+    end
+  end
+
+  # ─── Message Building Tests ─────────────────────────────────────────────
+
+  describe "build_user_messages/1" do
+    test "wraps prompt in user message" do
+      assert [%{role: "user", content: "hello"}] = ProviderUtils.build_user_messages("hello")
+    end
+  end
+
+  describe "build_tools_config/2" do
+    test "returns empty list for empty tools" do
+      assert [] = ProviderUtils.build_tools_config([])
+    end
+
+    test "converts tools to OpenAI format by default" do
+      tools = [TestPrism.view()]
+      result = ProviderUtils.build_tools_config(tools, :openai)
+      assert [%{type: "function"}] = result
+    end
+
+    test "converts tools to Anthropic format" do
+      tools = [TestPrism.view()]
+      result = ProviderUtils.build_tools_config(tools, :anthropic)
+      assert [%{name: _, description: _, input_schema: _}] = result
+    end
+  end
+
+  # ─── Tool Choice Formatting Tests ───────────────────────────────────────
+
+  describe "format_tool_choice/1" do
+    test "formats :none" do
+      assert "none" = ProviderUtils.format_tool_choice(:none)
+    end
+
+    test "formats :auto" do
+      assert "auto" = ProviderUtils.format_tool_choice(:auto)
+    end
+
+    test "formats string name" do
+      assert %{"type" => "function", "function" => %{"name" => "My_Tool"}} =
+               ProviderUtils.format_tool_choice("My.Tool")
+    end
+
+    test "defaults to auto for unknown" do
+      assert "auto" = ProviderUtils.format_tool_choice(nil)
+    end
+  end
+
+  # ─── Sanitize Function Name Tests ───────────────────────────────────────
+
+  describe "sanitize_function_name/1" do
+    test "replaces dots with underscores" do
+      assert "Elixir_MyModule_SubModule" = ProviderUtils.sanitize_function_name("Elixir.MyModule.SubModule")
+    end
+
+    test "leaves clean names unchanged" do
+      assert "my_function" = ProviderUtils.sanitize_function_name("my_function")
+    end
+  end
+
+  # ─── Tool Execution Tests ──────────────────────────────────────────────
+
+  describe "execute_tool_calls/1" do
+    test "handles nil" do
+      assert {:ok, nil} = ProviderUtils.execute_tool_calls(nil)
+    end
+
+    test "executes prism tool calls" do
+      tool_calls = [
+        %{
+          "function" => %{
+            "name" => "#{TestPrism}",
+            "arguments" => ~s({"value": "success"})
+          }
+        }
+      ]
+
+      assert {:ok, [%{result: "success"}]} = ProviderUtils.execute_tool_calls(tool_calls)
+    end
+  end
+end


### PR DESCRIPTION
## Overview

Implements the **LLM Provider Abstraction Layer** as described in #99.

## New Modules

### `Lux.LLM.ProviderRegistry`
A GenServer-based registry for managing multiple LLM providers:

- **Provider Registration** — Register/unregister/update providers dynamically
- **Automatic Model Selection** — Model-to-provider routing via explicit rules and prefix-based auto-detection (e.g., `gpt-*` → OpenAI, `claude-*` → Anthropic)
- **Tag-based Selection** — Select providers by capability tags (`:fast`, `:cheap`, `:reasoning`, `:tools`)
- **Priority Ordering** — Lower priority number = higher preference
- **Smart Fallback Handling** — Configurable fallback chains; auto-fallback to next provider on failure
- **Cost & Performance Monitoring** — Per-provider stats: total/successful/failed calls, avg latency, token usage, last error
- **Enable/Disable** — Toggle providers without removing configuration
- **Auto-registration** — Load providers from application config on startup

### `Lux.LLM.ProviderUtils`
Shared utilities extracted from duplicate code across all 5 existing providers:

- **Tool Conversion** — Beams/Prisms/Lenses → OpenAI and Anthropic function formats
- **Tool Execution** — Unified tool call execution with module resolution
- **Content Parsing** — JSON parsing with strict and lenient modes
- **Response Building** — Standard ResponseSignal construction from OpenAI-format responses
- **Message Building** — User message list construction
- **Tool Choice Formatting** — Standard formatting for tool_choice option

### Updated `Lux.LLM`
- Added `call_with_registry/3` for registry-routed calls with auto-selection and fallback
- **Fully backwards compatible** — existing `call/3` behavior unchanged
- Enhanced moduledoc listing all available providers

## Usage Examples

```elixir
# Start the registry
Lux.LLM.ProviderRegistry.start_link([])

# Register providers
Lux.LLM.ProviderRegistry.register_provider(:openai, %{
  module: Lux.LLM.OpenAI,
  priority: 1,
  models: ["gpt-4", "gpt-3.5-turbo"],
  config: %{api_key: "sk-..."},
  tags: [:reasoning, :tools]
})

Lux.LLM.ProviderRegistry.register_provider(:anthropic, %{
  module: Lux.LLM.Anthropic,
  priority: 2,
  models: ["claude-3-opus"],
  tags: [:reasoning]
})

# Auto-selects OpenAI based on model prefix
Lux.LLM.call_with_registry("Hello!", [], %{model: "gpt-4"})

# Falls back to Anthropic if OpenAI fails
Lux.LLM.call_with_registry("Hello!", [], %{model: "gpt-4", fallback: true})

# Select by tags
Lux.LLM.call_with_registry("Hello!", [], %{tags: [:fast, :cheap]})

# Check stats
Lux.LLM.ProviderRegistry.get_stats(:openai)
```

## Tests

- **ProviderRegistry**: 20 tests — registration, selection, fallback, statistics, model routing
- **ProviderUtils**: 15 tests — tool conversion, content parsing, message building, tool execution

## Acceptance Criteria

- [x] Design and implement universal provider interface
- [x] Create provider registry and management system
- [x] Implement automatic model selection logic
- [x] Add intelligent fallback handling
- [x] Implement cost tracking and optimization
- [x] Add performance monitoring and analytics
- [x] Include documentation and examples

Closes #99