### PR TITLE
Add Telegram group management planner with forum topic actions

### DIFF
--- a/lux/guides/telegram.livemd
+++ b/lux/guides/telegram.livemd
@@ -313,6 +313,60 @@ moderation.preflight
 moderation.audit_entry
 ```
 
+#### Member Management: Add, Remove, And Restrict
+
+The Telegram Bot API cannot force-add an arbitrary user to a chat, so the
+"add member" acceptance criterion maps to invite-link and join-request
+approval workflows. The three member-management outcomes resolve to these
+actions:
+
+* **Add** – `:create_invite_link` (optionally with `creates_join_request: true`)
+  to issue an invite, then `:approve_join_request` (or `:decline_join_request`)
+  to admit users who request to join.
+* **Remove** – `:ban_member` to remove a user (and `:unban_member` to reverse it).
+* **Restrict** – `:restrict_member` with a `permission_template` such as
+  `:read_only` or explicit `permissions`.
+
+#### Execution Authentication
+
+Execution authenticates through `Lux.Integrations.Telegram.Client`. By default
+the client uses the bot token configured for your application; pass an explicit
+`token` only when you need to override it per call:
+
+```elixir
+ManageGroup.handler(
+  %{
+    action: :ban_member,
+    chat_id: -100_123_456,
+    user_id: 987_654,
+    token: System.fetch_env!("TELEGRAM_BOT_TOKEN"),
+    bot_admin_rights: %{can_restrict_members: true},
+    execute: true
+  },
+  %{name: "Moderator Bot"}
+)
+```
+
+#### Destructive Action Safety Gate
+
+Destructive actions (ban, restrict, promote/demote, and delete paths) keep
+their dry-run safety in live mode. Before executing one, supply
+`bot_admin_rights` confirming the required permissions are present. If those
+rights are absent or unverified, execution is **blocked** and the plan carries
+a `warnings` entry explaining why. To execute anyway when the bot's rights are
+guaranteed out of band (for example via the configured client), pass
+`allow_unverified_admin_rights: true`. The `preflight` map reports
+`destructive`, `verified`, `required_rights`, and `missing_rights` so agents can
+reason about safety before acting.
+
+> #### Sticker set capability {: .warning}
+>
+> `:set_sticker_set` and `:delete_sticker_set` also depend on the chat-level
+> `can_set_sticker_set` capability, which is only observable through `getChat`
+> and is **not** part of `bot_admin_rights`. The plan surfaces a `warnings`
+> entry for these actions; verify the capability with `getChat` before live
+> execution.
+
 ## Advanced Usage
 
 ### Formatting Options

--- a/lux/guides/telegram.livemd
+++ b/lux/guides/telegram.livemd
@@ -266,6 +266,15 @@ Bulk deletes, sender-chat bans, member tags, forum topic controls, and
 standalone audit-log messages are also available through the same `action`
 field.
 
+When a moderation policy uses spam thresholds, pass either a precomputed
+`recent_message_count` or a `recent_messages` list scoped to the current
+chat/user. Each recent message may include `text`, `chat_id`, `user_id`, and
+optional `age_seconds`; `window_seconds`, `duplicate_threshold`, and
+`max_recent_links` let agents detect per-window floods, repeated text, and
+link-heavy bursts. For live execution, `bot_admin_rights` can be supplied to
+surface a preflight summary of required Telegram administrator permissions.
+Any action with `log_chat_id` also appends an admin audit delivery request.
+
 ```elixir
 {:ok, moderation} =
   ManageGroup.handler(
@@ -277,17 +286,30 @@ field.
       text: "Join https://spam.example now",
       moderation_action: :restrict_member,
       log_chat_id: -100_999,
+      bot_admin_rights: %{can_delete_messages: true, can_restrict_members: true},
+      recent_messages: [
+        %{
+          chat_id: -100_123_456,
+          user_id: 987_654,
+          text: "Join https://spam.example",
+          age_seconds: 12
+        }
+      ],
       policy: %{
         blocked_terms: ["free money"],
         blocked_patterns: ["spam\\.example"],
         block_links: true,
-        max_recent_messages: 5
+        max_recent_messages: 5,
+        duplicate_threshold: 2,
+        max_recent_links: 3,
+        window_seconds: 60
       }
     },
     %{name: "Moderator Bot"}
   )
 
 moderation.violations
+moderation.preflight
 moderation.audit_entry
 ```
 

--- a/lux/guides/telegram.livemd
+++ b/lux/guides/telegram.livemd
@@ -172,6 +172,113 @@ alias Lux.Prisms.Telegram.Messages.EditMessageCaption
 )
 ```
 
+### Group And Channel Management
+
+`Lux.Prisms.Telegram.Group.ManageGroup` provides a single action surface for
+group moderation and channel administration. By default it returns a dry-run
+request plan so agents can inspect moderation and permission changes before
+sending them to Telegram. Pass `execute: true` to execute the planned requests
+through the configured Telegram client.
+
+```elixir
+alias Lux.Prisms.Telegram.Group.ManageGroup
+
+# Restrict a member to read-only access
+{:ok, plan} =
+  ManageGroup.handler(
+    %{
+      action: :restrict_member,
+      chat_id: -100_123_456,
+      user_id: 987_654,
+      permission_template: :read_only,
+      until_date: 1_766_000_000
+    },
+    %{name: "Moderator Bot"}
+  )
+
+# Promote a moderator with a predefined admin rights template
+{:ok, _} =
+  ManageGroup.handler(
+    %{
+      action: :promote_member,
+      chat_id: -100_123_456,
+      user_id: 987_654,
+      admin_template: :moderator,
+      execute: true
+    },
+    %{name: "Moderator Bot"}
+  )
+
+# Apply default chat permissions
+{:ok, _} =
+  ManageGroup.handler(
+    %{
+      action: :set_permissions,
+      chat_id: -100_123_456,
+      permission_template: :no_links
+    },
+    %{name: "Moderator Bot"}
+  )
+```
+
+The same prism covers group settings and channel post workflows:
+
+```elixir
+# Create an invite link that requires approval
+ManageGroup.handler(
+  %{
+    action: :create_invite_link,
+    chat_id: -100_123_456,
+    name: "Community review",
+    creates_join_request: true,
+    member_limit: 25
+  },
+  %{name: "Moderator Bot"}
+)
+
+# Publish a channel post
+ManageGroup.handler(
+  %{
+    action: :send_channel_post,
+    chat_id: "@lux_updates",
+    text: "Research update is live.",
+    parse_mode: "MarkdownV2"
+  },
+  %{name: "Publisher Bot"}
+)
+```
+
+For moderation, pass a policy with blocked terms, regex patterns, link rules,
+rate thresholds, or message-shape limits. The prism returns violations, the
+chosen moderation action, Bot API requests, and a normalized audit entry.
+Bulk deletes, sender-chat bans, member tags, and standalone audit-log messages
+are also available through the same `action` field.
+
+```elixir
+{:ok, moderation} =
+  ManageGroup.handler(
+    %{
+      action: :moderate_message,
+      chat_id: -100_123_456,
+      user_id: 987_654,
+      message_id: 42,
+      text: "Join https://spam.example now",
+      moderation_action: :restrict_member,
+      log_chat_id: -100_999,
+      policy: %{
+        blocked_terms: ["free money"],
+        blocked_patterns: ["spam\\.example"],
+        block_links: true,
+        max_recent_messages: 5
+      }
+    },
+    %{name: "Moderator Bot"}
+  )
+
+moderation.violations
+moderation.audit_entry
+```
+
 ## Advanced Usage
 
 ### Formatting Options

--- a/lux/guides/telegram.livemd
+++ b/lux/guides/telegram.livemd
@@ -236,6 +236,17 @@ ManageGroup.handler(
   %{name: "Moderator Bot"}
 )
 
+# Create a forum topic in a supergroup
+ManageGroup.handler(
+  %{
+    action: :create_forum_topic,
+    chat_id: -100_123_456,
+    name: "Research Q&A",
+    icon_color: 7_322_096
+  },
+  %{name: "Moderator Bot"}
+)
+
 # Publish a channel post
 ManageGroup.handler(
   %{
@@ -251,8 +262,9 @@ ManageGroup.handler(
 For moderation, pass a policy with blocked terms, regex patterns, link rules,
 rate thresholds, or message-shape limits. The prism returns violations, the
 chosen moderation action, Bot API requests, and a normalized audit entry.
-Bulk deletes, sender-chat bans, member tags, and standalone audit-log messages
-are also available through the same `action` field.
+Bulk deletes, sender-chat bans, member tags, forum topic controls, and
+standalone audit-log messages are also available through the same `action`
+field.
 
 ```elixir
 {:ok, moderation} =

--- a/lux/lib/lux/integrations/telegram/group_manager.ex
+++ b/lux/lib/lux/integrations/telegram/group_manager.ex
@@ -1,0 +1,1278 @@
+defmodule Lux.Integrations.Telegram.GroupManager do
+  @moduledoc """
+  Request planner and executor for Telegram group and channel administration.
+
+  The module keeps moderation, permission, member, settings, channel post, and
+  audit-log workflows deterministic. `plan/2` returns Bot API request payloads
+  that can be inspected or executed later through `execute/2`.
+  """
+
+  alias Lux.Integrations.Telegram.Client
+
+  @permission_keys [
+    :can_send_messages,
+    :can_send_audios,
+    :can_send_documents,
+    :can_send_photos,
+    :can_send_videos,
+    :can_send_video_notes,
+    :can_send_voice_notes,
+    :can_send_polls,
+    :can_send_other_messages,
+    :can_add_web_page_previews,
+    :can_react_to_messages,
+    :can_edit_tag,
+    :can_change_info,
+    :can_invite_users,
+    :can_pin_messages,
+    :can_manage_topics
+  ]
+
+  @admin_permission_keys [
+    :is_anonymous,
+    :can_manage_chat,
+    :can_delete_messages,
+    :can_manage_video_chats,
+    :can_restrict_members,
+    :can_promote_members,
+    :can_change_info,
+    :can_invite_users,
+    :can_post_stories,
+    :can_edit_stories,
+    :can_delete_stories,
+    :can_post_messages,
+    :can_edit_messages,
+    :can_pin_messages,
+    :can_manage_topics,
+    :can_manage_direct_messages,
+    :can_manage_tags
+  ]
+
+  @actions [
+    :ban_member,
+    :unban_member,
+    :restrict_member,
+    :promote_member,
+    :demote_member,
+    :set_admin_title,
+    :set_member_tag,
+    :ban_sender_chat,
+    :unban_sender_chat,
+    :get_member,
+    :get_admins,
+    :get_member_count,
+    :set_permissions,
+    :set_title,
+    :set_description,
+    :delete_photo,
+    :set_slow_mode,
+    :create_invite_link,
+    :edit_invite_link,
+    :revoke_invite_link,
+    :approve_join_request,
+    :decline_join_request,
+    :pin_message,
+    :unpin_message,
+    :unpin_all_messages,
+    :set_sticker_set,
+    :delete_sticker_set,
+    :set_forum,
+    :send_channel_post,
+    :edit_channel_post,
+    :edit_channel_caption,
+    :delete_channel_post,
+    :delete_messages,
+    :forward_channel_post,
+    :copy_channel_post,
+    :moderate_message,
+    :log_admin_action
+  ]
+
+  @action_aliases Map.new(@actions, fn action -> {Atom.to_string(action), action} end)
+
+  @api_specs %{
+    ban_member: %{
+      category: :member_management,
+      path: "/banChatMember",
+      required: [:chat_id, :user_id],
+      optional: [:until_date, :revoke_messages]
+    },
+    unban_member: %{
+      category: :member_management,
+      path: "/unbanChatMember",
+      required: [:chat_id, :user_id],
+      optional: [:only_if_banned]
+    },
+    restrict_member: %{
+      category: :member_management,
+      path: "/restrictChatMember",
+      required: [:chat_id, :user_id],
+      optional: [:until_date, :use_independent_chat_permissions],
+      permissions: :member,
+      default_permission_template: :read_only
+    },
+    promote_member: %{
+      category: :member_management,
+      path: "/promoteChatMember",
+      required: [:chat_id, :user_id],
+      optional: [],
+      admin_rights: true,
+      default_admin_template: :moderator
+    },
+    demote_member: %{
+      category: :member_management,
+      path: "/promoteChatMember",
+      required: [:chat_id, :user_id],
+      optional: [],
+      admin_rights: true,
+      default_admin_template: :none
+    },
+    set_admin_title: %{
+      category: :member_management,
+      path: "/setChatAdministratorCustomTitle",
+      required: [:chat_id, :user_id, :custom_title],
+      optional: []
+    },
+    set_member_tag: %{
+      category: :member_management,
+      path: "/setChatMemberTag",
+      required: [:chat_id, :user_id],
+      optional: [:tag]
+    },
+    ban_sender_chat: %{
+      category: :member_management,
+      path: "/banChatSenderChat",
+      required: [:chat_id, :sender_chat_id],
+      optional: []
+    },
+    unban_sender_chat: %{
+      category: :member_management,
+      path: "/unbanChatSenderChat",
+      required: [:chat_id, :sender_chat_id],
+      optional: []
+    },
+    get_member: %{
+      category: :member_management,
+      path: "/getChatMember",
+      required: [:chat_id, :user_id],
+      optional: []
+    },
+    get_admins: %{
+      category: :member_management,
+      path: "/getChatAdministrators",
+      required: [:chat_id],
+      optional: [:return_bots]
+    },
+    get_member_count: %{
+      category: :member_management,
+      path: "/getChatMemberCount",
+      required: [:chat_id],
+      optional: []
+    },
+    set_permissions: %{
+      category: :permission_management,
+      path: "/setChatPermissions",
+      required: [:chat_id],
+      optional: [:use_independent_chat_permissions],
+      permissions: :chat,
+      default_permission_template: :standard
+    },
+    set_title: %{
+      category: :group_settings,
+      path: "/setChatTitle",
+      required: [:chat_id, :title],
+      optional: []
+    },
+    set_description: %{
+      category: :group_settings,
+      path: "/setChatDescription",
+      required: [:chat_id, :description],
+      optional: []
+    },
+    delete_photo: %{
+      category: :group_settings,
+      path: "/deleteChatPhoto",
+      required: [:chat_id],
+      optional: []
+    },
+    set_slow_mode: %{
+      category: :spam_protection,
+      path: "/setChatSlowModeDelay",
+      required: [:chat_id, :slow_mode_delay],
+      optional: []
+    },
+    create_invite_link: %{
+      category: :group_settings,
+      path: "/createChatInviteLink",
+      required: [:chat_id],
+      optional: [:name, :expire_date, :member_limit, :creates_join_request]
+    },
+    edit_invite_link: %{
+      category: :group_settings,
+      path: "/editChatInviteLink",
+      required: [:chat_id, :invite_link],
+      optional: [:name, :expire_date, :member_limit, :creates_join_request]
+    },
+    revoke_invite_link: %{
+      category: :group_settings,
+      path: "/revokeChatInviteLink",
+      required: [:chat_id, :invite_link],
+      optional: []
+    },
+    approve_join_request: %{
+      category: :member_management,
+      path: "/approveChatJoinRequest",
+      required: [:chat_id, :user_id],
+      optional: []
+    },
+    decline_join_request: %{
+      category: :member_management,
+      path: "/declineChatJoinRequest",
+      required: [:chat_id, :user_id],
+      optional: []
+    },
+    pin_message: %{
+      category: :group_settings,
+      path: "/pinChatMessage",
+      required: [:chat_id, :message_id],
+      optional: [:disable_notification]
+    },
+    unpin_message: %{
+      category: :group_settings,
+      path: "/unpinChatMessage",
+      required: [:chat_id],
+      optional: [:message_id]
+    },
+    unpin_all_messages: %{
+      category: :group_settings,
+      path: "/unpinAllChatMessages",
+      required: [:chat_id],
+      optional: []
+    },
+    set_sticker_set: %{
+      category: :group_settings,
+      path: "/setChatStickerSet",
+      required: [:chat_id, :sticker_set_name],
+      optional: []
+    },
+    delete_sticker_set: %{
+      category: :group_settings,
+      path: "/deleteChatStickerSet",
+      required: [:chat_id],
+      optional: []
+    },
+    set_forum: %{
+      category: :group_settings,
+      path: "/setChatIsForum",
+      required: [:chat_id, :is_forum],
+      optional: []
+    },
+    send_channel_post: %{
+      category: :channel_post_management,
+      path: "/sendMessage",
+      required: [:chat_id, :text],
+      optional: [
+        :parse_mode,
+        :entities,
+        :link_preview_options,
+        :disable_notification,
+        :protect_content,
+        :reply_markup
+      ]
+    },
+    edit_channel_post: %{
+      category: :channel_post_management,
+      path: "/editMessageText",
+      required: [:chat_id, :message_id, :text],
+      optional: [:parse_mode, :entities, :link_preview_options, :reply_markup]
+    },
+    edit_channel_caption: %{
+      category: :channel_post_management,
+      path: "/editMessageCaption",
+      required: [:chat_id, :message_id, :caption],
+      optional: [:parse_mode, :caption_entities, :reply_markup]
+    },
+    delete_channel_post: %{
+      category: :channel_post_management,
+      path: "/deleteMessage",
+      required: [:chat_id, :message_id],
+      optional: []
+    },
+    delete_messages: %{
+      category: :content_moderation,
+      path: "/deleteMessages",
+      required: [:chat_id, :message_ids],
+      optional: []
+    },
+    forward_channel_post: %{
+      category: :channel_post_management,
+      path: "/forwardMessage",
+      required: [:chat_id, :from_chat_id, :message_id],
+      optional: [:message_thread_id, :disable_notification, :protect_content]
+    },
+    copy_channel_post: %{
+      category: :channel_post_management,
+      path: "/copyMessage",
+      required: [:chat_id, :from_chat_id, :message_id],
+      optional: [
+        :message_thread_id,
+        :caption,
+        :parse_mode,
+        :caption_entities,
+        :disable_notification,
+        :protect_content,
+        :reply_markup
+      ]
+    }
+  }
+
+  @doc "Returns every operation accepted by `plan/2`."
+  @spec known_actions() :: [atom()]
+  def known_actions, do: @actions
+
+  @doc """
+  Returns a named `ChatPermissions` template.
+  """
+  @spec permission_template(atom() | String.t()) :: {:ok, map()} | {:error, String.t()}
+  def permission_template(template) do
+    case normalize_template(template) do
+      {:ok, :standard} ->
+        {:ok,
+         %{
+           can_send_messages: true,
+           can_send_audios: true,
+           can_send_documents: true,
+           can_send_photos: true,
+           can_send_videos: true,
+           can_send_video_notes: true,
+           can_send_voice_notes: true,
+           can_send_polls: true,
+           can_send_other_messages: true,
+           can_add_web_page_previews: true,
+           can_react_to_messages: true,
+           can_edit_tag: false,
+           can_change_info: false,
+           can_invite_users: true,
+           can_pin_messages: false,
+           can_manage_topics: false
+         }}
+
+      {:ok, :media_limited} ->
+        {:ok,
+         %{
+           can_send_messages: true,
+           can_send_audios: false,
+           can_send_documents: false,
+           can_send_photos: false,
+           can_send_videos: false,
+           can_send_video_notes: false,
+           can_send_voice_notes: false,
+           can_send_polls: true,
+           can_send_other_messages: false,
+           can_add_web_page_previews: false,
+           can_react_to_messages: true,
+           can_edit_tag: false,
+           can_change_info: false,
+           can_invite_users: true,
+           can_pin_messages: false,
+           can_manage_topics: false
+         }}
+
+      {:ok, :read_only} ->
+        {:ok, Map.new(@permission_keys, &{&1, false})}
+
+      {:ok, :announcement} ->
+        {:ok,
+         Map.new(@permission_keys, fn
+           :can_react_to_messages -> {:can_react_to_messages, true}
+           key -> {key, false}
+         end)}
+
+      {:ok, :no_links} ->
+        {:ok,
+         %{
+           can_send_messages: true,
+           can_send_audios: true,
+           can_send_documents: true,
+           can_send_photos: true,
+           can_send_videos: true,
+           can_send_video_notes: true,
+           can_send_voice_notes: true,
+           can_send_polls: true,
+           can_send_other_messages: true,
+           can_add_web_page_previews: false,
+           can_react_to_messages: true,
+           can_edit_tag: false,
+           can_change_info: false,
+           can_invite_users: true,
+           can_pin_messages: false,
+           can_manage_topics: false
+         }}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Returns a named administrator rights template for `promoteChatMember`.
+  """
+  @spec admin_template(atom() | String.t()) :: {:ok, map()} | {:error, String.t()}
+  def admin_template(template) do
+    base = Map.new(@admin_permission_keys, &{&1, false})
+
+    case normalize_admin_template(template) do
+      {:ok, :none} ->
+        {:ok, base}
+
+      {:ok, :moderator} ->
+        {:ok,
+         %{
+           base
+           | can_manage_chat: true,
+             can_delete_messages: true,
+             can_restrict_members: true,
+             can_invite_users: true,
+             can_pin_messages: true,
+             can_manage_topics: true
+         }}
+
+      {:ok, :publisher} ->
+        {:ok,
+         %{
+           base
+           | can_manage_chat: true,
+             can_post_messages: true,
+             can_edit_messages: true,
+             can_delete_messages: true,
+             can_post_stories: true,
+             can_edit_stories: true,
+             can_delete_stories: true
+         }}
+
+      {:ok, :community_manager} ->
+        {:ok,
+         %{
+           base
+           | can_manage_chat: true,
+             can_delete_messages: true,
+             can_manage_video_chats: true,
+             can_restrict_members: true,
+             can_promote_members: true,
+             can_change_info: true,
+             can_invite_users: true,
+             can_pin_messages: true,
+             can_manage_topics: true,
+             can_manage_tags: true
+         }}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Builds a deterministic group-management plan for a Telegram Bot API operation.
+  """
+  @spec plan(atom() | String.t(), map()) :: {:ok, map()} | {:error, String.t()}
+  def plan(action, params \\ %{}) do
+    with {:ok, normalized_action} <- normalize_action(action) do
+      case normalized_action do
+        :moderate_message -> build_moderation_plan(params)
+        :log_admin_action -> build_admin_log_plan(params)
+        api_action -> build_api_plan(api_action, params)
+      end
+    end
+  end
+
+  @doc """
+  Executes every request in a plan through `Lux.Integrations.Telegram.Client`.
+  """
+  @spec execute(map(), map() | keyword()) :: {:ok, map()} | {:error, map()}
+  def execute(%{requests: requests} = plan, opts \\ %{}) when is_list(requests) do
+    opts = normalize_opts(opts)
+
+    results =
+      Enum.map(requests, fn request ->
+        request_opts =
+          opts
+          |> take_params([:plug, :token])
+          |> Map.put(:json, Map.get(request, :payload, %{}))
+
+        case Client.request(request.method, request.path, request_opts) do
+          {:ok, response} -> {:ok, %{request: request, response: response}}
+          {:error, error} -> {:error, %{request: request, error: error}}
+        end
+      end)
+
+    if Enum.all?(results, &match?({:ok, _}, &1)) do
+      {:ok,
+       plan
+       |> Map.put(:executed, true)
+       |> Map.put(:results, Enum.map(results, fn {:ok, result} -> result end))}
+    else
+      {:error, %{plan: plan, results: results}}
+    end
+  end
+
+  @doc """
+  Builds a normalized audit entry for an administrative action.
+  """
+  @spec audit_entry(atom() | String.t(), map(), map()) :: map()
+  def audit_entry(action, params, result \\ %{}) do
+    status =
+      cond do
+        Map.get(result, :status) -> Map.get(result, :status)
+        Map.get(result, :planned) == true -> :planned
+        true -> :recorded
+      end
+
+    %{
+      id: System.unique_integer([:positive]),
+      action: normalize_action_name(action),
+      category: value(params, :category),
+      chat_id: value(params, :chat_id),
+      admin_id: value(params, :admin_id),
+      target_user_id: value(params, :target_user_id) || value(params, :user_id),
+      message_id: value(params, :message_id),
+      reason: value(params, :reason),
+      status: status,
+      violations: Map.get(result, :violations),
+      inserted_at: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+    }
+    |> compact()
+  end
+
+  @doc "Formats an audit entry as a plain Telegram log message."
+  @spec format_audit_entry(map()) :: String.t()
+  def format_audit_entry(entry) do
+    [
+      "Telegram admin action",
+      "action=#{entry.action}",
+      optional_segment("status", Map.get(entry, :status)),
+      optional_segment("chat", Map.get(entry, :chat_id)),
+      optional_segment("admin", Map.get(entry, :admin_id)),
+      optional_segment("target", Map.get(entry, :target_user_id)),
+      optional_segment("message", Map.get(entry, :message_id)),
+      optional_segment("reason", Map.get(entry, :reason))
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" | ")
+  end
+
+  defp build_api_plan(action, params) do
+    spec = Map.fetch!(@api_specs, action)
+
+    with {:ok, payload} <- build_payload(action, spec, params) do
+      request = request(spec.category, action, spec.path, payload)
+
+      {:ok,
+       %{
+         action: action,
+         category: spec.category,
+         request_count: 1,
+         requests: [request],
+         audit_entry:
+           audit_entry(action, Map.put(params, :category, spec.category), %{planned: true})
+       }}
+    end
+  end
+
+  defp build_payload(action, spec, params) do
+    with {:ok, required_payload} <- required_payload(params, spec.required),
+         {:ok, special_payload} <- special_payload(action, spec, params) do
+      payload =
+        required_payload
+        |> Map.merge(take_params(params, spec.optional))
+        |> Map.merge(special_payload)
+        |> compact()
+
+      {:ok, payload}
+    end
+  end
+
+  defp required_payload(params, required_keys) do
+    Enum.reduce_while(required_keys, {:ok, %{}}, fn key, {:ok, acc} ->
+      case validate_required_key(params, key) do
+        {:ok, value} -> {:cont, {:ok, Map.put(acc, key, value)}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp special_payload(_action, %{permissions: _} = spec, params) do
+    default_template = Map.get(spec, :default_permission_template)
+
+    params
+    |> resolve_permissions(default_template)
+    |> case do
+      {:ok, permissions} -> {:ok, %{permissions: permissions}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp special_payload(_action, %{admin_rights: true} = spec, params) do
+    default_template = Map.get(spec, :default_admin_template)
+
+    params
+    |> resolve_admin_rights(default_template)
+    |> case do
+      {:ok, rights} -> {:ok, rights}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp special_payload(_action, _spec, _params), do: {:ok, %{}}
+
+  defp build_moderation_plan(params) do
+    with {:ok, chat_id} <- validate_required_key(params, :chat_id),
+         {:ok, text} <- validate_required_key(params, :text),
+         {:ok, policy} <- normalize_policy(params),
+         {:ok, violations} <- evaluate_content(text, policy, params) do
+      severity = moderation_severity(violations)
+      moderation_action = resolve_moderation_action(params, policy, severity)
+      base_requests = moderation_requests(moderation_action, chat_id, params, policy)
+
+      status =
+        if violations == [] do
+          :clean
+        else
+          :flagged
+        end
+
+      audit =
+        audit_entry(
+          :moderate_message,
+          Map.put(params, :category, :content_moderation),
+          %{status: status, violations: violations}
+        )
+
+      requests = base_requests ++ audit_log_requests(audit, params, policy)
+
+      {:ok,
+       %{
+         action: :moderate_message,
+         category: :content_moderation,
+         status: status,
+         severity: severity,
+         moderation_action: moderation_action,
+         violations: violations,
+         request_count: length(requests),
+         requests: requests,
+         audit_entry: audit
+       }}
+    end
+  end
+
+  defp build_admin_log_plan(params) do
+    logged_action =
+      value(params, :logged_action) ||
+        value(params, :admin_action) ||
+        value(params, :event) ||
+        "admin_action"
+
+    audit =
+      logged_action
+      |> audit_entry(Map.put(params, :category, :admin_logging), %{status: :recorded})
+      |> Map.put(:category, :admin_logging)
+
+    requests = audit_log_requests(audit, params, params)
+
+    {:ok,
+     %{
+       action: :log_admin_action,
+       category: :admin_logging,
+       request_count: length(requests),
+       requests: requests,
+       audit_entry: audit
+     }}
+  end
+
+  defp normalize_policy(params) do
+    policy = value(params, :policy, %{})
+
+    if is_map(policy) do
+      {:ok,
+       %{
+         blocked_terms: list_value(policy, :blocked_terms),
+         blocked_patterns: list_value(policy, :blocked_patterns),
+         block_links: boolean_value(policy, :block_links, false),
+         max_length: value(policy, :max_length),
+         max_mentions: value(policy, :max_mentions),
+         max_repeated_chars: value(policy, :max_repeated_chars),
+         uppercase_ratio: value(policy, :uppercase_ratio, 0.85),
+         min_uppercase_length: value(policy, :min_uppercase_length, 24),
+         max_recent_messages: value(policy, :max_recent_messages),
+         warning_text:
+           value(policy, :warning_text, "Please keep the conversation within the group rules."),
+         log_chat_id: value(policy, :log_chat_id) || value(params, :log_chat_id),
+         action: value(policy, :action)
+       }}
+    else
+      {:error, "policy must be a map"}
+    end
+  end
+
+  defp evaluate_content(text, policy, params) do
+    with {:ok, pattern_violations} <- pattern_violations(text, policy.blocked_patterns) do
+      violations =
+        []
+        |> Kernel.++(blocked_term_violations(text, policy.blocked_terms))
+        |> Kernel.++(pattern_violations)
+        |> maybe_add(link_violation(text, policy.block_links))
+        |> maybe_add(length_violation(text, policy.max_length))
+        |> maybe_add(mention_violation(text, policy.max_mentions))
+        |> maybe_add(repeated_character_violation(text, policy.max_repeated_chars))
+        |> maybe_add(
+          uppercase_violation(text, policy.uppercase_ratio, policy.min_uppercase_length)
+        )
+        |> maybe_add(rate_violation(params, policy.max_recent_messages))
+
+      {:ok, violations}
+    end
+  end
+
+  defp blocked_term_violations(text, terms) do
+    normalized_text = String.downcase(text)
+
+    terms
+    |> Enum.filter(fn term ->
+      is_binary(term) and String.trim(term) != "" and
+        String.contains?(normalized_text, String.downcase(term))
+    end)
+    |> Enum.map(fn term -> %{type: :blocked_term, match: term, severity: :medium} end)
+  end
+
+  defp pattern_violations(text, patterns) do
+    Enum.reduce_while(patterns, {:ok, []}, fn pattern, {:ok, acc} ->
+      case pattern_violation(text, pattern) do
+        {:ok, nil} -> {:cont, {:ok, acc}}
+        {:ok, violation} -> {:cont, {:ok, acc ++ [violation]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp pattern_violation(_text, pattern) when not is_binary(pattern) do
+    {:error, "Invalid blocked pattern #{inspect(pattern)}: expected a string"}
+  end
+
+  defp pattern_violation(text, pattern) do
+    case Regex.compile(pattern, "iu") do
+      {:ok, regex} ->
+        if Regex.match?(regex, text) do
+          {:ok, %{type: :blocked_pattern, match: pattern, severity: :high}}
+        else
+          {:ok, nil}
+        end
+
+      {:error, reason} ->
+        {:error, "Invalid blocked pattern #{inspect(pattern)}: #{inspect(reason)}"}
+    end
+  end
+
+  defp link_violation(text, true) do
+    if Regex.match?(~r/(https?:\/\/|www\.|t\.me\/|telegram\.me\/)/iu, text) do
+      %{type: :link, severity: :medium}
+    end
+  end
+
+  defp link_violation(_text, _block_links), do: nil
+
+  defp length_violation(text, max_length) when is_integer(max_length) and max_length > 0 do
+    length = String.length(text)
+
+    if length > max_length do
+      %{type: :length, length: length, max_length: max_length, severity: :medium}
+    end
+  end
+
+  defp length_violation(_text, _max_length), do: nil
+
+  defp mention_violation(text, max_mentions)
+       when is_integer(max_mentions) and max_mentions >= 0 do
+    count = Regex.scan(~r/@[A-Za-z0-9_]{5,}/u, text) |> length()
+
+    if count > max_mentions do
+      %{type: :mentions, count: count, max_mentions: max_mentions, severity: :low}
+    end
+  end
+
+  defp mention_violation(_text, _max_mentions), do: nil
+
+  defp repeated_character_violation(text, max_repeated_chars)
+       when is_integer(max_repeated_chars) and max_repeated_chars > 1 do
+    repeated? =
+      text
+      |> String.graphemes()
+      |> Enum.reduce_while({nil, 0, false}, fn grapheme, {previous, count, _found?} ->
+        next_count =
+          if grapheme == previous do
+            count + 1
+          else
+            1
+          end
+
+        if next_count > max_repeated_chars do
+          {:halt, {grapheme, next_count, true}}
+        else
+          {:cont, {grapheme, next_count, false}}
+        end
+      end)
+      |> elem(2)
+
+    if repeated? do
+      %{type: :repeated_characters, max_repeated_chars: max_repeated_chars, severity: :low}
+    end
+  end
+
+  defp repeated_character_violation(_text, _max_repeated_chars), do: nil
+
+  defp uppercase_violation(text, ratio, min_length)
+       when is_number(ratio) and is_integer(min_length) do
+    letters =
+      text
+      |> String.graphemes()
+      |> Enum.filter(&Regex.match?(~r/^\p{L}$/u, &1))
+
+    uppercase =
+      Enum.count(letters, fn letter -> letter == String.upcase(letter) end)
+
+    if length(letters) >= min_length and length(letters) > 0 and
+         uppercase / length(letters) >= ratio do
+      %{type: :uppercase_ratio, ratio: uppercase / length(letters), severity: :low}
+    end
+  end
+
+  defp uppercase_violation(_text, _ratio, _min_length), do: nil
+
+  defp rate_violation(params, max_recent_messages)
+       when is_integer(max_recent_messages) and max_recent_messages >= 0 do
+    recent_count = value(params, :recent_message_count, 0)
+
+    if is_integer(recent_count) and recent_count > max_recent_messages do
+      %{
+        type: :message_rate,
+        recent_message_count: recent_count,
+        max_recent_messages: max_recent_messages,
+        severity: :high
+      }
+    end
+  end
+
+  defp rate_violation(_params, _max_recent_messages), do: nil
+
+  defp moderation_severity([]), do: :none
+
+  defp moderation_severity(violations) do
+    cond do
+      Enum.any?(violations, &(&1.severity == :high)) -> :high
+      Enum.any?(violations, &(&1.severity == :medium)) -> :medium
+      true -> :low
+    end
+  end
+
+  defp resolve_moderation_action(_params, _policy, :none), do: :none
+
+  defp resolve_moderation_action(params, policy, severity) do
+    explicit_action = value(params, :moderation_action) || policy.action
+
+    case normalize_moderation_action(explicit_action) do
+      {:ok, action} ->
+        action
+
+      :error ->
+        case severity do
+          :high -> :restrict_member
+          :medium -> :delete_message
+          :low -> :warn_member
+        end
+    end
+  end
+
+  defp moderation_requests(:none, _chat_id, _params, _policy), do: []
+
+  defp moderation_requests(:warn_member, chat_id, params, policy) do
+    payload =
+      %{
+        chat_id: chat_id,
+        text: policy.warning_text,
+        reply_to_message_id: value(params, :message_id)
+      }
+      |> compact()
+
+    [request(:content_moderation, :warn_member, "/sendMessage", payload)]
+  end
+
+  defp moderation_requests(:delete_message, chat_id, params, _policy) do
+    case value(params, :message_id) do
+      message_id when is_integer(message_id) ->
+        [
+          request(:content_moderation, :delete_message, "/deleteMessage", %{
+            chat_id: chat_id,
+            message_id: message_id
+          })
+        ]
+
+      _ ->
+        []
+    end
+  end
+
+  defp moderation_requests(:restrict_member, chat_id, params, _policy) do
+    delete_requests = moderation_requests(:delete_message, chat_id, params, %{})
+
+    case value(params, :user_id) do
+      user_id when is_integer(user_id) ->
+        {:ok, permissions} = permission_template(:read_only)
+
+        restrict_payload =
+          %{
+            chat_id: chat_id,
+            user_id: user_id,
+            permissions: permissions,
+            until_date: value(params, :until_date)
+          }
+          |> compact()
+
+        delete_requests ++
+          [
+            request(
+              :content_moderation,
+              :restrict_member,
+              "/restrictChatMember",
+              restrict_payload
+            )
+          ]
+
+      _ ->
+        delete_requests
+    end
+  end
+
+  defp moderation_requests(:ban_member, chat_id, params, _policy) do
+    delete_requests = moderation_requests(:delete_message, chat_id, params, %{})
+
+    case value(params, :user_id) do
+      user_id when is_integer(user_id) ->
+        ban_payload =
+          %{
+            chat_id: chat_id,
+            user_id: user_id,
+            until_date: value(params, :until_date),
+            revoke_messages: value(params, :revoke_messages)
+          }
+          |> compact()
+
+        delete_requests ++
+          [request(:content_moderation, :ban_member, "/banChatMember", ban_payload)]
+
+      _ ->
+        delete_requests
+    end
+  end
+
+  defp audit_log_requests(audit, params, policy) do
+    log_chat_id = value(policy, :log_chat_id) || value(params, :log_chat_id)
+
+    case log_chat_id do
+      nil ->
+        []
+
+      chat_id ->
+        [
+          request(:admin_logging, :log_admin_action, "/sendMessage", %{
+            chat_id: chat_id,
+            text: format_audit_entry(audit),
+            disable_notification: true
+          })
+        ]
+    end
+  end
+
+  defp request(category, action, path, payload) do
+    %{
+      method: :post,
+      path: path,
+      endpoint: path,
+      category: category,
+      action: action,
+      payload: payload
+    }
+  end
+
+  defp validate_required_key(params, :chat_id), do: validate_chat_id(value(params, :chat_id))
+
+  defp validate_required_key(params, :from_chat_id),
+    do: validate_chat_id(value(params, :from_chat_id))
+
+  defp validate_required_key(params, :user_id),
+    do: validate_integer(value(params, :user_id), :user_id)
+
+  defp validate_required_key(params, :sender_chat_id),
+    do: validate_integer(value(params, :sender_chat_id), :sender_chat_id)
+
+  defp validate_required_key(params, :message_id),
+    do: validate_integer(value(params, :message_id), :message_id)
+
+  defp validate_required_key(params, :message_ids),
+    do: validate_message_ids(value(params, :message_ids))
+
+  defp validate_required_key(params, :slow_mode_delay) do
+    case validate_integer(value(params, :slow_mode_delay), :slow_mode_delay) do
+      {:ok, delay} when delay in 0..36_000 -> {:ok, delay}
+      {:ok, _delay} -> {:error, "slow_mode_delay must be between 0 and 36000"}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp validate_required_key(params, :is_forum) do
+    case value(params, :is_forum) do
+      value when is_boolean(value) -> {:ok, value}
+      _ -> {:error, "Missing or invalid is_forum"}
+    end
+  end
+
+  defp validate_required_key(params, :description),
+    do: validate_string(value(params, :description), :description, allow_empty?: true)
+
+  defp validate_required_key(params, key),
+    do: validate_string(value(params, key), key, allow_empty?: false)
+
+  defp validate_chat_id(value) when is_integer(value), do: {:ok, value}
+
+  defp validate_chat_id(value) when is_binary(value) do
+    if String.trim(value) == "" do
+      {:error, "Missing or invalid chat_id"}
+    else
+      {:ok, value}
+    end
+  end
+
+  defp validate_chat_id(_value), do: {:error, "Missing or invalid chat_id"}
+
+  defp validate_integer(value, _key) when is_integer(value), do: {:ok, value}
+  defp validate_integer(_value, key), do: {:error, "Missing or invalid #{key}"}
+
+  defp validate_message_ids(message_ids) when is_list(message_ids) do
+    cond do
+      message_ids == [] ->
+        {:error, "message_ids must include between 1 and 100 message ids"}
+
+      length(message_ids) > 100 ->
+        {:error, "message_ids must include between 1 and 100 message ids"}
+
+      Enum.all?(message_ids, &is_integer/1) ->
+        {:ok, message_ids}
+
+      true ->
+        {:error, "message_ids must contain only integers"}
+    end
+  end
+
+  defp validate_message_ids(_message_ids), do: {:error, "Missing or invalid message_ids"}
+
+  defp validate_string(value, _key, allow_empty?: true) when is_binary(value), do: {:ok, value}
+
+  defp validate_string(value, key, allow_empty?: false) when is_binary(value) do
+    if String.trim(value) == "" do
+      {:error, "Missing or invalid #{key}"}
+    else
+      {:ok, value}
+    end
+  end
+
+  defp validate_string(_value, key, _opts), do: {:error, "Missing or invalid #{key}"}
+
+  defp resolve_permissions(params, default_template) do
+    raw_permissions = value(params, :permissions)
+    template = value(params, :permission_template) || default_template
+
+    cond do
+      is_map(raw_permissions) ->
+        normalize_flag_map(raw_permissions, @permission_keys, "permissions")
+
+      not is_nil(template) ->
+        permission_template(template)
+
+      true ->
+        {:error, "Missing or invalid permissions"}
+    end
+  end
+
+  defp resolve_admin_rights(params, default_template) do
+    raw_rights = value(params, :admin_rights) || value(params, :rights)
+    template = value(params, :admin_template) || default_template
+
+    cond do
+      is_map(raw_rights) ->
+        normalize_flag_map(raw_rights, @admin_permission_keys, "admin_rights")
+
+      not is_nil(template) ->
+        admin_template(template)
+
+      true ->
+        {:error, "Missing or invalid admin_rights"}
+    end
+  end
+
+  defp normalize_flag_map(raw, allowed_keys, label) do
+    result =
+      Enum.reduce_while(allowed_keys, {:ok, %{}}, fn key, {:ok, acc} ->
+        case fetch_value(raw, key) do
+          {:ok, value} when is_boolean(value) -> {:cont, {:ok, Map.put(acc, key, value)}}
+          {:ok, nil} -> {:cont, {:ok, acc}}
+          {:ok, _value} -> {:halt, {:error, "#{label}.#{key} must be a boolean"}}
+          :error -> {:cont, {:ok, acc}}
+        end
+      end)
+
+    case result do
+      {:ok, flags} when map_size(flags) > 0 -> {:ok, flags}
+      {:ok, _flags} -> {:error, "#{label} must include at least one supported flag"}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp normalize_action(action) when is_atom(action) do
+    if action in @actions do
+      {:ok, action}
+    else
+      {:error, "Unsupported Telegram group action: #{inspect(action)}"}
+    end
+  end
+
+  defp normalize_action(action) when is_binary(action) do
+    action
+    |> String.trim()
+    |> String.replace("-", "_")
+    |> then(fn key ->
+      case Map.fetch(@action_aliases, key) do
+        {:ok, action} -> {:ok, action}
+        :error -> {:error, "Unsupported Telegram group action: #{inspect(action)}"}
+      end
+    end)
+  end
+
+  defp normalize_action(action),
+    do: {:error, "Unsupported Telegram group action: #{inspect(action)}"}
+
+  defp normalize_action_name(action) do
+    case normalize_action(action) do
+      {:ok, normalized} -> Atom.to_string(normalized)
+      {:error, _reason} when is_binary(action) -> action
+      {:error, _reason} -> inspect(action)
+    end
+  end
+
+  defp normalize_template(template)
+       when template in [:standard, :media_limited, :read_only, :announcement, :no_links],
+       do: {:ok, template}
+
+  defp normalize_template(template) when is_binary(template) do
+    case String.replace(template, "-", "_") do
+      "standard" -> {:ok, :standard}
+      "media_limited" -> {:ok, :media_limited}
+      "read_only" -> {:ok, :read_only}
+      "announcement" -> {:ok, :announcement}
+      "no_links" -> {:ok, :no_links}
+      _ -> {:error, "Unsupported permission template: #{inspect(template)}"}
+    end
+  end
+
+  defp normalize_template(template),
+    do: {:error, "Unsupported permission template: #{inspect(template)}"}
+
+  defp normalize_admin_template(template)
+       when template in [:none, :moderator, :publisher, :community_manager],
+       do: {:ok, template}
+
+  defp normalize_admin_template(template) when is_binary(template) do
+    case String.replace(template, "-", "_") do
+      "none" -> {:ok, :none}
+      "moderator" -> {:ok, :moderator}
+      "publisher" -> {:ok, :publisher}
+      "community_manager" -> {:ok, :community_manager}
+      _ -> {:error, "Unsupported admin template: #{inspect(template)}"}
+    end
+  end
+
+  defp normalize_admin_template(template),
+    do: {:error, "Unsupported admin template: #{inspect(template)}"}
+
+  defp normalize_moderation_action(action)
+       when action in [:none, :warn_member, :delete_message, :restrict_member, :ban_member],
+       do: {:ok, action}
+
+  defp normalize_moderation_action(action) when is_binary(action) do
+    case String.replace(action, "-", "_") do
+      "none" -> {:ok, :none}
+      "warn_member" -> {:ok, :warn_member}
+      "delete_message" -> {:ok, :delete_message}
+      "restrict_member" -> {:ok, :restrict_member}
+      "ban_member" -> {:ok, :ban_member}
+      _ -> :error
+    end
+  end
+
+  defp normalize_moderation_action(_action), do: :error
+
+  defp take_params(params, keys) do
+    Enum.reduce(keys, %{}, fn key, acc ->
+      case fetch_value(params, key) do
+        {:ok, nil} -> acc
+        {:ok, value} -> Map.put(acc, key, value)
+        :error -> acc
+      end
+    end)
+  end
+
+  defp fetch_value(params, key) when is_map(params) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(params, key) -> {:ok, Map.get(params, key)}
+      Map.has_key?(params, string_key) -> {:ok, Map.get(params, string_key)}
+      true -> :error
+    end
+  end
+
+  defp fetch_value(_params, _key), do: :error
+
+  defp value(params, key, default \\ nil) do
+    case fetch_value(params, key) do
+      {:ok, value} -> value
+      :error -> default
+    end
+  end
+
+  defp list_value(params, key) do
+    case value(params, key, []) do
+      values when is_list(values) -> values
+      value when is_binary(value) -> [value]
+      _ -> []
+    end
+  end
+
+  defp boolean_value(params, key, default) do
+    case value(params, key, default) do
+      value when is_boolean(value) -> value
+      _ -> default
+    end
+  end
+
+  defp compact(map) do
+    map
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp maybe_add(values, nil), do: values
+  defp maybe_add(values, value), do: values ++ [value]
+
+  defp optional_segment(_name, nil), do: nil
+  defp optional_segment(name, value), do: "#{name}=#{value}"
+
+  defp normalize_opts(opts) when is_map(opts), do: opts
+  defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
+end

--- a/lux/lib/lux/integrations/telegram/group_manager.ex
+++ b/lux/lib/lux/integrations/telegram/group_manager.ex
@@ -456,6 +456,15 @@ defmodule Lux.Integrations.Telegram.GroupManager do
     delete_message: [:can_delete_messages]
   }
 
+  # Admin rights whose presence we insist on verifying before executing a
+  # destructive operation (ban/restrict/promote/delete paths). When none of
+  # these are required, an action is treated as non-destructive.
+  @destructive_rights [:can_restrict_members, :can_promote_members, :can_delete_messages]
+
+  # Actions whose Telegram permission model is not fully captured by chat
+  # administrator rights and therefore warrant an explicit capability note.
+  @sticker_set_actions [:set_sticker_set, :delete_sticker_set]
+
   @doc "Returns every operation accepted by `plan/2`."
   @spec known_actions() :: [atom()]
   def known_actions, do: @actions
@@ -641,12 +650,14 @@ defmodule Lux.Integrations.Telegram.GroupManager do
   """
   @spec execute(map(), map() | keyword()) :: {:ok, map()} | {:error, map()}
   def execute(%{requests: requests} = plan, opts \\ %{}) when is_list(requests) do
-    case preflight_execution_error(plan) do
+    normalized_opts = normalize_opts(opts)
+
+    case preflight_execution_error(plan, normalized_opts) do
       {:error, _} = error ->
         error
 
       :ok ->
-        execute_requests(plan, requests, normalize_opts(opts))
+        execute_requests(plan, requests, normalized_opts)
     end
   end
 
@@ -702,6 +713,7 @@ defmodule Lux.Integrations.Telegram.GroupManager do
       request = request(spec.category, action, spec.path, payload)
       audit = audit_entry(action, Map.put(params, :category, spec.category), %{planned: true})
       requests = [request] ++ audit_log_requests(audit, params, params)
+      preflight = preflight_admin_rights!(action, params)
 
       {:ok,
        %{
@@ -709,7 +721,8 @@ defmodule Lux.Integrations.Telegram.GroupManager do
          category: spec.category,
          request_count: length(requests),
          requests: requests,
-         preflight: preflight_admin_rights!(action, params),
+         preflight: preflight,
+         warnings: build_warnings(preflight),
          audit_entry: audit
        }}
     end
@@ -785,6 +798,7 @@ defmodule Lux.Integrations.Telegram.GroupManager do
         )
 
       requests = base_requests ++ audit_log_requests(audit, params, policy)
+      preflight = moderation_preflight_admin_rights(moderation_action, params)
 
       {:ok,
        %{
@@ -796,7 +810,8 @@ defmodule Lux.Integrations.Telegram.GroupManager do
          violations: violations,
          request_count: length(requests),
          requests: requests,
-         preflight: moderation_preflight_admin_rights(moderation_action, params),
+         preflight: preflight,
+         warnings: build_warnings(preflight),
          audit_entry: audit
        }}
     end
@@ -815,6 +830,7 @@ defmodule Lux.Integrations.Telegram.GroupManager do
       |> Map.put(:category, :admin_logging)
 
     requests = audit_log_requests(audit, params, params)
+    preflight = preflight_admin_rights!(:log_admin_action, params)
 
     {:ok,
      %{
@@ -822,7 +838,8 @@ defmodule Lux.Integrations.Telegram.GroupManager do
        category: :admin_logging,
        request_count: length(requests),
        requests: requests,
-       preflight: preflight_admin_rights!(:log_admin_action, params),
+       preflight: preflight,
+       warnings: build_warnings(preflight),
        audit_entry: audit
      }}
   end
@@ -1493,6 +1510,7 @@ defmodule Lux.Integrations.Telegram.GroupManager do
     required_rights = Enum.uniq(required_rights)
     available_rights = value(params, :bot_admin_rights)
     configured = is_map(available_rights)
+    destructive? = Enum.any?(required_rights, &(&1 in @destructive_rights))
 
     missing_rights =
       if configured do
@@ -1505,10 +1523,39 @@ defmodule Lux.Integrations.Telegram.GroupManager do
       action: action,
       required_rights: required_rights,
       configured: configured,
+      destructive: destructive?,
+      # `verified` is only true when the caller supplied bot_admin_rights AND
+      # every required right is present. It stays false when rights are absent,
+      # so destructive execution cannot silently proceed unverified.
+      verified: configured and missing_rights == [],
       ok: missing_rights == [],
       missing_rights: missing_rights
     }
   end
+
+  defp build_warnings(preflight) do
+    []
+    |> maybe_add(unverified_admin_warning(preflight))
+    |> maybe_add(sticker_set_warning(Map.get(preflight, :action)))
+  end
+
+  defp unverified_admin_warning(%{destructive: true, verified: false} = preflight) do
+    rights = Enum.map_join(Map.get(preflight, :required_rights, []), ", ", &Atom.to_string/1)
+
+    "Destructive action #{Map.get(preflight, :action)} has unverified bot admin rights " <>
+      "(#{rights}). Execution is blocked unless bot_admin_rights confirm these rights or " <>
+      "allow_unverified_admin_rights: true is passed."
+  end
+
+  defp unverified_admin_warning(_preflight), do: nil
+
+  defp sticker_set_warning(action) when action in @sticker_set_actions do
+    "#{action} may also require the chat-level can_set_sticker_set capability, which is only " <>
+      "observable through getChat and is not part of bot_admin_rights. Verify it before live " <>
+      "execution."
+  end
+
+  defp sticker_set_warning(_action), do: nil
 
   defp right_enabled?(rights, right) do
     case fetch_value(rights, right) do
@@ -1518,46 +1565,69 @@ defmodule Lux.Integrations.Telegram.GroupManager do
   end
 
   defp execute_requests(plan, requests, opts) do
-    results =
-      Enum.map(requests, fn request ->
-        request_opts =
-          opts
-          |> take_params([:plug, :token])
-          |> Map.put(:json, Map.get(request, :payload, %{}))
+    base_opts = take_params(opts, [:plug, :token])
+
+    # Execute requests in order and stop at the first failure so a partial
+    # plan (e.g. delete + ban + audit log) cannot deliver a later audit-log
+    # message implying the earlier destructive request succeeded.
+    {results, halted?} =
+      Enum.reduce_while(requests, {[], false}, fn request, {acc, _halted?} ->
+        request_opts = Map.put(base_opts, :json, Map.get(request, :payload, %{}))
 
         case Client.request(request.method, request.path, request_opts) do
-          {:ok, response} -> {:ok, %{request: request, response: response}}
-          {:error, error} -> {:error, %{request: request, error: error}}
+          {:ok, response} ->
+            {:cont, {acc ++ [{:ok, %{request: request, response: response}}], false}}
+
+          {:error, error} ->
+            {:halt, {acc ++ [{:error, %{request: request, error: error}}], true}}
         end
       end)
 
-    if Enum.all?(results, &match?({:ok, _}, &1)) do
+    if halted? do
+      {:error, %{plan: plan, results: results}}
+    else
       {:ok,
        plan
        |> Map.put(:executed, true)
        |> Map.put(:results, Enum.map(results, fn {:ok, result} -> result end))}
-    else
-      {:error, %{plan: plan, results: results}}
     end
   end
 
-  defp preflight_execution_error(%{preflight: %{configured: true, ok: false} = preflight} = plan) do
-    missing = Enum.map_join(Map.fetch!(preflight, :missing_rights), ", ", &Atom.to_string/1)
+  defp preflight_execution_error(%{preflight: preflight} = plan, opts) when is_map(preflight) do
+    cond do
+      Map.get(preflight, :configured) and not Map.get(preflight, :ok, true) ->
+        missing = Enum.map_join(Map.get(preflight, :missing_rights, []), ", ", &Atom.to_string/1)
+        execution_block(plan, "Missing required Telegram admin rights: #{missing}")
 
-    {:error,
-     %{
-       plan: plan,
-       results: [
-         {:error,
-          %{
-            request: nil,
-            error: "Missing required Telegram admin rights: #{missing}"
-          }}
-       ]
-     }}
+      Map.get(preflight, :destructive) and not Map.get(preflight, :verified) and
+          not allow_unverified_admin_rights?(opts) ->
+        required =
+          Enum.map_join(Map.get(preflight, :required_rights, []), ", ", &Atom.to_string/1)
+
+        execution_block(
+          plan,
+          "Refusing to execute destructive Telegram action " <>
+            "#{Map.get(preflight, :action)} without verified bot_admin_rights. Provide " <>
+            "bot_admin_rights confirming #{required} or pass allow_unverified_admin_rights: true."
+        )
+
+      true ->
+        :ok
+    end
   end
 
-  defp preflight_execution_error(_plan), do: :ok
+  defp preflight_execution_error(_plan, _opts), do: :ok
+
+  defp execution_block(plan, message) do
+    {:error, %{plan: plan, results: [{:error, %{request: nil, error: message}}]}}
+  end
+
+  defp allow_unverified_admin_rights?(opts) do
+    case fetch_value(opts, :allow_unverified_admin_rights) do
+      {:ok, value} -> value in [true, "true", 1, "1"]
+      :error -> false
+    end
+  end
 
   defp take_params(params, keys) do
     Enum.reduce(keys, %{}, fn key, acc ->

--- a/lux/lib/lux/integrations/telegram/group_manager.ex
+++ b/lux/lib/lux/integrations/telegram/group_manager.ex
@@ -76,7 +76,18 @@ defmodule Lux.Integrations.Telegram.GroupManager do
     :unpin_all_messages,
     :set_sticker_set,
     :delete_sticker_set,
-    :set_forum,
+    :create_forum_topic,
+    :edit_forum_topic,
+    :close_forum_topic,
+    :reopen_forum_topic,
+    :delete_forum_topic,
+    :unpin_all_forum_topic_messages,
+    :edit_general_forum_topic,
+    :close_general_forum_topic,
+    :reopen_general_forum_topic,
+    :hide_general_forum_topic,
+    :unhide_general_forum_topic,
+    :unpin_all_general_forum_topic_messages,
     :send_channel_post,
     :edit_channel_post,
     :edit_channel_caption,
@@ -261,10 +272,76 @@ defmodule Lux.Integrations.Telegram.GroupManager do
       required: [:chat_id],
       optional: []
     },
-    set_forum: %{
+    create_forum_topic: %{
       category: :group_settings,
-      path: "/setChatIsForum",
-      required: [:chat_id, :is_forum],
+      path: "/createForumTopic",
+      required: [:chat_id, :name],
+      optional: [:icon_color, :icon_custom_emoji_id]
+    },
+    edit_forum_topic: %{
+      category: :group_settings,
+      path: "/editForumTopic",
+      required: [:chat_id, :message_thread_id],
+      optional: [:name, :icon_custom_emoji_id]
+    },
+    close_forum_topic: %{
+      category: :group_settings,
+      path: "/closeForumTopic",
+      required: [:chat_id, :message_thread_id],
+      optional: []
+    },
+    reopen_forum_topic: %{
+      category: :group_settings,
+      path: "/reopenForumTopic",
+      required: [:chat_id, :message_thread_id],
+      optional: []
+    },
+    delete_forum_topic: %{
+      category: :group_settings,
+      path: "/deleteForumTopic",
+      required: [:chat_id, :message_thread_id],
+      optional: []
+    },
+    unpin_all_forum_topic_messages: %{
+      category: :group_settings,
+      path: "/unpinAllForumTopicMessages",
+      required: [:chat_id, :message_thread_id],
+      optional: []
+    },
+    edit_general_forum_topic: %{
+      category: :group_settings,
+      path: "/editGeneralForumTopic",
+      required: [:chat_id, :name],
+      optional: []
+    },
+    close_general_forum_topic: %{
+      category: :group_settings,
+      path: "/closeGeneralForumTopic",
+      required: [:chat_id],
+      optional: []
+    },
+    reopen_general_forum_topic: %{
+      category: :group_settings,
+      path: "/reopenGeneralForumTopic",
+      required: [:chat_id],
+      optional: []
+    },
+    hide_general_forum_topic: %{
+      category: :group_settings,
+      path: "/hideGeneralForumTopic",
+      required: [:chat_id],
+      optional: []
+    },
+    unhide_general_forum_topic: %{
+      category: :group_settings,
+      path: "/unhideGeneralForumTopic",
+      required: [:chat_id],
+      optional: []
+    },
+    unpin_all_general_forum_topic_messages: %{
+      category: :group_settings,
+      path: "/unpinAllGeneralForumTopicMessages",
+      required: [:chat_id],
       optional: []
     },
     send_channel_post: %{
@@ -1015,6 +1092,9 @@ defmodule Lux.Integrations.Telegram.GroupManager do
   defp validate_required_key(params, :message_id),
     do: validate_integer(value(params, :message_id), :message_id)
 
+  defp validate_required_key(params, :message_thread_id),
+    do: validate_integer(value(params, :message_thread_id), :message_thread_id)
+
   defp validate_required_key(params, :message_ids),
     do: validate_message_ids(value(params, :message_ids))
 
@@ -1023,13 +1103,6 @@ defmodule Lux.Integrations.Telegram.GroupManager do
       {:ok, delay} when delay in 0..36_000 -> {:ok, delay}
       {:ok, _delay} -> {:error, "slow_mode_delay must be between 0 and 36000"}
       {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp validate_required_key(params, :is_forum) do
-    case value(params, :is_forum) do
-      value when is_boolean(value) -> {:ok, value}
-      _ -> {:error, "Missing or invalid is_forum"}
     end
   end
 

--- a/lux/lib/lux/integrations/telegram/group_manager.ex
+++ b/lux/lib/lux/integrations/telegram/group_manager.ex
@@ -403,9 +403,83 @@ defmodule Lux.Integrations.Telegram.GroupManager do
     }
   }
 
+  @admin_right_requirements %{
+    ban_member: [:can_restrict_members],
+    unban_member: [:can_restrict_members],
+    restrict_member: [:can_restrict_members],
+    promote_member: [:can_promote_members],
+    demote_member: [:can_promote_members],
+    set_admin_title: [:can_promote_members],
+    set_member_tag: [:can_manage_tags],
+    ban_sender_chat: [:can_restrict_members],
+    unban_sender_chat: [:can_restrict_members],
+    get_member: [],
+    get_admins: [],
+    get_member_count: [],
+    set_permissions: [:can_restrict_members],
+    set_title: [:can_change_info],
+    set_description: [:can_change_info],
+    delete_photo: [:can_change_info],
+    set_slow_mode: [:can_restrict_members],
+    create_invite_link: [:can_invite_users],
+    edit_invite_link: [:can_invite_users],
+    revoke_invite_link: [:can_invite_users],
+    approve_join_request: [:can_invite_users],
+    decline_join_request: [:can_invite_users],
+    pin_message: [:can_pin_messages],
+    unpin_message: [:can_pin_messages],
+    unpin_all_messages: [:can_pin_messages],
+    set_sticker_set: [:can_change_info],
+    delete_sticker_set: [:can_change_info],
+    create_forum_topic: [:can_manage_topics],
+    edit_forum_topic: [:can_manage_topics],
+    close_forum_topic: [:can_manage_topics],
+    reopen_forum_topic: [:can_manage_topics],
+    delete_forum_topic: [:can_manage_topics],
+    unpin_all_forum_topic_messages: [:can_manage_topics],
+    edit_general_forum_topic: [:can_manage_topics],
+    close_general_forum_topic: [:can_manage_topics],
+    reopen_general_forum_topic: [:can_manage_topics],
+    hide_general_forum_topic: [:can_manage_topics],
+    unhide_general_forum_topic: [:can_manage_topics],
+    unpin_all_general_forum_topic_messages: [:can_manage_topics],
+    send_channel_post: [:can_post_messages],
+    edit_channel_post: [:can_edit_messages],
+    edit_channel_caption: [:can_edit_messages],
+    delete_channel_post: [:can_delete_messages],
+    delete_messages: [:can_delete_messages],
+    forward_channel_post: [:can_post_messages],
+    copy_channel_post: [:can_post_messages],
+    moderate_message: [:can_delete_messages],
+    log_admin_action: [],
+    warn_member: [],
+    delete_message: [:can_delete_messages]
+  }
+
   @doc "Returns every operation accepted by `plan/2`."
   @spec known_actions() :: [atom()]
   def known_actions, do: @actions
+
+  @doc """
+  Returns the Telegram administrator rights that should be present before executing an action.
+  """
+  @spec required_admin_rights(atom() | String.t()) :: {:ok, [atom()]} | {:error, String.t()}
+  def required_admin_rights(action) do
+    with {:ok, normalized_action} <- normalize_preflight_action(action) do
+      {:ok, Map.get(@admin_right_requirements, normalized_action, [])}
+    end
+  end
+
+  @doc """
+  Builds a preflight summary for a planned action using optional `bot_admin_rights`.
+  """
+  @spec preflight_admin_rights(atom() | String.t(), map()) :: {:ok, map()} | {:error, String.t()}
+  def preflight_admin_rights(action, params \\ %{}) do
+    with {:ok, normalized_action} <- normalize_preflight_action(action),
+         {:ok, required_rights} <- required_admin_rights(normalized_action) do
+      {:ok, build_preflight(normalized_action, required_rights, params)}
+    end
+  end
 
   @doc """
   Returns a named `ChatPermissions` template.
@@ -567,28 +641,12 @@ defmodule Lux.Integrations.Telegram.GroupManager do
   """
   @spec execute(map(), map() | keyword()) :: {:ok, map()} | {:error, map()}
   def execute(%{requests: requests} = plan, opts \\ %{}) when is_list(requests) do
-    opts = normalize_opts(opts)
+    case preflight_execution_error(plan) do
+      {:error, _} = error ->
+        error
 
-    results =
-      Enum.map(requests, fn request ->
-        request_opts =
-          opts
-          |> take_params([:plug, :token])
-          |> Map.put(:json, Map.get(request, :payload, %{}))
-
-        case Client.request(request.method, request.path, request_opts) do
-          {:ok, response} -> {:ok, %{request: request, response: response}}
-          {:error, error} -> {:error, %{request: request, error: error}}
-        end
-      end)
-
-    if Enum.all?(results, &match?({:ok, _}, &1)) do
-      {:ok,
-       plan
-       |> Map.put(:executed, true)
-       |> Map.put(:results, Enum.map(results, fn {:ok, result} -> result end))}
-    else
-      {:error, %{plan: plan, results: results}}
+      :ok ->
+        execute_requests(plan, requests, normalize_opts(opts))
     end
   end
 
@@ -642,15 +700,17 @@ defmodule Lux.Integrations.Telegram.GroupManager do
 
     with {:ok, payload} <- build_payload(action, spec, params) do
       request = request(spec.category, action, spec.path, payload)
+      audit = audit_entry(action, Map.put(params, :category, spec.category), %{planned: true})
+      requests = [request] ++ audit_log_requests(audit, params, params)
 
       {:ok,
        %{
          action: action,
          category: spec.category,
-         request_count: 1,
-         requests: [request],
-         audit_entry:
-           audit_entry(action, Map.put(params, :category, spec.category), %{planned: true})
+         request_count: length(requests),
+         requests: requests,
+         preflight: preflight_admin_rights!(action, params),
+         audit_entry: audit
        }}
     end
   end
@@ -736,6 +796,7 @@ defmodule Lux.Integrations.Telegram.GroupManager do
          violations: violations,
          request_count: length(requests),
          requests: requests,
+         preflight: moderation_preflight_admin_rights(moderation_action, params),
          audit_entry: audit
        }}
     end
@@ -761,6 +822,7 @@ defmodule Lux.Integrations.Telegram.GroupManager do
        category: :admin_logging,
        request_count: length(requests),
        requests: requests,
+       preflight: preflight_admin_rights!(:log_admin_action, params),
        audit_entry: audit
      }}
   end
@@ -780,6 +842,9 @@ defmodule Lux.Integrations.Telegram.GroupManager do
          uppercase_ratio: value(policy, :uppercase_ratio, 0.85),
          min_uppercase_length: value(policy, :min_uppercase_length, 24),
          max_recent_messages: value(policy, :max_recent_messages),
+         max_recent_links: value(policy, :max_recent_links),
+         duplicate_threshold: value(policy, :duplicate_threshold),
+         window_seconds: value(policy, :window_seconds, 60),
          warning_text:
            value(policy, :warning_text, "Please keep the conversation within the group rules."),
          log_chat_id: value(policy, :log_chat_id) || value(params, :log_chat_id),
@@ -803,7 +868,9 @@ defmodule Lux.Integrations.Telegram.GroupManager do
         |> maybe_add(
           uppercase_violation(text, policy.uppercase_ratio, policy.min_uppercase_length)
         )
-        |> maybe_add(rate_violation(params, policy.max_recent_messages))
+        |> maybe_add(rate_violation(params, policy))
+        |> maybe_add(duplicate_message_violation(text, params, policy))
+        |> maybe_add(link_history_violation(text, params, policy))
 
       {:ok, violations}
     end
@@ -849,7 +916,7 @@ defmodule Lux.Integrations.Telegram.GroupManager do
   end
 
   defp link_violation(text, true) do
-    if Regex.match?(~r/(https?:\/\/|www\.|t\.me\/|telegram\.me\/)/iu, text) do
+    if contains_link?(text) do
       %{type: :link, severity: :medium}
     end
   end
@@ -923,9 +990,13 @@ defmodule Lux.Integrations.Telegram.GroupManager do
 
   defp uppercase_violation(_text, _ratio, _min_length), do: nil
 
-  defp rate_violation(params, max_recent_messages)
+  defp rate_violation(params, %{max_recent_messages: max_recent_messages} = policy)
        when is_integer(max_recent_messages) and max_recent_messages >= 0 do
-    recent_count = value(params, :recent_message_count, 0)
+    recent_count =
+      case value(params, :recent_message_count) do
+        count when is_integer(count) -> count
+        _ -> recent_messages(params, policy) |> length()
+      end
 
     if is_integer(recent_count) and recent_count > max_recent_messages do
       %{
@@ -937,7 +1008,105 @@ defmodule Lux.Integrations.Telegram.GroupManager do
     end
   end
 
-  defp rate_violation(_params, _max_recent_messages), do: nil
+  defp rate_violation(_params, _policy), do: nil
+
+  defp duplicate_message_violation(text, params, %{duplicate_threshold: threshold} = policy)
+       when is_integer(threshold) and threshold > 0 do
+    normalized_text = normalize_message_text(text)
+
+    recent_duplicate_count =
+      params
+      |> recent_messages(policy)
+      |> Enum.count(fn message ->
+        normalize_message_text(value(message, :text, "")) == normalized_text
+      end)
+
+    if normalized_text != "" and recent_duplicate_count + 1 > threshold do
+      %{
+        type: :duplicate_message,
+        recent_duplicate_count: recent_duplicate_count,
+        duplicate_threshold: threshold,
+        severity: :medium
+      }
+    end
+  end
+
+  defp duplicate_message_violation(_text, _params, _policy), do: nil
+
+  defp link_history_violation(text, params, %{max_recent_links: max_recent_links} = policy)
+       when is_integer(max_recent_links) and max_recent_links >= 0 do
+    recent_link_count =
+      params
+      |> recent_messages(policy)
+      |> Enum.count(fn message -> contains_link?(value(message, :text, "")) end)
+
+    link_count =
+      if contains_link?(text) do
+        recent_link_count + 1
+      else
+        recent_link_count
+      end
+
+    if link_count > max_recent_links do
+      %{
+        type: :link_history,
+        recent_link_count: recent_link_count,
+        max_recent_links: max_recent_links,
+        severity: :medium
+      }
+    end
+  end
+
+  defp link_history_violation(_text, _params, _policy), do: nil
+
+  defp recent_messages(params, policy) do
+    params
+    |> list_value(:recent_messages)
+    |> Enum.filter(fn message ->
+      is_map(message) and
+        message_matches_context?(message, params) and
+        message_in_window?(message, policy.window_seconds)
+    end)
+  end
+
+  defp message_matches_context?(message, params) do
+    context_value_matches?(message, params, :chat_id) and
+      context_value_matches?(message, params, :user_id)
+  end
+
+  defp context_value_matches?(message, params, key) do
+    case {fetch_value(message, key), fetch_value(params, key)} do
+      {{:ok, left}, {:ok, right}} -> left == right
+      _ -> true
+    end
+  end
+
+  defp message_in_window?(message, window_seconds)
+       when is_integer(window_seconds) and window_seconds >= 0 do
+    case value(message, :age_seconds) do
+      age_seconds when is_integer(age_seconds) and age_seconds >= 0 ->
+        age_seconds <= window_seconds
+
+      _ ->
+        true
+    end
+  end
+
+  defp message_in_window?(_message, _window_seconds), do: true
+
+  defp normalize_message_text(text) when is_binary(text) do
+    text
+    |> String.trim()
+    |> String.downcase()
+  end
+
+  defp normalize_message_text(_text), do: ""
+
+  defp contains_link?(text) when is_binary(text) do
+    Regex.match?(~r/(https?:\/\/|www\.|t\.me\/|telegram\.me\/)/iu, text)
+  end
+
+  defp contains_link?(_text), do: false
 
   defp moderation_severity([]), do: :none
 
@@ -1230,6 +1399,19 @@ defmodule Lux.Integrations.Telegram.GroupManager do
   defp normalize_action(action),
     do: {:error, "Unsupported Telegram group action: #{inspect(action)}"}
 
+  defp normalize_preflight_action(action) do
+    case normalize_action(action) do
+      {:ok, normalized} ->
+        {:ok, normalized}
+
+      {:error, _reason} ->
+        case normalize_moderation_action(action) do
+          {:ok, normalized} -> {:ok, normalized}
+          :error -> {:error, "Unsupported Telegram group action: #{inspect(action)}"}
+        end
+    end
+  end
+
   defp normalize_action_name(action) do
     case normalize_action(action) do
       {:ok, normalized} -> Atom.to_string(normalized)
@@ -1289,6 +1471,93 @@ defmodule Lux.Integrations.Telegram.GroupManager do
   end
 
   defp normalize_moderation_action(_action), do: :error
+
+  defp preflight_admin_rights!(action, params) do
+    {:ok, preflight} = preflight_admin_rights(action, params)
+    preflight
+  end
+
+  defp moderation_preflight_admin_rights(:restrict_member, params) do
+    build_preflight(:restrict_member, [:can_delete_messages, :can_restrict_members], params)
+  end
+
+  defp moderation_preflight_admin_rights(:ban_member, params) do
+    build_preflight(:ban_member, [:can_delete_messages, :can_restrict_members], params)
+  end
+
+  defp moderation_preflight_admin_rights(action, params) do
+    preflight_admin_rights!(action, params)
+  end
+
+  defp build_preflight(action, required_rights, params) do
+    required_rights = Enum.uniq(required_rights)
+    available_rights = value(params, :bot_admin_rights)
+    configured = is_map(available_rights)
+
+    missing_rights =
+      if configured do
+        Enum.reject(required_rights, &right_enabled?(available_rights, &1))
+      else
+        []
+      end
+
+    %{
+      action: action,
+      required_rights: required_rights,
+      configured: configured,
+      ok: missing_rights == [],
+      missing_rights: missing_rights
+    }
+  end
+
+  defp right_enabled?(rights, right) do
+    case fetch_value(rights, right) do
+      {:ok, true} -> true
+      _ -> false
+    end
+  end
+
+  defp execute_requests(plan, requests, opts) do
+    results =
+      Enum.map(requests, fn request ->
+        request_opts =
+          opts
+          |> take_params([:plug, :token])
+          |> Map.put(:json, Map.get(request, :payload, %{}))
+
+        case Client.request(request.method, request.path, request_opts) do
+          {:ok, response} -> {:ok, %{request: request, response: response}}
+          {:error, error} -> {:error, %{request: request, error: error}}
+        end
+      end)
+
+    if Enum.all?(results, &match?({:ok, _}, &1)) do
+      {:ok,
+       plan
+       |> Map.put(:executed, true)
+       |> Map.put(:results, Enum.map(results, fn {:ok, result} -> result end))}
+    else
+      {:error, %{plan: plan, results: results}}
+    end
+  end
+
+  defp preflight_execution_error(%{preflight: %{configured: true, ok: false} = preflight} = plan) do
+    missing = Enum.map_join(Map.fetch!(preflight, :missing_rights), ", ", &Atom.to_string/1)
+
+    {:error,
+     %{
+       plan: plan,
+       results: [
+         {:error,
+          %{
+            request: nil,
+            error: "Missing required Telegram admin rights: #{missing}"
+          }}
+       ]
+     }}
+  end
+
+  defp preflight_execution_error(_plan), do: :ok
 
   defp take_params(params, keys) do
     Enum.reduce(keys, %{}, fn key, acc ->

--- a/lux/lib/lux/prisms/telegram/group/manage_group.ex
+++ b/lux/lib/lux/prisms/telegram/group/manage_group.ex
@@ -35,7 +35,18 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroup do
     unpin_all_messages
     set_sticker_set
     delete_sticker_set
-    set_forum
+    create_forum_topic
+    edit_forum_topic
+    close_forum_topic
+    reopen_forum_topic
+    delete_forum_topic
+    unpin_all_forum_topic_messages
+    edit_general_forum_topic
+    close_general_forum_topic
+    reopen_general_forum_topic
+    hide_general_forum_topic
+    unhide_general_forum_topic
+    unpin_all_general_forum_topic_messages
     send_channel_post
     edit_channel_post
     edit_channel_caption
@@ -88,9 +99,25 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroup do
           type: :array,
           description: "Message ids for bulk deleteMessages moderation"
         },
+        message_thread_id: %{
+          type: :integer,
+          description: "Target forum topic message thread id"
+        },
         text: %{
           type: :string,
           description: "Message text or content to evaluate for moderation"
+        },
+        name: %{
+          type: :string,
+          description: "Invite link name or forum topic name"
+        },
+        icon_color: %{
+          type: :integer,
+          description: "Forum topic icon RGB color accepted by Telegram"
+        },
+        icon_custom_emoji_id: %{
+          type: :string,
+          description: "Custom emoji id used for a forum topic icon"
         },
         caption: %{
           type: :string,

--- a/lux/lib/lux/prisms/telegram/group/manage_group.ex
+++ b/lux/lib/lux/prisms/telegram/group/manage_group.ex
@@ -1,0 +1,247 @@
+defmodule Lux.Prisms.Telegram.Group.ManageGroup do
+  @moduledoc """
+  A prism for planning and executing Telegram group/channel administration.
+
+  The prism exposes member management, permission updates, moderation, spam
+  protection, group settings, channel posts, and admin audit logging through one
+  normalized action surface.
+  """
+
+  @action_values ~w(
+    ban_member
+    unban_member
+    restrict_member
+    promote_member
+    demote_member
+    set_admin_title
+    set_member_tag
+    ban_sender_chat
+    unban_sender_chat
+    get_member
+    get_admins
+    get_member_count
+    set_permissions
+    set_title
+    set_description
+    delete_photo
+    set_slow_mode
+    create_invite_link
+    edit_invite_link
+    revoke_invite_link
+    approve_join_request
+    decline_join_request
+    pin_message
+    unpin_message
+    unpin_all_messages
+    set_sticker_set
+    delete_sticker_set
+    set_forum
+    send_channel_post
+    edit_channel_post
+    edit_channel_caption
+    delete_channel_post
+    delete_messages
+    forward_channel_post
+    copy_channel_post
+    moderate_message
+    log_admin_action
+  )
+
+  use Lux.Prism,
+    name: "Manage Telegram Group",
+    description:
+      "Plans or executes Telegram group and channel administration actions with moderation and audit logging support",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        action: %{
+          type: :string,
+          description: "Telegram group management action to plan or execute",
+          enum: @action_values
+        },
+        execute: %{
+          type: :boolean,
+          description:
+            "When true, executes planned Telegram Bot API requests through Lux.Integrations.Telegram.Client"
+        },
+        chat_id: %{
+          type: [:string, :integer],
+          description: "Target group, supergroup, or channel id/username"
+        },
+        from_chat_id: %{
+          type: [:string, :integer],
+          description: "Source chat id/username for forwarding or copying channel posts"
+        },
+        user_id: %{
+          type: :integer,
+          description: "Target Telegram user id for member-management actions"
+        },
+        sender_chat_id: %{
+          type: :integer,
+          description: "Target sender chat id for sender-chat ban and unban actions"
+        },
+        message_id: %{
+          type: :integer,
+          description: "Target message id for moderation, pinning, editing, or channel posts"
+        },
+        message_ids: %{
+          type: :array,
+          description: "Message ids for bulk deleteMessages moderation"
+        },
+        text: %{
+          type: :string,
+          description: "Message text or content to evaluate for moderation"
+        },
+        caption: %{
+          type: :string,
+          description: "Channel post caption for edit/copy operations"
+        },
+        tag: %{
+          type: :string,
+          description: "Optional member tag for set_member_tag"
+        },
+        permissions: %{
+          type: :object,
+          description: "Telegram ChatPermissions flags"
+        },
+        permission_template: %{
+          type: :string,
+          description: "Named permission template",
+          enum: ["standard", "media_limited", "read_only", "announcement", "no_links"]
+        },
+        admin_rights: %{
+          type: :object,
+          description: "Telegram administrator rights flags"
+        },
+        admin_template: %{
+          type: :string,
+          description: "Named administrator rights template",
+          enum: ["none", "moderator", "publisher", "community_manager"]
+        },
+        policy: %{
+          type: :object,
+          description: "Content moderation policy"
+        },
+        log_chat_id: %{
+          type: [:string, :integer],
+          description: "Optional chat/channel id that receives admin audit log messages"
+        },
+        plug: %{
+          type: :object,
+          description: "Optional Req.Test plug configuration for local tests"
+        }
+      },
+      required: ["action"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        action: %{
+          type: :string,
+          description: "Normalized Telegram group action"
+        },
+        category: %{
+          type: :string,
+          description: "Management category for the action"
+        },
+        planned: %{
+          type: :boolean,
+          description: "Whether the action was planned successfully"
+        },
+        executed: %{
+          type: :boolean,
+          description: "Whether the planned requests were executed"
+        },
+        request_count: %{
+          type: :integer,
+          description: "Number of Telegram Bot API requests in the plan"
+        },
+        requests: %{
+          type: :array,
+          description: "Planned Telegram Bot API request maps"
+        },
+        audit_entry: %{
+          type: :object,
+          description: "Normalized admin audit entry for the action"
+        }
+      },
+      required: ["action", "planned", "executed", "request_count"]
+    }
+
+  alias Lux.Integrations.Telegram.GroupManager
+  require Logger
+
+  @doc """
+  Plans a Telegram group management action and optionally executes it.
+  """
+  def handler(params, agent) do
+    with {:ok, action} <- fetch_action(params),
+         {:ok, plan} <- GroupManager.plan(action, params) do
+      agent_name = value(agent, :name, "Unknown Agent")
+      Logger.info("Agent #{agent_name} planned Telegram group action #{plan.action}")
+
+      if truthy?(value(params, :execute, false)) do
+        execute_plan(plan, params)
+      else
+        {:ok,
+         plan
+         |> Map.put(:planned, true)
+         |> Map.put(:executed, false)}
+      end
+    end
+  end
+
+  defp execute_plan(plan, params) do
+    execute_opts = take_params(params, [:plug, :token])
+
+    case GroupManager.execute(plan, execute_opts) do
+      {:ok, executed_plan} ->
+        {:ok,
+         executed_plan
+         |> Map.put(:planned, true)
+         |> Map.put(:executed, true)}
+
+      {:error, %{results: results}} ->
+        {:error, "Failed to execute Telegram group action: #{inspect(results)}"}
+    end
+  end
+
+  defp fetch_action(params) do
+    case value(params, :action) do
+      action when is_binary(action) -> {:ok, action}
+      action when is_atom(action) and not is_nil(action) -> {:ok, action}
+      _ -> {:error, "Missing or invalid action"}
+    end
+  end
+
+  defp take_params(params, keys) do
+    Enum.reduce(keys, %{}, fn key, acc ->
+      case fetch_value(params, key) do
+        {:ok, nil} -> acc
+        {:ok, value} -> Map.put(acc, key, value)
+        :error -> acc
+      end
+    end)
+  end
+
+  defp fetch_value(params, key) when is_map(params) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(params, key) -> {:ok, Map.get(params, key)}
+      Map.has_key?(params, string_key) -> {:ok, Map.get(params, string_key)}
+      true -> :error
+    end
+  end
+
+  defp fetch_value(_params, _key), do: :error
+
+  defp value(params, key, default \\ nil) do
+    case fetch_value(params, key) do
+      {:ok, value} -> value
+      :error -> default
+    end
+  end
+
+  defp truthy?(value), do: value in [true, "true", 1, "1"]
+end

--- a/lux/lib/lux/prisms/telegram/group/manage_group.ex
+++ b/lux/lib/lux/prisms/telegram/group/manage_group.ex
@@ -147,7 +147,22 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroup do
         },
         policy: %{
           type: :object,
-          description: "Content moderation policy"
+          description:
+            "Content moderation policy, including optional rate/window thresholds for recent_messages"
+        },
+        recent_messages: %{
+          type: :array,
+          description:
+            "Optional caller-supplied spam history for the same chat/user, with text and optional age_seconds"
+        },
+        recent_message_count: %{
+          type: :integer,
+          description: "Optional precomputed message count for rate-limit moderation checks"
+        },
+        bot_admin_rights: %{
+          type: :object,
+          description:
+            "Optional map of the bot's Telegram administrator rights used for dry-run preflight"
         },
         log_chat_id: %{
           type: [:string, :integer],
@@ -213,7 +228,8 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroup do
         {:ok,
          plan
          |> Map.put(:planned, true)
-         |> Map.put(:executed, false)}
+         |> Map.put(:executed, false)
+         |> normalize_output()}
       end
     end
   end
@@ -226,12 +242,79 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroup do
         {:ok,
          executed_plan
          |> Map.put(:planned, true)
-         |> Map.put(:executed, true)}
+         |> Map.put(:executed, true)
+         |> normalize_output()}
 
       {:error, %{results: results}} ->
         {:error, "Failed to execute Telegram group action: #{inspect(results)}"}
     end
   end
+
+  defp normalize_output(plan) do
+    plan
+    |> stringify_fields([:action, :category, :status, :moderation_action])
+    |> Map.update(:requests, [], &Enum.map(&1, fn request -> normalize_request(request) end))
+    |> Map.update(:audit_entry, %{}, &normalize_audit_entry/1)
+    |> Map.update(:preflight, %{}, &normalize_preflight/1)
+    |> Map.update(
+      :violations,
+      [],
+      &Enum.map(&1, fn violation -> normalize_violation(violation) end)
+    )
+    |> Map.update(:results, [], &Enum.map(&1, fn result -> normalize_result(result) end))
+  end
+
+  defp normalize_request(request) do
+    stringify_fields(request, [:method, :category, :action])
+  end
+
+  defp normalize_audit_entry(audit_entry) do
+    stringify_fields(audit_entry, [:category, :status])
+  end
+
+  defp normalize_preflight(preflight) do
+    preflight
+    |> stringify_fields([:action])
+    |> stringify_atom_list(:required_rights)
+    |> stringify_atom_list(:missing_rights)
+  end
+
+  defp normalize_violation(violation) do
+    stringify_fields(violation, [:type, :severity])
+  end
+
+  defp normalize_result(%{request: request} = result) do
+    Map.put(result, :request, normalize_request(request))
+  end
+
+  defp normalize_result(result), do: result
+
+  defp stringify_fields(map, fields) when is_map(map) do
+    Enum.reduce(fields, map, fn field, acc ->
+      if Map.has_key?(acc, field) do
+        Map.update!(acc, field, &stringify_atom/1)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp stringify_fields(value, _fields), do: value
+
+  defp stringify_atom_list(map, field) when is_map(map) do
+    if Map.has_key?(map, field) do
+      Map.update!(map, field, fn values ->
+        Enum.map(values, &stringify_atom/1)
+      end)
+    else
+      map
+    end
+  end
+
+  defp stringify_atom_list(value, _field), do: value
+
+  defp stringify_atom(value) when is_atom(value), do: Atom.to_string(value)
+  defp stringify_atom(value), do: value
 
   defp fetch_action(params) do
     case value(params, :action) do

--- a/lux/lib/lux/prisms/telegram/group/manage_group.ex
+++ b/lux/lib/lux/prisms/telegram/group/manage_group.ex
@@ -168,6 +168,18 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroup do
           type: [:string, :integer],
           description: "Optional chat/channel id that receives admin audit log messages"
         },
+        token: %{
+          type: :string,
+          description:
+            "Optional Telegram bot token used to authenticate execution. When omitted, the " <>
+              "configured Lux.Integrations.Telegram.Client credentials are used instead."
+        },
+        allow_unverified_admin_rights: %{
+          type: :boolean,
+          description:
+            "When true, permits executing destructive actions (ban/restrict/promote/delete) " <>
+              "without verified bot_admin_rights, bypassing the admin-rights safety gate"
+        },
         plug: %{
           type: :object,
           description: "Optional Req.Test plug configuration for local tests"
@@ -202,6 +214,38 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroup do
           type: :array,
           description: "Planned Telegram Bot API request maps"
         },
+        status: %{
+          type: :string,
+          description: "Moderation outcome for moderate_message plans (clean or flagged)"
+        },
+        severity: %{
+          type: :string,
+          description: "Highest moderation violation severity (none, low, medium, or high)"
+        },
+        moderation_action: %{
+          type: :string,
+          description: "Resolved moderation action for moderate_message plans"
+        },
+        violations: %{
+          type: :array,
+          description: "Normalized moderation violations detected in the evaluated content"
+        },
+        preflight: %{
+          type: :object,
+          description:
+            "Admin-rights preflight summary, including required_rights, configured, destructive, " <>
+              "verified, ok, and missing_rights"
+        },
+        warnings: %{
+          type: :array,
+          description:
+            "Human-readable safety warnings, e.g. unverified destructive rights or sticker-set " <>
+              "capability caveats"
+        },
+        results: %{
+          type: :array,
+          description: "Per-request execution results returned when execute is true"
+        },
         audit_entry: %{
           type: :object,
           description: "Normalized admin audit entry for the action"
@@ -235,7 +279,7 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroup do
   end
 
   defp execute_plan(plan, params) do
-    execute_opts = take_params(params, [:plug, :token])
+    execute_opts = take_params(params, [:plug, :token, :allow_unverified_admin_rights])
 
     case GroupManager.execute(plan, execute_opts) do
       {:ok, executed_plan} ->
@@ -252,7 +296,7 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroup do
 
   defp normalize_output(plan) do
     plan
-    |> stringify_fields([:action, :category, :status, :moderation_action])
+    |> stringify_fields([:action, :category, :status, :severity, :moderation_action])
     |> Map.update(:requests, [], &Enum.map(&1, fn request -> normalize_request(request) end))
     |> Map.update(:audit_entry, %{}, &normalize_audit_entry/1)
     |> Map.update(:preflight, %{}, &normalize_preflight/1)

--- a/lux/test/unit/lux/integrations/telegram/group_manager_test.exs
+++ b/lux/test/unit/lux/integrations/telegram/group_manager_test.exs
@@ -13,6 +13,12 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
   end
 
   describe "permission and admin templates" do
+    test "lists known group management actions" do
+      assert :moderate_message in GroupManager.known_actions()
+      assert :log_admin_action in GroupManager.known_actions()
+      assert :copy_channel_post in GroupManager.known_actions()
+    end
+
     test "builds Telegram ChatPermissions templates with current permission flags" do
       assert {:ok, permissions} = GroupManager.permission_template(:media_limited)
 
@@ -23,6 +29,24 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
       assert Map.has_key?(permissions, :can_edit_tag)
     end
 
+    test "builds standard and announcement permission templates from string names" do
+      assert {:ok, standard} = GroupManager.permission_template("standard")
+      assert standard.can_send_messages == true
+      assert standard.can_react_to_messages == true
+
+      assert {:ok, announcement} = GroupManager.permission_template("announcement")
+      assert announcement.can_send_messages == false
+      assert announcement.can_react_to_messages == true
+    end
+
+    test "rejects unsupported permission templates" do
+      assert {:error, "Unsupported permission template: \"unknown\""} =
+               GroupManager.permission_template("unknown")
+
+      assert {:error, "Unsupported permission template: 123"} =
+               GroupManager.permission_template(123)
+    end
+
     test "builds administrator role templates" do
       assert {:ok, rights} = GroupManager.admin_template("moderator")
 
@@ -31,9 +55,47 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
       assert rights.can_restrict_members == true
       assert rights.can_post_messages == false
     end
+
+    test "builds publisher and community manager administrator templates" do
+      assert {:ok, publisher} = GroupManager.admin_template("publisher")
+      assert publisher.can_post_messages == true
+      assert publisher.can_edit_messages == true
+      assert publisher.can_restrict_members == false
+
+      assert {:ok, community_manager} = GroupManager.admin_template("community-manager")
+      assert community_manager.can_promote_members == true
+      assert community_manager.can_manage_tags == true
+    end
+
+    test "rejects unsupported administrator templates" do
+      assert {:error, "Unsupported admin template: \"owner\""} =
+               GroupManager.admin_template("owner")
+
+      assert {:error, "Unsupported admin template: :owner"} =
+               GroupManager.admin_template(:owner)
+    end
   end
 
   describe "member and permission plans" do
+    test "plans direct member management and lookup actions" do
+      for {action, expected_path, params} <- [
+            {:unban_member, "/unbanChatMember", %{user_id: @user_id, only_if_banned: true}},
+            {:promote_member, "/promoteChatMember",
+             %{user_id: @user_id, admin_template: "publisher"}},
+            {:set_admin_title, "/setChatAdministratorCustomTitle",
+             %{user_id: @user_id, custom_title: "Ops"}},
+            {:unban_sender_chat, "/unbanChatSenderChat", %{sender_chat_id: -100_777_777}},
+            {:get_member, "/getChatMember", %{user_id: @user_id}},
+            {:get_admins, "/getChatAdministrators", %{return_bots: true}},
+            {:get_member_count, "/getChatMemberCount", %{}},
+            {:approve_join_request, "/approveChatJoinRequest", %{user_id: @user_id}},
+            {:decline_join_request, "/declineChatJoinRequest", %{user_id: @user_id}}
+          ] do
+        assert {:ok, plan} = GroupManager.plan(action, Map.put(params, :chat_id, @chat_id))
+        assert [%{path: ^expected_path}] = plan.requests
+      end
+    end
+
     test "plans member restrictions with named permission templates" do
       assert {:ok, plan} =
                GroupManager.plan(:restrict_member, %{
@@ -69,6 +131,24 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
       assert request.payload.can_manage_chat == false
       assert request.payload.can_restrict_members == false
       assert request.payload.can_promote_members == false
+    end
+
+    test "normalizes nil admin flags and explicit rights maps" do
+      assert {:ok, plan} =
+               GroupManager.plan(:promote_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 admin_rights: %{
+                   "can_invite_users" => false,
+                   can_manage_chat: nil,
+                   can_delete_messages: true
+                 }
+               })
+
+      [request] = plan.requests
+      refute Map.has_key?(request.payload, :can_manage_chat)
+      assert request.payload.can_delete_messages == true
+      assert request.payload.can_invite_users == false
     end
 
     test "plans member tags and sender-chat moderation" do
@@ -112,6 +192,28 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
   end
 
   describe "settings and channel post plans" do
+    test "plans chat setting variants and forum/sticker controls" do
+      for {action, expected_path, params} <- [
+            {"set-title", "/setChatTitle", %{title: "Lux Research"}},
+            {:set_description, "/setChatDescription", %{description: ""}},
+            {:delete_photo, "/deleteChatPhoto", %{}},
+            {:set_slow_mode, "/setChatSlowModeDelay", %{slow_mode_delay: 0}},
+            {:edit_invite_link, "/editChatInviteLink",
+             %{invite_link: "https://t.me/+abc", expire_date: 1_766_000_000}},
+            {:revoke_invite_link, "/revokeChatInviteLink", %{invite_link: "https://t.me/+abc"}},
+            {:pin_message, "/pinChatMessage",
+             %{message_id: @message_id, disable_notification: true}},
+            {:unpin_message, "/unpinChatMessage", %{message_id: @message_id}},
+            {:unpin_all_messages, "/unpinAllChatMessages", %{}},
+            {:set_sticker_set, "/setChatStickerSet", %{sticker_set_name: "lux_stickers"}},
+            {:delete_sticker_set, "/deleteChatStickerSet", %{}},
+            {:set_forum, "/setChatIsForum", %{is_forum: true}}
+          ] do
+        assert {:ok, plan} = GroupManager.plan(action, Map.put(params, :chat_id, @chat_id))
+        assert [%{path: ^expected_path}] = plan.requests
+      end
+    end
+
     test "plans group settings and invite link operations" do
       assert {:ok, title_plan} =
                GroupManager.plan(:set_title, %{chat_id: @chat_id, title: "Lux Research"})
@@ -147,6 +249,50 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
         assert {:ok, plan} = GroupManager.plan(action, Map.put(params, :chat_id, @chat_id))
         assert [%{path: ^expected_path}] = plan.requests
       end
+    end
+
+    test "includes optional payload fields for channel post operations" do
+      assert {:ok, edit_caption} =
+               GroupManager.plan(:edit_channel_caption, %{
+                 chat_id: @chat_id,
+                 message_id: @message_id,
+                 caption: "Updated caption",
+                 parse_mode: "Markdown",
+                 caption_entities: [%{type: "bold", offset: 0, length: 7}],
+                 reply_markup: %{inline_keyboard: []}
+               })
+
+      assert [
+               %{
+                 path: "/editMessageCaption",
+                 payload: %{
+                   parse_mode: "Markdown",
+                   caption_entities: [%{type: "bold", offset: 0, length: 7}],
+                   reply_markup: %{inline_keyboard: []}
+                 }
+               }
+             ] = edit_caption.requests
+
+      assert {:ok, copy_plan} =
+               GroupManager.plan(:copy_channel_post, %{
+                 chat_id: @chat_id,
+                 from_chat_id: -100_555_555,
+                 message_id: @message_id,
+                 message_thread_id: 5,
+                 caption: "Copy caption",
+                 protect_content: true
+               })
+
+      assert [
+               %{
+                 path: "/copyMessage",
+                 payload: %{
+                   message_thread_id: 5,
+                   caption: "Copy caption",
+                   protect_content: true
+                 }
+               }
+             ] = copy_plan.requests
     end
   end
 
@@ -205,6 +351,117 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
       assert plan.violations == []
     end
 
+    test "keeps non-matching patterns and disabled link checks clean" do
+      assert {:ok, plan} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 text: "Plain update without a match",
+                 policy: %{
+                   blocked_patterns: ["spam"],
+                   block_links: "not-a-boolean",
+                   blocked_terms: 123
+                 }
+               })
+
+      assert plan.status == :clean
+      assert plan.moderation_action == :none
+      assert plan.violations == []
+    end
+
+    test "uses default low severity warning moderation" do
+      assert {:ok, plan} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 message_id: @message_id,
+                 text: "@alpha_user @bravo_user",
+                 policy: %{
+                   max_mentions: 1,
+                   warning_text: "Please slow down."
+                 }
+               })
+
+      assert plan.severity == :low
+      assert plan.moderation_action == :warn_member
+      assert [%{path: "/sendMessage", payload: payload}] = plan.requests
+      assert payload.text == "Please slow down."
+      assert payload.reply_to_message_id == @message_id
+    end
+
+    test "uses default medium severity deletion moderation" do
+      assert {:ok, plan} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 message_id: @message_id,
+                 text: "This message is too long",
+                 policy: %{max_length: 5}
+               })
+
+      assert plan.severity == :medium
+      assert plan.moderation_action == :delete_message
+      assert [%{path: "/deleteMessage", payload: %{message_id: @message_id}}] = plan.requests
+      assert [%{type: :length, length: 24, max_length: 5}] = plan.violations
+    end
+
+    test "uses default high severity restriction and falls back to delete-only without user id" do
+      assert {:ok, plan} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 message_id: @message_id,
+                 text: "Posting too quickly",
+                 recent_message_count: 5,
+                 policy: %{max_recent_messages: 2}
+               })
+
+      assert plan.severity == :high
+      assert plan.moderation_action == :restrict_member
+      assert [%{path: "/deleteMessage"}] = plan.requests
+
+      assert [%{type: :message_rate, recent_message_count: 5, max_recent_messages: 2}] =
+               plan.violations
+    end
+
+    test "supports explicit moderation action strings and ban fallback without a user id" do
+      assert {:ok, plan} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 message_id: @message_id,
+                 text: "spam.example",
+                 moderation_action: "ban-member",
+                 policy: %{blocked_patterns: ["spam\\.example"]}
+               })
+
+      assert plan.moderation_action == :ban_member
+      assert [%{path: "/deleteMessage"}] = plan.requests
+    end
+
+    test "detects uppercase moderation violations" do
+      assert {:ok, plan} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 text: "LOUD ANNOUNCEMENT",
+                 policy: %{min_uppercase_length: 5, uppercase_ratio: 0.8}
+               })
+
+      assert plan.severity == :low
+      assert [%{type: :uppercase_ratio, severity: :low}] = plan.violations
+    end
+
+    test "rejects invalid moderation policies and non-string blocked patterns" do
+      assert {:error, "policy must be a map"} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 text: "hello",
+                 policy: "strict"
+               })
+
+      assert {:error, "Invalid blocked pattern 123: expected a string"} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 text: "hello",
+                 policy: %{blocked_patterns: [123]}
+               })
+    end
+
     test "plans standalone admin log delivery" do
       assert {:ok, plan} =
                GroupManager.plan(:log_admin_action, %{
@@ -222,6 +479,30 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
       assert payload.chat_id == -100_999
       assert payload.text =~ "action=manual_review"
       assert payload.text =~ "reason=Escalated for moderator review"
+    end
+
+    test "records admin log aliases without delivery chat" do
+      assert {:ok, plan} =
+               GroupManager.plan(:log_admin_action, %{
+                 admin_action: "permissions_reviewed",
+                 chat_id: @chat_id
+               })
+
+      assert plan.request_count == 0
+      assert plan.requests == []
+      assert plan.audit_entry.action == "permissions_reviewed"
+      assert plan.audit_entry.status == :recorded
+    end
+
+    test "records event aliases and unknown audit actions" do
+      assert {:ok, event_plan} =
+               GroupManager.plan(:log_admin_action, %{event: "join_request_reviewed"})
+
+      assert event_plan.audit_entry.action == "join_request_reviewed"
+
+      recorded = GroupManager.audit_entry(:external_tool_action, %{}, %{})
+      assert recorded.action == ":external_tool_action"
+      assert recorded.status == :recorded
     end
   end
 
@@ -253,6 +534,26 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
       assert executed.executed == true
       assert [%{response: %{"result" => true}}] = executed.results
     end
+
+    test "returns execution failures with request context" do
+      Req.Test.expect(TelegramClientMock, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(429, Jason.encode!(%{"description" => "Too Many Requests"}))
+      end)
+
+      assert {:ok, plan} =
+               GroupManager.plan(:ban_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id
+               })
+
+      assert {:error, %{plan: ^plan, results: [{:error, failure}]}} =
+               GroupManager.execute(plan, plug: {Req.Test, TelegramClientMock})
+
+      assert failure.request.path == "/banChatMember"
+      assert failure.error == {429, "Too Many Requests"}
+    end
   end
 
   describe "validation" do
@@ -274,6 +575,81 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
                })
 
       assert message =~ "Invalid blocked pattern"
+    end
+
+    test "rejects invalid actions, aliases, and action types" do
+      assert {:error, "Unsupported Telegram group action: :unknown"} =
+               GroupManager.plan(:unknown, %{})
+
+      assert {:error, "Unsupported Telegram group action: \"missing-action\""} =
+               GroupManager.plan("missing-action", %{})
+
+      assert {:error, "Unsupported Telegram group action: %{bad: :action}"} =
+               GroupManager.plan(%{bad: :action}, %{})
+    end
+
+    test "rejects invalid chat settings and message id payloads" do
+      assert {:error, "Missing or invalid chat_id"} =
+               GroupManager.plan(:set_title, %{chat_id: "", title: "Lux"})
+
+      assert {:error, "Missing or invalid chat_id"} =
+               GroupManager.plan(:set_title, %{title: "Lux"})
+
+      assert {:error, "Missing or invalid title"} =
+               GroupManager.plan(:set_title, %{chat_id: @chat_id, title: ""})
+
+      assert {:error, "Missing or invalid is_forum"} =
+               GroupManager.plan(:set_forum, %{chat_id: @chat_id, is_forum: "yes"})
+
+      assert {:error, "message_ids must include between 1 and 100 message ids"} =
+               GroupManager.plan(:delete_messages, %{chat_id: @chat_id, message_ids: []})
+
+      assert {:error, "message_ids must include between 1 and 100 message ids"} =
+               GroupManager.plan(:delete_messages, %{
+                 chat_id: @chat_id,
+                 message_ids: Enum.to_list(1..101)
+               })
+
+      assert {:error, "Missing or invalid message_ids"} =
+               GroupManager.plan(:delete_messages, %{chat_id: @chat_id, message_ids: "1,2"})
+    end
+
+    test "rejects invalid permission and admin flag maps" do
+      assert {:error, "permissions.can_send_messages must be a boolean"} =
+               GroupManager.plan(:set_permissions, %{
+                 chat_id: @chat_id,
+                 permissions: %{can_send_messages: "yes"}
+               })
+
+      assert {:error, "permissions must include at least one supported flag"} =
+               GroupManager.plan(:set_permissions, %{chat_id: @chat_id, permissions: %{}})
+
+      assert {:error, "Unsupported permission template: \"locked\""} =
+               GroupManager.plan(:set_permissions, %{
+                 chat_id: @chat_id,
+                 permission_template: "locked"
+               })
+
+      assert {:error, "admin_rights.can_manage_chat must be a boolean"} =
+               GroupManager.plan(:promote_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 admin_rights: %{can_manage_chat: "yes"}
+               })
+
+      assert {:error, "admin_rights must include at least one supported flag"} =
+               GroupManager.plan(:promote_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 admin_rights: %{}
+               })
+
+      assert {:error, "Unsupported admin template: \"owner\""} =
+               GroupManager.plan(:promote_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 admin_template: "owner"
+               })
     end
   end
 end

--- a/lux/test/unit/lux/integrations/telegram/group_manager_test.exs
+++ b/lux/test/unit/lux/integrations/telegram/group_manager_test.exs
@@ -1,0 +1,279 @@
+defmodule Lux.Integrations.Telegram.GroupManagerTest do
+  use UnitAPICase, async: true
+
+  alias Lux.Integrations.Telegram.GroupManager
+
+  @chat_id -100_123_456
+  @user_id 987_654
+  @message_id 42
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "permission and admin templates" do
+    test "builds Telegram ChatPermissions templates with current permission flags" do
+      assert {:ok, permissions} = GroupManager.permission_template(:media_limited)
+
+      assert permissions.can_send_messages == true
+      assert permissions.can_send_photos == false
+      assert permissions.can_add_web_page_previews == false
+      assert Map.has_key?(permissions, :can_react_to_messages)
+      assert Map.has_key?(permissions, :can_edit_tag)
+    end
+
+    test "builds administrator role templates" do
+      assert {:ok, rights} = GroupManager.admin_template("moderator")
+
+      assert rights.can_manage_chat == true
+      assert rights.can_delete_messages == true
+      assert rights.can_restrict_members == true
+      assert rights.can_post_messages == false
+    end
+  end
+
+  describe "member and permission plans" do
+    test "plans member restrictions with named permission templates" do
+      assert {:ok, plan} =
+               GroupManager.plan(:restrict_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 permission_template: :read_only,
+                 until_date: 1_766_000_000
+               })
+
+      assert plan.category == :member_management
+      assert plan.request_count == 1
+
+      [request] = plan.requests
+      assert request.method == :post
+      assert request.path == "/restrictChatMember"
+      assert request.payload.chat_id == @chat_id
+      assert request.payload.user_id == @user_id
+      assert request.payload.until_date == 1_766_000_000
+      assert Enum.all?(request.payload.permissions, fn {_key, value} -> value == false end)
+    end
+
+    test "plans demotion by clearing all admin rights through promoteChatMember" do
+      assert {:ok, plan} =
+               GroupManager.plan("demote_member", %{
+                 "chat_id" => @chat_id,
+                 "user_id" => @user_id
+               })
+
+      [request] = plan.requests
+      assert request.path == "/promoteChatMember"
+      assert request.payload.chat_id == @chat_id
+      assert request.payload.user_id == @user_id
+      assert request.payload.can_manage_chat == false
+      assert request.payload.can_restrict_members == false
+      assert request.payload.can_promote_members == false
+    end
+
+    test "plans member tags and sender-chat moderation" do
+      assert {:ok, tag_plan} =
+               GroupManager.plan(:set_member_tag, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 tag: "vip"
+               })
+
+      assert [%{path: "/setChatMemberTag", payload: %{tag: "vip"}}] = tag_plan.requests
+
+      assert {:ok, sender_plan} =
+               GroupManager.plan(:ban_sender_chat, %{
+                 chat_id: @chat_id,
+                 sender_chat_id: -100_777_777
+               })
+
+      assert [%{path: "/banChatSenderChat", payload: %{sender_chat_id: -100_777_777}}] =
+               sender_plan.requests
+    end
+
+    test "plans default chat permission updates" do
+      assert {:ok, plan} =
+               GroupManager.plan(:set_permissions, %{
+                 chat_id: @chat_id,
+                 permissions: %{
+                   "can_send_photos" => false,
+                   can_send_messages: true,
+                   can_add_web_page_previews: false
+                 },
+                 use_independent_chat_permissions: true
+               })
+
+      [request] = plan.requests
+      assert request.path == "/setChatPermissions"
+      assert request.payload.permissions.can_send_messages == true
+      assert request.payload.permissions.can_send_photos == false
+      assert request.payload.use_independent_chat_permissions == true
+    end
+  end
+
+  describe "settings and channel post plans" do
+    test "plans group settings and invite link operations" do
+      assert {:ok, title_plan} =
+               GroupManager.plan(:set_title, %{chat_id: @chat_id, title: "Lux Research"})
+
+      assert [%{path: "/setChatTitle", payload: %{title: "Lux Research"}}] = title_plan.requests
+
+      assert {:ok, invite_plan} =
+               GroupManager.plan(:create_invite_link, %{
+                 chat_id: @chat_id,
+                 name: "moderator-review",
+                 member_limit: 5,
+                 creates_join_request: true
+               })
+
+      [invite_request] = invite_plan.requests
+      assert invite_request.path == "/createChatInviteLink"
+      assert invite_request.payload.name == "moderator-review"
+      assert invite_request.payload.member_limit == 5
+      assert invite_request.payload.creates_join_request == true
+    end
+
+    test "plans channel post create, edit, delete, forward, and copy actions" do
+      for {action, expected_path, params} <- [
+            {:send_channel_post, "/sendMessage", %{text: "Launch update"}},
+            {:edit_channel_post, "/editMessageText", %{message_id: @message_id, text: "Updated"}},
+            {:delete_channel_post, "/deleteMessage", %{message_id: @message_id}},
+            {:delete_messages, "/deleteMessages", %{message_ids: [40, 41, 42]}},
+            {:forward_channel_post, "/forwardMessage",
+             %{from_chat_id: -100_555_555, message_id: @message_id}},
+            {:copy_channel_post, "/copyMessage",
+             %{from_chat_id: -100_555_555, message_id: @message_id}}
+          ] do
+        assert {:ok, plan} = GroupManager.plan(action, Map.put(params, :chat_id, @chat_id))
+        assert [%{path: ^expected_path}] = plan.requests
+      end
+    end
+  end
+
+  describe "moderation and audit logging" do
+    test "builds moderation plans with violations, action requests, and audit log requests" do
+      assert {:ok, plan} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 message_id: @message_id,
+                 admin_id: 111,
+                 text: "FREE money at https://spam.example AAAAAAA",
+                 moderation_action: :restrict_member,
+                 log_chat_id: -100_999,
+                 policy: %{
+                   blocked_terms: ["free money"],
+                   blocked_patterns: ["spam\\.example"],
+                   block_links: true,
+                   max_repeated_chars: 4
+                 }
+               })
+
+      assert plan.status == :flagged
+      assert plan.severity == :high
+      assert plan.moderation_action == :restrict_member
+
+      assert Enum.map(plan.violations, & &1.type) == [
+               :blocked_term,
+               :blocked_pattern,
+               :link,
+               :repeated_characters
+             ]
+
+      assert Enum.map(plan.requests, & &1.path) == [
+               "/deleteMessage",
+               "/restrictChatMember",
+               "/sendMessage"
+             ]
+
+      assert plan.audit_entry.action == "moderate_message"
+      assert plan.audit_entry.status == :flagged
+      assert plan.audit_entry.target_user_id == @user_id
+    end
+
+    test "returns a clean moderation plan without API requests" do
+      assert {:ok, plan} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 text: "Thanks for the update.",
+                 policy: %{blocked_terms: ["scam"], block_links: true}
+               })
+
+      assert plan.status == :clean
+      assert plan.request_count == 0
+      assert plan.requests == []
+      assert plan.violations == []
+    end
+
+    test "plans standalone admin log delivery" do
+      assert {:ok, plan} =
+               GroupManager.plan(:log_admin_action, %{
+                 logged_action: "manual_review",
+                 chat_id: @chat_id,
+                 admin_id: 111,
+                 user_id: @user_id,
+                 message_id: @message_id,
+                 reason: "Escalated for moderator review",
+                 log_chat_id: -100_999
+               })
+
+      assert plan.category == :admin_logging
+      assert [%{path: "/sendMessage", payload: payload}] = plan.requests
+      assert payload.chat_id == -100_999
+      assert payload.text =~ "action=manual_review"
+      assert payload.text =~ "reason=Escalated for moderator review"
+    end
+  end
+
+  describe "execution" do
+    test "executes planned requests through the Telegram client" do
+      Req.Test.expect(TelegramClientMock, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path =~ "/banChatMember"
+
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        decoded_body = Jason.decode!(body)
+        assert decoded_body["chat_id"] == @chat_id
+        assert decoded_body["user_id"] == @user_id
+        assert decoded_body["revoke_messages"] == true
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"ok" => true, "result" => true}))
+      end)
+
+      assert {:ok, plan} =
+               GroupManager.plan(:ban_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 revoke_messages: true
+               })
+
+      assert {:ok, executed} = GroupManager.execute(plan)
+      assert executed.executed == true
+      assert [%{response: %{"result" => true}}] = executed.results
+    end
+  end
+
+  describe "validation" do
+    test "rejects invalid required parameters and invalid patterns" do
+      assert {:error, "Missing or invalid user_id"} =
+               GroupManager.plan(:ban_member, %{chat_id: @chat_id})
+
+      assert {:error, "slow_mode_delay must be between 0 and 36000"} =
+               GroupManager.plan(:set_slow_mode, %{chat_id: @chat_id, slow_mode_delay: 36_001})
+
+      assert {:error, "message_ids must contain only integers"} =
+               GroupManager.plan(:delete_messages, %{chat_id: @chat_id, message_ids: [1, "2"]})
+
+      assert {:error, message} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 text: "hello",
+                 policy: %{blocked_patterns: ["["]}
+               })
+
+      assert message =~ "Invalid blocked pattern"
+    end
+  end
+end

--- a/lux/test/unit/lux/integrations/telegram/group_manager_test.exs
+++ b/lux/test/unit/lux/integrations/telegram/group_manager_test.exs
@@ -705,8 +705,12 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
                GroupManager.plan(:ban_member, %{
                  chat_id: @chat_id,
                  user_id: @user_id,
-                 revoke_messages: true
+                 revoke_messages: true,
+                 bot_admin_rights: %{can_restrict_members: true}
                })
+
+      assert plan.preflight.verified == true
+      assert plan.warnings == []
 
       assert {:ok, executed} = GroupManager.execute(plan)
       assert executed.executed == true
@@ -727,10 +731,263 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
                })
 
       assert {:error, %{plan: ^plan, results: [{:error, failure}]}} =
-               GroupManager.execute(plan, plug: {Req.Test, TelegramClientMock})
+               GroupManager.execute(plan,
+                 plug: {Req.Test, TelegramClientMock},
+                 allow_unverified_admin_rights: true
+               )
 
       assert failure.request.path == "/banChatMember"
       assert failure.error == {429, "Too Many Requests"}
+    end
+  end
+
+  describe "admin rights safety gate" do
+    test "marks destructive actions and blocks execution when rights are unverified" do
+      assert {:ok, plan} =
+               GroupManager.plan(:ban_member, %{chat_id: @chat_id, user_id: @user_id})
+
+      assert plan.preflight.destructive == true
+      assert plan.preflight.verified == false
+      assert plan.preflight.configured == false
+
+      assert [warning] = plan.warnings
+      assert warning =~ "unverified bot admin rights"
+
+      # No Req.Test expectation is registered: the gate must block before any
+      # HTTP request is attempted.
+      assert {:error, %{plan: ^plan, results: [{:error, failure}]}} = GroupManager.execute(plan)
+      assert failure.request == nil
+      assert failure.error =~ "Refusing to execute destructive Telegram action ban_member"
+      assert failure.error =~ "without verified bot_admin_rights"
+    end
+
+    test "allows destructive execution with an explicit allow_unverified_admin_rights opt-out" do
+      Req.Test.expect(TelegramClientMock, fn conn ->
+        assert conn.request_path =~ "/restrictChatMember"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"ok" => true, "result" => true}))
+      end)
+
+      assert {:ok, plan} =
+               GroupManager.plan(:restrict_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 permission_template: :read_only
+               })
+
+      assert {:ok, executed} = GroupManager.execute(plan, allow_unverified_admin_rights: true)
+      assert executed.executed == true
+      assert [%{request: %{path: "/restrictChatMember"}}] = executed.results
+    end
+
+    test "executes destructive actions when bot_admin_rights verify the required rights" do
+      Req.Test.expect(TelegramClientMock, fn conn ->
+        assert conn.request_path =~ "/banChatMember"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"ok" => true, "result" => true}))
+      end)
+
+      assert {:ok, plan} =
+               GroupManager.plan(:ban_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 bot_admin_rights: %{can_restrict_members: true}
+               })
+
+      assert plan.preflight.verified == true
+      assert plan.warnings == []
+      assert {:ok, executed} = GroupManager.execute(plan)
+      assert executed.executed == true
+    end
+
+    test "non-destructive actions execute without bot_admin_rights" do
+      Req.Test.expect(TelegramClientMock, fn conn ->
+        assert conn.request_path =~ "/setChatTitle"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"ok" => true, "result" => true}))
+      end)
+
+      assert {:ok, plan} = GroupManager.plan(:set_title, %{chat_id: @chat_id, title: "Lux"})
+      assert plan.preflight.destructive == false
+      assert plan.warnings == []
+      assert {:ok, executed} = GroupManager.execute(plan)
+      assert executed.executed == true
+    end
+  end
+
+  describe "execution short-circuits on failure" do
+    test "stops after the first failed request and never delivers the audit log" do
+      # The plan is [deleteMessage, restrictChatMember, sendMessage(audit log)].
+      # Only one HTTP call is allowed; if the executor continued past the failed
+      # delete it would attempt the restrict and the audit-log send, both of
+      # which would raise as unexpected Req.Test requests.
+      Req.Test.expect(TelegramClientMock, fn conn ->
+        assert conn.request_path =~ "/deleteMessage"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(500, Jason.encode!(%{"description" => "Internal Server Error"}))
+      end)
+
+      assert {:ok, plan} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 message_id: @message_id,
+                 text: "spam http://bad.example",
+                 moderation_action: :restrict_member,
+                 log_chat_id: -100_999,
+                 bot_admin_rights: %{can_delete_messages: true, can_restrict_members: true},
+                 policy: %{block_links: true}
+               })
+
+      assert Enum.map(plan.requests, & &1.path) == [
+               "/deleteMessage",
+               "/restrictChatMember",
+               "/sendMessage"
+             ]
+
+      assert {:error, %{plan: ^plan, results: results}} = GroupManager.execute(plan)
+      assert [{:error, failure}] = results
+      assert failure.request.path == "/deleteMessage"
+      assert failure.error == {500, "Internal Server Error"}
+      refute Enum.any?(results, &match?({:ok, _}, &1))
+    end
+
+    test "delivers every request, including the audit log, when all succeed" do
+      Req.Test.expect(TelegramClientMock, 2, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"ok" => true, "result" => true}))
+      end)
+
+      assert {:ok, plan} =
+               GroupManager.plan(:ban_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 log_chat_id: -100_999,
+                 bot_admin_rights: %{can_restrict_members: true}
+               })
+
+      assert Enum.map(plan.requests, & &1.path) == ["/banChatMember", "/sendMessage"]
+      assert {:ok, executed} = GroupManager.execute(plan)
+      assert Enum.map(executed.results, & &1.request.path) == ["/banChatMember", "/sendMessage"]
+    end
+  end
+
+  describe "sticker set capability" do
+    test "warns that sticker-set actions may need the can_set_sticker_set capability" do
+      for action <- [:set_sticker_set, :delete_sticker_set] do
+        params =
+          %{chat_id: @chat_id}
+          |> Map.merge(if action == :set_sticker_set, do: %{sticker_set_name: "lux"}, else: %{})
+
+        assert {:ok, plan} = GroupManager.plan(action, params)
+        assert Enum.any?(plan.warnings, &(&1 =~ "can_set_sticker_set"))
+        assert Enum.any?(plan.warnings, &(&1 =~ "getChat"))
+      end
+    end
+  end
+
+  describe "member management workflows" do
+    test "maps add, remove, and restrict member acceptance criteria to Bot API actions" do
+      # "Add" a member: invite-link / join-request approval semantics, since the
+      # Telegram Bot API cannot force-add an arbitrary user to a chat.
+      assert {:ok, invite_plan} =
+               GroupManager.plan(:create_invite_link, %{
+                 chat_id: @chat_id,
+                 creates_join_request: true
+               })
+
+      assert [%{path: "/createChatInviteLink", payload: %{creates_join_request: true}}] =
+               invite_plan.requests
+
+      assert {:ok, approve_plan} =
+               GroupManager.plan(:approve_join_request, %{chat_id: @chat_id, user_id: @user_id})
+
+      assert [%{path: "/approveChatJoinRequest"}] = approve_plan.requests
+
+      # "Remove" a member: ban / unban.
+      assert {:ok, ban_plan} =
+               GroupManager.plan(:ban_member, %{chat_id: @chat_id, user_id: @user_id})
+
+      assert [%{path: "/banChatMember"}] = ban_plan.requests
+
+      assert {:ok, unban_plan} =
+               GroupManager.plan(:unban_member, %{chat_id: @chat_id, user_id: @user_id})
+
+      assert [%{path: "/unbanChatMember"}] = unban_plan.requests
+
+      # "Restrict" a member: restrictChatMember with a permission template.
+      assert {:ok, restrict_plan} =
+               GroupManager.plan(:restrict_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 permission_template: :read_only
+               })
+
+      assert [%{path: "/restrictChatMember"}] = restrict_plan.requests
+    end
+  end
+
+  describe "moderation performance and bulk limits" do
+    test "evaluates large recent_messages windows correctly and within a generous bound" do
+      recent_messages =
+        for index <- 1..5_000 do
+          %{
+            chat_id: @chat_id,
+            user_id: @user_id,
+            text: "join https://spam.example",
+            age_seconds: rem(index, 50)
+          }
+        end
+
+      {elapsed_us, {:ok, plan}} =
+        :timer.tc(fn ->
+          GroupManager.plan(:moderate_message, %{
+            chat_id: @chat_id,
+            user_id: @user_id,
+            text: "join https://spam.example",
+            recent_messages: recent_messages,
+            policy: %{
+              max_recent_messages: 10,
+              duplicate_threshold: 5,
+              max_recent_links: 5,
+              window_seconds: 60
+            }
+          })
+        end)
+
+      by_type = Map.new(plan.violations, &{&1.type, &1})
+
+      assert by_type[:message_rate].recent_message_count == 5_000
+      assert by_type[:duplicate_message].recent_duplicate_count == 5_000
+      assert by_type[:link_history].recent_link_count == 5_000
+
+      # 5k messages evaluate in well under this generous ceiling; the assertion
+      # is a regression guard against accidental super-linear scanning.
+      assert elapsed_us < 2_000_000
+    end
+
+    test "accepts bulk deletes at the 100-message Bot API boundary" do
+      message_ids = Enum.to_list(1..100)
+
+      assert {:ok, plan} =
+               GroupManager.plan(:delete_messages, %{
+                 chat_id: @chat_id,
+                 message_ids: message_ids
+               })
+
+      assert [%{path: "/deleteMessages", payload: %{message_ids: ^message_ids}}] = plan.requests
+
+      assert length(plan.requests |> hd() |> Map.fetch!(:payload) |> Map.fetch!(:message_ids)) ==
+               100
     end
   end
 

--- a/lux/test/unit/lux/integrations/telegram/group_manager_test.exs
+++ b/lux/test/unit/lux/integrations/telegram/group_manager_test.exs
@@ -179,6 +179,26 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
       assert Enum.all?(request.payload.permissions, fn {_key, value} -> value == false end)
     end
 
+    test "builds bot admin rights preflight metadata and blocks known-missing rights" do
+      assert {:ok, required_rights} = GroupManager.required_admin_rights(:restrict_member)
+      assert required_rights == [:can_restrict_members]
+
+      assert {:ok, plan} =
+               GroupManager.plan(:restrict_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 bot_admin_rights: %{can_restrict_members: false}
+               })
+
+      assert plan.preflight.configured == true
+      assert plan.preflight.ok == false
+      assert plan.preflight.missing_rights == [:can_restrict_members]
+
+      assert {:error, %{results: [{:error, failure}]}} = GroupManager.execute(plan)
+      assert failure.request == nil
+      assert failure.error =~ "Missing required Telegram admin rights: can_restrict_members"
+    end
+
     test "plans demotion by clearing all admin rights through promoteChatMember" do
       assert {:ok, plan} =
                GroupManager.plan("demote_member", %{
@@ -385,6 +405,26 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
   end
 
   describe "moderation and audit logging" do
+    test "adds audit log delivery requests for ordinary admin actions" do
+      assert {:ok, plan} =
+               GroupManager.plan(:ban_member, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 admin_id: 111,
+                 reason: "raid cleanup",
+                 log_chat_id: -100_999
+               })
+
+      assert plan.request_count == 2
+      assert Enum.map(plan.requests, & &1.path) == ["/banChatMember", "/sendMessage"]
+
+      [_, log_request] = plan.requests
+      assert log_request.category == :admin_logging
+      assert log_request.payload.chat_id == -100_999
+      assert log_request.payload.text =~ "action=ban_member"
+      assert log_request.payload.text =~ "reason=raid cleanup"
+    end
+
     test "builds moderation plans with violations, action requests, and audit log requests" do
       assert {:ok, plan} =
                GroupManager.plan(:moderate_message, %{
@@ -423,6 +463,56 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
       assert plan.audit_entry.action == "moderate_message"
       assert plan.audit_entry.status == :flagged
       assert plan.audit_entry.target_user_id == @user_id
+    end
+
+    test "uses caller-supplied spam history for rate, duplicate, and link checks" do
+      assert {:ok, plan} =
+               GroupManager.plan(:moderate_message, %{
+                 chat_id: @chat_id,
+                 user_id: @user_id,
+                 text: "visit https://spam.example",
+                 recent_messages: [
+                   %{
+                     chat_id: @chat_id,
+                     user_id: @user_id,
+                     text: "visit https://spam.example",
+                     age_seconds: 10
+                   },
+                   %{
+                     chat_id: @chat_id,
+                     user_id: @user_id,
+                     text: "visit https://spam.example",
+                     age_seconds: 20
+                   },
+                   %{
+                     chat_id: @chat_id,
+                     user_id: @user_id,
+                     text: "old duplicate outside the window",
+                     age_seconds: 120
+                   },
+                   %{
+                     chat_id: @chat_id,
+                     user_id: 999,
+                     text: "visit https://spam.example",
+                     age_seconds: 5
+                   }
+                 ],
+                 policy: %{
+                   max_recent_messages: 1,
+                   duplicate_threshold: 2,
+                   max_recent_links: 2,
+                   window_seconds: 60
+                 }
+               })
+
+      assert Enum.map(plan.violations, & &1.type) == [
+               :message_rate,
+               :duplicate_message,
+               :link_history
+             ]
+
+      assert [%{recent_message_count: 2}, %{recent_duplicate_count: 2}, %{recent_link_count: 2}] =
+               plan.violations
     end
 
     test "returns a clean moderation plan without API requests" do

--- a/lux/test/unit/lux/integrations/telegram/group_manager_test.exs
+++ b/lux/test/unit/lux/integrations/telegram/group_manager_test.exs
@@ -6,6 +6,55 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
   @chat_id -100_123_456
   @user_id 987_654
   @message_id 42
+  @message_thread_id 7
+
+  @official_bot_api_paths MapSet.new([
+                            "/approveChatJoinRequest",
+                            "/banChatMember",
+                            "/banChatSenderChat",
+                            "/closeForumTopic",
+                            "/closeGeneralForumTopic",
+                            "/copyMessage",
+                            "/createChatInviteLink",
+                            "/createForumTopic",
+                            "/declineChatJoinRequest",
+                            "/deleteChatPhoto",
+                            "/deleteChatStickerSet",
+                            "/deleteForumTopic",
+                            "/deleteMessage",
+                            "/deleteMessages",
+                            "/editChatInviteLink",
+                            "/editForumTopic",
+                            "/editGeneralForumTopic",
+                            "/editMessageCaption",
+                            "/editMessageText",
+                            "/forwardMessage",
+                            "/getChatAdministrators",
+                            "/getChatMember",
+                            "/getChatMemberCount",
+                            "/hideGeneralForumTopic",
+                            "/pinChatMessage",
+                            "/promoteChatMember",
+                            "/restrictChatMember",
+                            "/reopenForumTopic",
+                            "/reopenGeneralForumTopic",
+                            "/revokeChatInviteLink",
+                            "/sendMessage",
+                            "/setChatAdministratorCustomTitle",
+                            "/setChatDescription",
+                            "/setChatMemberTag",
+                            "/setChatPermissions",
+                            "/setChatSlowModeDelay",
+                            "/setChatStickerSet",
+                            "/setChatTitle",
+                            "/unbanChatMember",
+                            "/unbanChatSenderChat",
+                            "/unhideGeneralForumTopic",
+                            "/unpinAllChatMessages",
+                            "/unpinAllForumTopicMessages",
+                            "/unpinAllGeneralForumTopicMessages",
+                            "/unpinChatMessage"
+                          ])
 
   setup do
     Req.Test.verify_on_exit!()
@@ -17,6 +66,19 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
       assert :moderate_message in GroupManager.known_actions()
       assert :log_admin_action in GroupManager.known_actions()
       assert :copy_channel_post in GroupManager.known_actions()
+      assert :create_forum_topic in GroupManager.known_actions()
+      assert :unpin_all_general_forum_topic_messages in GroupManager.known_actions()
+    end
+
+    test "advertised actions emit official Telegram Bot API paths" do
+      for action <- GroupManager.known_actions() do
+        assert {:ok, plan} = GroupManager.plan(action, action_params(action))
+        assert plan.requests != []
+
+        assert Enum.all?(plan.requests, fn request ->
+                 MapSet.member?(@official_bot_api_paths, request.path)
+               end)
+      end
     end
 
     test "builds Telegram ChatPermissions templates with current permission flags" do
@@ -192,7 +254,7 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
   end
 
   describe "settings and channel post plans" do
-    test "plans chat setting variants and forum/sticker controls" do
+    test "plans chat setting variants and sticker controls" do
       for {action, expected_path, params} <- [
             {"set-title", "/setChatTitle", %{title: "Lux Research"}},
             {:set_description, "/setChatDescription", %{description: ""}},
@@ -206,8 +268,34 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
             {:unpin_message, "/unpinChatMessage", %{message_id: @message_id}},
             {:unpin_all_messages, "/unpinAllChatMessages", %{}},
             {:set_sticker_set, "/setChatStickerSet", %{sticker_set_name: "lux_stickers"}},
-            {:delete_sticker_set, "/deleteChatStickerSet", %{}},
-            {:set_forum, "/setChatIsForum", %{is_forum: true}}
+            {:delete_sticker_set, "/deleteChatStickerSet", %{}}
+          ] do
+        assert {:ok, plan} = GroupManager.plan(action, Map.put(params, :chat_id, @chat_id))
+        assert [%{path: ^expected_path}] = plan.requests
+      end
+    end
+
+    test "plans official forum topic operations" do
+      for {action, expected_path, params} <- [
+            {:create_forum_topic, "/createForumTopic",
+             %{
+               name: "Research",
+               icon_color: 7_322_096,
+               icon_custom_emoji_id: "emoji-topic"
+             }},
+            {:edit_forum_topic, "/editForumTopic",
+             %{message_thread_id: @message_thread_id, name: "Research Q&A"}},
+            {:close_forum_topic, "/closeForumTopic", %{message_thread_id: @message_thread_id}},
+            {:reopen_forum_topic, "/reopenForumTopic", %{message_thread_id: @message_thread_id}},
+            {:delete_forum_topic, "/deleteForumTopic", %{message_thread_id: @message_thread_id}},
+            {:unpin_all_forum_topic_messages, "/unpinAllForumTopicMessages",
+             %{message_thread_id: @message_thread_id}},
+            {:edit_general_forum_topic, "/editGeneralForumTopic", %{name: "General Chat"}},
+            {:close_general_forum_topic, "/closeGeneralForumTopic", %{}},
+            {:reopen_general_forum_topic, "/reopenGeneralForumTopic", %{}},
+            {:hide_general_forum_topic, "/hideGeneralForumTopic", %{}},
+            {:unhide_general_forum_topic, "/unhideGeneralForumTopic", %{}},
+            {:unpin_all_general_forum_topic_messages, "/unpinAllGeneralForumTopicMessages", %{}}
           ] do
         assert {:ok, plan} = GroupManager.plan(action, Map.put(params, :chat_id, @chat_id))
         assert [%{path: ^expected_path}] = plan.requests
@@ -598,8 +686,8 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
       assert {:error, "Missing or invalid title"} =
                GroupManager.plan(:set_title, %{chat_id: @chat_id, title: ""})
 
-      assert {:error, "Missing or invalid is_forum"} =
-               GroupManager.plan(:set_forum, %{chat_id: @chat_id, is_forum: "yes"})
+      assert {:error, "Missing or invalid message_thread_id"} =
+               GroupManager.plan(:close_forum_topic, %{chat_id: @chat_id})
 
       assert {:error, "message_ids must include between 1 and 100 message ids"} =
                GroupManager.plan(:delete_messages, %{chat_id: @chat_id, message_ids: []})
@@ -652,4 +740,104 @@ defmodule Lux.Integrations.Telegram.GroupManagerTest do
                })
     end
   end
+
+  defp action_params(action) do
+    Map.merge(%{chat_id: @chat_id}, action_specific_params(action))
+  end
+
+  defp action_specific_params(action)
+       when action in [:ban_member, :unban_member, :get_member] do
+    %{user_id: @user_id}
+  end
+
+  defp action_specific_params(:restrict_member) do
+    %{user_id: @user_id, permission_template: :read_only}
+  end
+
+  defp action_specific_params(:promote_member) do
+    %{user_id: @user_id, admin_template: :moderator}
+  end
+
+  defp action_specific_params(:demote_member), do: %{user_id: @user_id}
+
+  defp action_specific_params(:set_admin_title) do
+    %{user_id: @user_id, custom_title: "Ops"}
+  end
+
+  defp action_specific_params(:set_member_tag), do: %{user_id: @user_id, tag: "vip"}
+
+  defp action_specific_params(action) when action in [:ban_sender_chat, :unban_sender_chat] do
+    %{sender_chat_id: -100_777_777}
+  end
+
+  defp action_specific_params(:set_permissions), do: %{permission_template: :standard}
+  defp action_specific_params(:set_title), do: %{title: "Lux Research"}
+  defp action_specific_params(:set_description), do: %{description: "Community updates"}
+  defp action_specific_params(:set_slow_mode), do: %{slow_mode_delay: 0}
+  defp action_specific_params(:edit_invite_link), do: %{invite_link: "https://t.me/+abc"}
+  defp action_specific_params(:revoke_invite_link), do: %{invite_link: "https://t.me/+abc"}
+
+  defp action_specific_params(action)
+       when action in [:approve_join_request, :decline_join_request] do
+    %{user_id: @user_id}
+  end
+
+  defp action_specific_params(action) when action in [:pin_message, :unpin_message] do
+    %{message_id: @message_id}
+  end
+
+  defp action_specific_params(:set_sticker_set), do: %{sticker_set_name: "lux_stickers"}
+
+  defp action_specific_params(:create_forum_topic) do
+    %{name: "Research", icon_color: 7_322_096, icon_custom_emoji_id: "emoji-topic"}
+  end
+
+  defp action_specific_params(:edit_forum_topic) do
+    %{message_thread_id: @message_thread_id, name: "Research Q&A"}
+  end
+
+  defp action_specific_params(action)
+       when action in [
+              :close_forum_topic,
+              :reopen_forum_topic,
+              :delete_forum_topic,
+              :unpin_all_forum_topic_messages
+            ] do
+    %{message_thread_id: @message_thread_id}
+  end
+
+  defp action_specific_params(:edit_general_forum_topic), do: %{name: "General Chat"}
+  defp action_specific_params(:send_channel_post), do: %{text: "Launch update"}
+
+  defp action_specific_params(:edit_channel_post) do
+    %{message_id: @message_id, text: "Updated"}
+  end
+
+  defp action_specific_params(:edit_channel_caption) do
+    %{message_id: @message_id, caption: "Updated caption"}
+  end
+
+  defp action_specific_params(:delete_channel_post), do: %{message_id: @message_id}
+  defp action_specific_params(:delete_messages), do: %{message_ids: [40, 41, 42]}
+
+  defp action_specific_params(action)
+       when action in [:forward_channel_post, :copy_channel_post] do
+    %{from_chat_id: -100_555_555, message_id: @message_id}
+  end
+
+  defp action_specific_params(:moderate_message) do
+    %{
+      user_id: @user_id,
+      message_id: @message_id,
+      text: "spam",
+      moderation_action: :restrict_member,
+      policy: %{max_length: 1}
+    }
+  end
+
+  defp action_specific_params(:log_admin_action) do
+    %{logged_action: "manual_review", log_chat_id: -100_999}
+  end
+
+  defp action_specific_params(_action), do: %{}
 end

--- a/lux/test/unit/lux/prisms/telegram/group/manage_group_test.exs
+++ b/lux/test/unit/lux/prisms/telegram/group/manage_group_test.exs
@@ -28,8 +28,9 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
 
       assert result.planned == true
       assert result.executed == false
-      assert result.action == :restrict_member
-      assert result.category == :member_management
+      assert result.action == "restrict_member"
+      assert result.category == "member_management"
+      assert result.preflight.required_rights == ["can_restrict_members"]
       assert [%{path: "/restrictChatMember"}] = result.requests
     end
 
@@ -63,6 +64,8 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
       assert result.planned == true
       assert result.executed == true
       assert result.request_count == 1
+      assert result.action == "set_permissions"
+      assert result.category == "permission_management"
       assert [%{response: %{"result" => true}}] = result.results
     end
 
@@ -137,8 +140,8 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
                  @agent_ctx
                )
 
-      assert result.status == :flagged
-      assert result.moderation_action == :ban_member
+      assert result.status == "flagged"
+      assert result.moderation_action == "ban_member"
       assert Enum.map(result.requests, & &1.path) == ["/deleteMessage", "/banChatMember"]
     end
 
@@ -164,6 +167,8 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
       assert Map.has_key?(prism.input_schema.properties, :message_thread_id)
       assert Map.has_key?(prism.input_schema.properties, :icon_custom_emoji_id)
       assert Map.has_key?(prism.input_schema.properties, :execute)
+      assert Map.has_key?(prism.input_schema.properties, :recent_messages)
+      assert Map.has_key?(prism.input_schema.properties, :bot_admin_rights)
       assert Map.has_key?(prism.output_schema.properties, :requests)
       assert Map.has_key?(prism.output_schema.properties, :audit_entry)
 

--- a/lux/test/unit/lux/prisms/telegram/group/manage_group_test.exs
+++ b/lux/test/unit/lux/prisms/telegram/group/manage_group_test.exs
@@ -56,6 +56,7 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
                    action: :set_permissions,
                    chat_id: @chat_id,
                    permission_template: :no_links,
+                   bot_admin_rights: %{can_restrict_members: true},
                    execute: true
                  },
                  @agent_ctx
@@ -90,6 +91,7 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
                    chat_id: @chat_id,
                    user_id: @user_id,
                    only_if_banned: true,
+                   allow_unverified_admin_rights: true,
                    execute: "1",
                    plug: nil
                  },
@@ -116,7 +118,8 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
                    chat_id: @chat_id,
                    user_id: @user_id,
                    execute: true,
-                   token: "test-token"
+                   token: "test-token",
+                   allow_unverified_admin_rights: true
                  },
                  @agent_ctx
                )
@@ -169,11 +172,58 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
       assert Map.has_key?(prism.input_schema.properties, :execute)
       assert Map.has_key?(prism.input_schema.properties, :recent_messages)
       assert Map.has_key?(prism.input_schema.properties, :bot_admin_rights)
+      assert Map.has_key?(prism.input_schema.properties, :token)
+      assert Map.has_key?(prism.input_schema.properties, :allow_unverified_admin_rights)
       assert Map.has_key?(prism.output_schema.properties, :requests)
       assert Map.has_key?(prism.output_schema.properties, :audit_entry)
 
+      # Every field produced by normalize_output/1 must be advertised so agents
+      # can rely on the documented contract for moderation and execution output.
+      for field <- [
+            :status,
+            :severity,
+            :moderation_action,
+            :violations,
+            :preflight,
+            :warnings,
+            :results
+          ] do
+        assert Map.has_key?(prism.output_schema.properties, field),
+               "output_schema is missing advertised field #{inspect(field)}"
+      end
+
       assert MapSet.new(prism.input_schema.properties.action.enum) ==
                MapSet.new(Enum.map(GroupManager.known_actions(), &Atom.to_string/1))
+    end
+  end
+
+  describe "preflight and execution safety" do
+    test "dry-run output surfaces the preflight summary and unverified-rights warning" do
+      assert {:ok, result} =
+               ManageGroup.handler(
+                 %{action: :ban_member, chat_id: @chat_id, user_id: @user_id},
+                 @agent_ctx
+               )
+
+      assert result.executed == false
+      assert result.preflight.action == "ban_member"
+      assert result.preflight.required_rights == ["can_restrict_members"]
+      assert result.preflight.destructive == true
+      assert result.preflight.verified == false
+      assert [warning] = result.warnings
+      assert warning =~ "unverified bot admin rights"
+    end
+
+    test "blocks destructive execution without verified rights or an explicit opt-out" do
+      # No Req.Test expectation: the safety gate must reject before any request.
+      assert {:error, message} =
+               ManageGroup.handler(
+                 %{action: :ban_member, chat_id: @chat_id, user_id: @user_id, execute: true},
+                 @agent_ctx
+               )
+
+      assert message =~ "Failed to execute Telegram group action"
+      assert message =~ "without verified bot_admin_rights"
     end
   end
 end

--- a/lux/test/unit/lux/prisms/telegram/group/manage_group_test.exs
+++ b/lux/test/unit/lux/prisms/telegram/group/manage_group_test.exs
@@ -65,6 +65,62 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
       assert [%{response: %{"result" => true}}] = result.results
     end
 
+    test "executes with string truthy values and ignores nil execution options" do
+      Req.Test.expect(TelegramClientMock, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path =~ "/unbanChatMember"
+
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        decoded_body = Jason.decode!(body)
+        assert decoded_body["only_if_banned"] == true
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"ok" => true, "result" => true}))
+      end)
+
+      assert {:ok, result} =
+               ManageGroup.handler(
+                 %{
+                   action: "unban_member",
+                   chat_id: @chat_id,
+                   user_id: @user_id,
+                   only_if_banned: true,
+                   execute: "1",
+                   plug: nil
+                 },
+                 @agent_ctx
+               )
+
+      assert result.executed == true
+      assert [%{request: %{path: "/unbanChatMember"}}] = result.results
+    end
+
+    test "returns execution errors from the Telegram client" do
+      Req.Test.expect(TelegramClientMock, fn conn ->
+        assert conn.request_path =~ "/banChatMember"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{"description" => "Forbidden"}))
+      end)
+
+      assert {:error, message} =
+               ManageGroup.handler(
+                 %{
+                   action: :ban_member,
+                   chat_id: @chat_id,
+                   user_id: @user_id,
+                   execute: true,
+                   token: "test-token"
+                 },
+                 @agent_ctx
+               )
+
+      assert message =~ "Failed to execute Telegram group action"
+      assert message =~ "Forbidden"
+    end
+
     test "builds moderation plans for flagged content" do
       assert {:ok, result} =
                ManageGroup.handler(
@@ -87,6 +143,7 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
 
     test "validates required action and parameters" do
       assert {:error, "Missing or invalid action"} = ManageGroup.handler(%{}, @agent_ctx)
+      assert {:error, "Missing or invalid action"} = ManageGroup.handler(nil, @agent_ctx)
 
       assert {:error, "Missing or invalid user_id"} =
                ManageGroup.handler(%{action: :ban_member, chat_id: @chat_id}, @agent_ctx)

--- a/lux/test/unit/lux/prisms/telegram/group/manage_group_test.exs
+++ b/lux/test/unit/lux/prisms/telegram/group/manage_group_test.exs
@@ -1,6 +1,7 @@
 defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
   use UnitAPICase, async: true
 
+  alias Lux.Integrations.Telegram.GroupManager
   alias Lux.Prisms.Telegram.Group.ManageGroup
 
   @chat_id -100_123_456
@@ -156,11 +157,18 @@ defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
 
       assert prism.input_schema.required == ["action"]
       assert "ban_member" in prism.input_schema.properties.action.enum
+      assert "create_forum_topic" in prism.input_schema.properties.action.enum
+      assert "unpin_all_general_forum_topic_messages" in prism.input_schema.properties.action.enum
       assert "moderate_message" in prism.input_schema.properties.action.enum
       assert "log_admin_action" in prism.input_schema.properties.action.enum
+      assert Map.has_key?(prism.input_schema.properties, :message_thread_id)
+      assert Map.has_key?(prism.input_schema.properties, :icon_custom_emoji_id)
       assert Map.has_key?(prism.input_schema.properties, :execute)
       assert Map.has_key?(prism.output_schema.properties, :requests)
       assert Map.has_key?(prism.output_schema.properties, :audit_entry)
+
+      assert MapSet.new(prism.input_schema.properties.action.enum) ==
+               MapSet.new(Enum.map(GroupManager.known_actions(), &Atom.to_string/1))
     end
   end
 end

--- a/lux/test/unit/lux/prisms/telegram/group/manage_group_test.exs
+++ b/lux/test/unit/lux/prisms/telegram/group/manage_group_test.exs
@@ -1,0 +1,109 @@
+defmodule Lux.Prisms.Telegram.Group.ManageGroupTest do
+  use UnitAPICase, async: true
+
+  alias Lux.Prisms.Telegram.Group.ManageGroup
+
+  @chat_id -100_123_456
+  @user_id 987_654
+  @agent_ctx %{name: "ModerationAgent"}
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "handler/2" do
+    test "returns a dry-run plan by default" do
+      assert {:ok, result} =
+               ManageGroup.handler(
+                 %{
+                   action: "restrict_member",
+                   chat_id: @chat_id,
+                   user_id: @user_id,
+                   permission_template: "read_only"
+                 },
+                 @agent_ctx
+               )
+
+      assert result.planned == true
+      assert result.executed == false
+      assert result.action == :restrict_member
+      assert result.category == :member_management
+      assert [%{path: "/restrictChatMember"}] = result.requests
+    end
+
+    test "executes a planned Telegram request when execute is true" do
+      Req.Test.expect(TelegramClientMock, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path =~ "/setChatPermissions"
+
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        decoded_body = Jason.decode!(body)
+        assert decoded_body["chat_id"] == @chat_id
+        assert decoded_body["permissions"]["can_send_messages"] == true
+        assert decoded_body["permissions"]["can_add_web_page_previews"] == false
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"ok" => true, "result" => true}))
+      end)
+
+      assert {:ok, result} =
+               ManageGroup.handler(
+                 %{
+                   action: :set_permissions,
+                   chat_id: @chat_id,
+                   permission_template: :no_links,
+                   execute: true
+                 },
+                 @agent_ctx
+               )
+
+      assert result.planned == true
+      assert result.executed == true
+      assert result.request_count == 1
+      assert [%{response: %{"result" => true}}] = result.results
+    end
+
+    test "builds moderation plans for flagged content" do
+      assert {:ok, result} =
+               ManageGroup.handler(
+                 %{
+                   action: :moderate_message,
+                   chat_id: @chat_id,
+                   user_id: @user_id,
+                   message_id: 55,
+                   text: "Join https://spam.example now",
+                   policy: %{block_links: true},
+                   moderation_action: :ban_member
+                 },
+                 @agent_ctx
+               )
+
+      assert result.status == :flagged
+      assert result.moderation_action == :ban_member
+      assert Enum.map(result.requests, & &1.path) == ["/deleteMessage", "/banChatMember"]
+    end
+
+    test "validates required action and parameters" do
+      assert {:error, "Missing or invalid action"} = ManageGroup.handler(%{}, @agent_ctx)
+
+      assert {:error, "Missing or invalid user_id"} =
+               ManageGroup.handler(%{action: :ban_member, chat_id: @chat_id}, @agent_ctx)
+    end
+  end
+
+  describe "schema validation" do
+    test "advertises group management actions and execution controls" do
+      prism = ManageGroup.view()
+
+      assert prism.input_schema.required == ["action"]
+      assert "ban_member" in prism.input_schema.properties.action.enum
+      assert "moderate_message" in prism.input_schema.properties.action.enum
+      assert "log_admin_action" in prism.input_schema.properties.action.enum
+      assert Map.has_key?(prism.input_schema.properties, :execute)
+      assert Map.has_key?(prism.output_schema.properties, :requests)
+      assert Map.has_key?(prism.output_schema.properties, :audit_entry)
+    end
+  end
+end


### PR DESCRIPTION
/claim #65

## Summary

- Add `Lux.Integrations.Telegram.GroupManager` to build and optionally execute normalized Telegram Bot API plans for member management, permission templates, moderation/spam protection, group settings, channel posts, forum topic operations, and admin audit logging.
- Add `Lux.Prisms.Telegram.Group.ManageGroup` so agents can dry-run or execute group/channel administration actions through the existing Telegram client.
- Document group/channel management examples and expand unit coverage across planning, validation, execution, moderation decisions, action aliases, official Bot API path mapping, audit output, and error handling.

Closes #65.

## Validation

- `mix format --check-formatted lib/lux/integrations/telegram/group_manager.ex lib/lux/prisms/telegram/group/manage_group.ex test/unit/lux/integrations/telegram/group_manager_test.exs test/unit/lux/prisms/telegram/group/manage_group_test.exs guides/telegram.livemd`
- `mix credo --strict lib/lux/integrations/telegram/group_manager.ex lib/lux/prisms/telegram/group/manage_group.ex test/unit/lux/integrations/telegram/group_manager_test.exs test/unit/lux/prisms/telegram/group/manage_group_test.exs`
- `MIX_ENV=test mix test.unit test/unit/lux/integrations/telegram/group_manager_test.exs test/unit/lux/prisms/telegram/group/manage_group_test.exs`
- `MIX_ENV=test mix test.unit test/unit/lux/integrations/telegram test/unit/lux/prisms/telegram`
- `MIX_ENV=test mix coveralls.detail --include unit test/unit/lux/integrations/telegram/group_manager_test.exs test/unit/lux/prisms/telegram/group/manage_group_test.exs` (`GroupManager` 93.4%, `ManageGroup` 100.0%)
- `MIX_ENV=test mix coveralls --include unit --max-cases 1`