### PR TITLE
Add Hyperliquid perps action planning and risk dashboard

### DIFF
--- a/lux/guides/hyperliquid_perps.livemd
+++ b/lux/guides/hyperliquid_perps.livemd
@@ -1,0 +1,71 @@
+# Hyperliquid Perpetual Trading
+
+Lux includes Hyperliquid helpers for public market/account reads, order planning, position
+tracking, margin management, liquidation monitoring, and risk verification.
+
+## Public Info Client
+
+```elixir
+alias Lux.Integrations.Hyperliquid.Client
+
+{:ok, meta} = Client.meta()
+{:ok, mids} = Client.all_mids()
+{:ok, book} = Client.l2_book("ETH")
+{:ok, state} = Client.clearinghouse_state("0x0000000000000000000000000000000000000001")
+{:ok, orders} = Client.open_orders("0x0000000000000000000000000000000000000001")
+```
+
+The client calls Hyperliquid's public `POST /info` endpoint. Trading writes use
+`POST /exchange` and require a signed payload.
+
+## Order Planning
+
+```elixir
+alias Lux.Integrations.Hyperliquid.Perps
+
+{:ok, action} =
+  Perps.order_action(
+    %{
+      coin: "ETH",
+      asset_index: 1,
+      is_buy: true,
+      sz: 0.1,
+      limit_px: 3000,
+      order_type: %{limit: %{tif: "Gtc"}}
+    }
+  )
+```
+
+The returned action is the compact Hyperliquid exchange action shape. It is ready
+for a signer/API-wallet adapter to attach `nonce` and `signature`; the helper does
+not handle private keys or submit live orders.
+
+Cancel, leverage, and isolated margin actions use the same pattern:
+
+```elixir
+Perps.cancel_action(%{coin: "ETH", asset_index: 1, oid: 123})
+Perps.leverage_action(%{coin: "ETH", asset_index: 1, leverage: 3, is_cross: true})
+Perps.margin_action(%{coin: "ETH", asset_index: 1, amount: 100, action: "add"})
+```
+
+## Risk Verification
+
+```elixir
+{:ok, decision} =
+  Perps.risk_check(state, mids, %{
+    coin: "ETH",
+    is_buy: true,
+    sz: 0.1,
+    limit_px: 3000
+  })
+```
+
+Risk checks cover projected leverage, order notional, projected position concentration,
+margin usage, and current liquidation buffers.
+
+## Agent Prisms
+
+`Lux.Prisms.Hyperliquid.HyperliquidOrderManagementPrism` validates and plans order,
+cancel, leverage, and margin actions. `Lux.Prisms.Hyperliquid.HyperliquidPerpsDashboardPrism`
+returns a compact dashboard for current positions, PnL, open orders, margin, and
+liquidation risk.

--- a/lux/lib/lux/integrations/hyperliquid.ex
+++ b/lux/lib/lux/integrations/hyperliquid.ex
@@ -1,0 +1,74 @@
+defmodule Lux.Integrations.Hyperliquid do
+  @moduledoc """
+  Shared settings and helpers for Hyperliquid perpetual trading.
+
+  The public info endpoint is safe to call without credentials. Exchange actions
+  still require a caller-provided signature before they can be submitted.
+  """
+
+  @api_base_url "https://api.hyperliquid.xyz"
+  @info_endpoint "/info"
+  @exchange_endpoint "/exchange"
+
+  @perp_info_types [
+    :meta,
+    :all_mids,
+    :l2_book,
+    :clearinghouse_state,
+    :open_orders,
+    :frontend_open_orders,
+    :order_status,
+    :historical_orders,
+    :user_fills,
+    :user_fills_by_time,
+    :user_funding,
+    :portfolio,
+    :candle_snapshot
+  ]
+
+  @doc "Returns default Hyperliquid API settings."
+  @spec client_settings() :: map()
+  def client_settings do
+    %{
+      base_url: configured_base_url(),
+      info_endpoint: @info_endpoint,
+      exchange_endpoint: @exchange_endpoint,
+      headers: [{"content-type", "application/json"}]
+    }
+  end
+
+  @doc "Returns supported info request types used by this integration."
+  @spec perp_info_types() :: [atom()]
+  def perp_info_types, do: @perp_info_types
+
+  @doc "Converts internal atom names to Hyperliquid info endpoint request types."
+  @spec info_type(atom() | String.t()) :: String.t()
+  def info_type(:all_mids), do: "allMids"
+  def info_type(:l2_book), do: "l2Book"
+  def info_type(:clearinghouse_state), do: "clearinghouseState"
+  def info_type(:open_orders), do: "openOrders"
+  def info_type(:frontend_open_orders), do: "frontendOpenOrders"
+  def info_type(:order_status), do: "orderStatus"
+  def info_type(:historical_orders), do: "historicalOrders"
+  def info_type(:user_fills), do: "userFills"
+  def info_type(:user_fills_by_time), do: "userFillsByTime"
+  def info_type(:user_funding), do: "userFunding"
+  def info_type(:candle_snapshot), do: "candleSnapshot"
+  def info_type(type) when is_atom(type), do: Atom.to_string(type)
+  def info_type(type) when is_binary(type), do: type
+
+  defp configured_base_url do
+    :lux
+    |> Application.get_env(:accounts, [])
+    |> Keyword.get(:hyperliquid_api_url, @api_base_url)
+    |> to_string()
+    |> String.trim_trailing("/")
+    |> strip_endpoint_suffix()
+  end
+
+  defp strip_endpoint_suffix(url) do
+    Enum.reduce([@info_endpoint, @exchange_endpoint], url, fn suffix, acc ->
+      if String.ends_with?(acc, suffix), do: String.trim_trailing(acc, suffix), else: acc
+    end)
+  end
+end

--- a/lux/lib/lux/integrations/hyperliquid/client.ex
+++ b/lux/lib/lux/integrations/hyperliquid/client.ex
@@ -1,0 +1,159 @@
+defmodule Lux.Integrations.Hyperliquid.Client do
+  @moduledoc """
+  Req-based Hyperliquid REST client for public info reads and signed exchange payloads.
+
+  Most issue #82 workflows can be exercised through the public `/info` endpoint and
+  deterministic exchange action planning. `exchange/2` only submits a payload that
+  already includes the required nonce/signature fields.
+  """
+
+  alias Lux.Integrations.Hyperliquid
+
+  @type request_opts :: keyword() | map()
+
+  @doc "Calls Hyperliquid's `/info` endpoint with a raw payload."
+  @spec info(map(), request_opts()) :: {:ok, term()} | {:error, term()}
+  def info(payload, opts \\ %{}) when is_map(payload) do
+    request(:post, :info_endpoint, payload, opts)
+  end
+
+  @doc "Submits an already signed payload to Hyperliquid's `/exchange` endpoint."
+  @spec exchange(map(), request_opts()) :: {:ok, term()} | {:error, term()}
+  def exchange(payload, opts \\ %{}) when is_map(payload) do
+    request(:post, :exchange_endpoint, payload, opts)
+  end
+
+  @doc "Fetches perpetual universe metadata."
+  @spec meta(request_opts()) :: {:ok, map()} | {:error, term()}
+  def meta(opts \\ %{}), do: info(%{type: Hyperliquid.info_type(:meta)}, opts)
+
+  @doc "Fetches all mid prices."
+  @spec all_mids(request_opts()) :: {:ok, map()} | {:error, term()}
+  def all_mids(opts \\ %{}), do: info(%{type: Hyperliquid.info_type(:all_mids)}, opts)
+
+  @doc "Fetches an L2 order book snapshot for a perpetual coin."
+  @spec l2_book(String.t(), request_opts()) :: {:ok, map()} | {:error, term()}
+  def l2_book(coin, opts \\ %{}) do
+    info(%{type: Hyperliquid.info_type(:l2_book), coin: coin}, opts)
+  end
+
+  @doc "Fetches a user's perpetual clearinghouse state."
+  @spec clearinghouse_state(String.t(), request_opts()) :: {:ok, map()} | {:error, term()}
+  def clearinghouse_state(user, opts \\ %{}) do
+    info(%{type: Hyperliquid.info_type(:clearinghouse_state), user: normalize_user(user)}, opts)
+  end
+
+  @doc "Fetches open orders for a user."
+  @spec open_orders(String.t(), request_opts()) :: {:ok, list()} | {:error, term()}
+  def open_orders(user, opts \\ %{}) do
+    info(%{type: Hyperliquid.info_type(:open_orders), user: normalize_user(user)}, opts)
+  end
+
+  @doc "Fetches frontend open orders for a user."
+  @spec frontend_open_orders(String.t(), request_opts()) :: {:ok, list()} | {:error, term()}
+  def frontend_open_orders(user, opts \\ %{}) do
+    info(%{type: Hyperliquid.info_type(:frontend_open_orders), user: normalize_user(user)}, opts)
+  end
+
+  @doc "Fetches order status by order id or client order id."
+  @spec order_status(String.t(), integer() | String.t(), request_opts()) ::
+          {:ok, map()} | {:error, term()}
+  def order_status(user, oid, opts \\ %{}) do
+    info(
+      %{type: Hyperliquid.info_type(:order_status), user: normalize_user(user), oid: oid},
+      opts
+    )
+  end
+
+  @doc "Fetches historical order records for a user."
+  @spec historical_orders(String.t(), request_opts()) :: {:ok, list()} | {:error, term()}
+  def historical_orders(user, opts \\ %{}) do
+    info(%{type: Hyperliquid.info_type(:historical_orders), user: normalize_user(user)}, opts)
+  end
+
+  @doc "Fetches recent user fills."
+  @spec user_fills(String.t(), request_opts()) :: {:ok, list()} | {:error, term()}
+  def user_fills(user, opts \\ %{}) do
+    info(%{type: Hyperliquid.info_type(:user_fills), user: normalize_user(user)}, opts)
+  end
+
+  @doc "Fetches user funding records for a time window."
+  @spec user_funding(String.t(), integer(), integer() | nil, request_opts()) ::
+          {:ok, list()} | {:error, term()}
+  def user_funding(user, start_time, end_time \\ nil, opts \\ %{}) do
+    %{
+      type: Hyperliquid.info_type(:user_funding),
+      user: normalize_user(user),
+      startTime: start_time
+    }
+    |> maybe_put(:endTime, end_time)
+    |> info(opts)
+  end
+
+  @doc "Fetches portfolio history for a user."
+  @spec portfolio(String.t(), request_opts()) :: {:ok, term()} | {:error, term()}
+  def portfolio(user, opts \\ %{}) do
+    info(%{type: Hyperliquid.info_type(:portfolio), user: normalize_user(user)}, opts)
+  end
+
+  @doc "Fetches a recent candle snapshot."
+  @spec candle_snapshot(String.t(), String.t(), integer(), integer(), request_opts()) ::
+          {:ok, list()} | {:error, term()}
+  def candle_snapshot(coin, interval, start_time, end_time, opts \\ %{}) do
+    info(
+      %{
+        type: Hyperliquid.info_type(:candle_snapshot),
+        req: %{coin: coin, interval: interval, startTime: start_time, endTime: end_time}
+      },
+      opts
+    )
+  end
+
+  defp request(method, endpoint_key, payload, opts) do
+    settings = Hyperliquid.client_settings()
+    opts = opts_list(opts)
+    base_url = Keyword.get(opts, :base_url, settings.base_url) |> String.trim_trailing("/")
+    endpoint = Map.fetch!(settings, endpoint_key)
+    headers = settings.headers ++ Keyword.get(opts, :headers, [])
+
+    [
+      method: method,
+      url: base_url <> endpoint,
+      headers: headers,
+      json: payload
+    ]
+    |> Keyword.merge(Application.get_env(:lux, __MODULE__, []))
+    |> Keyword.merge(Keyword.take(opts, [:receive_timeout, :retry, :max_retries]))
+    |> maybe_add_plug(Keyword.get(opts, :plug))
+    |> Req.new()
+    |> Req.request()
+    |> normalize_response()
+  end
+
+  defp normalize_response({:ok, %{status: status, body: %{"error" => error}}}) do
+    {:error, {status, error}}
+  end
+
+  defp normalize_response({:ok, %{status: status, body: %{"status" => "err"} = body}})
+       when status in 200..299 do
+    {:error, body}
+  end
+
+  defp normalize_response({:ok, %{status: status, body: body}}) when status in 200..299 do
+    {:ok, body}
+  end
+
+  defp normalize_response({:ok, %{status: status, body: body}}), do: {:error, {status, body}}
+  defp normalize_response({:error, error}), do: {:error, error}
+
+  defp normalize_user(user) when is_binary(user), do: String.downcase(user)
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp opts_list(opts) when is_map(opts), do: Map.to_list(opts)
+  defp opts_list(opts) when is_list(opts), do: opts
+
+  defp maybe_add_plug(options, nil), do: options
+  defp maybe_add_plug(options, plug), do: Keyword.put(options, :plug, plug)
+end

--- a/lux/lib/lux/integrations/hyperliquid/perps.ex
+++ b/lux/lib/lux/integrations/hyperliquid/perps.ex
@@ -1,0 +1,593 @@
+defmodule Lux.Integrations.Hyperliquid.Perps do
+  @moduledoc """
+  Perpetual trading helpers for Hyperliquid position, margin, PnL, and risk control.
+
+  These functions are deterministic and credential-free. They normalize Hyperliquid
+  account payloads, validate order/margin/leverage requests, and build compact
+  exchange actions that can be signed by a caller-owned signer.
+  """
+
+  @default_policy %{
+    max_leverage: 5.0,
+    max_order_notional_pct: 0.10,
+    max_position_notional_pct: 0.35,
+    max_margin_usage_pct: 0.65,
+    min_liquidation_buffer_pct: 0.12,
+    min_account_value: 0.0
+  }
+
+  @limit_tifs ["Alo", "Ioc", "Gtc"]
+  @trigger_types ["tp", "sl"]
+  @margin_actions ["add", "remove"]
+
+  @doc "Returns the default risk policy used by `risk_check/4`."
+  @spec default_policy() :: map()
+  def default_policy, do: @default_policy
+
+  @doc "Normalizes Hyperliquid asset positions."
+  @spec positions(map()) :: [map()]
+  def positions(user_state) when is_map(user_state) do
+    user_state
+    |> value(:assetPositions, [])
+    |> Enum.map(&normalize_position/1)
+    |> Enum.reject(&(&1.size == 0.0))
+  end
+
+  @doc "Summarizes account margin, leverage, and maintenance usage."
+  @spec margin_summary(map()) :: map()
+  def margin_summary(user_state) when is_map(user_state) do
+    margin = value(user_state, :crossMarginSummary, value(user_state, :marginSummary, %{}))
+    account_value = numeric(value(margin, :accountValue, 0))
+    total_notional = numeric(value(margin, :totalNtlPos, 0))
+    margin_used = numeric(value(margin, :totalMarginUsed, 0))
+    maintenance = numeric(value(user_state, :crossMaintenanceMarginUsed, 0))
+
+    %{
+      account_value: account_value,
+      total_notional: total_notional,
+      margin_used: margin_used,
+      maintenance_margin_used: maintenance,
+      withdrawable: numeric(value(user_state, :withdrawable, 0)),
+      leverage: ratio(total_notional, account_value),
+      margin_usage: ratio(margin_used, account_value),
+      maintenance_usage: ratio(maintenance, account_value)
+    }
+  end
+
+  @doc "Builds a validated order request compatible with the existing execution prism."
+  @spec order_request(map()) :: {:ok, map()} | {:error, [String.t()]}
+  def order_request(params) when is_map(params) do
+    {order_type, order_type_errors} =
+      validate_order_type(value(params, :order_type, %{limit: %{tif: "Gtc"}}))
+
+    request = %{
+      coin: value(params, :coin),
+      asset_index: value(params, :asset_index),
+      is_buy: value(params, :is_buy),
+      sz: numeric(value(params, :sz, value(params, :size, 0))),
+      limit_px: numeric(value(params, :limit_px, value(params, :price, 0))),
+      order_type: order_type,
+      reduce_only: value(params, :reduce_only, false),
+      cloid: value(params, :cloid),
+      grouping: value(params, :grouping, "na")
+    }
+
+    errors =
+      order_type_errors
+      |> maybe_add(not is_binary(request.coin) or request.coin == "", "coin is required")
+      |> maybe_add(not is_boolean(request.is_buy), "is_buy must be boolean")
+      |> maybe_add(request.sz <= 0, "size must be positive")
+      |> maybe_add(request.limit_px <= 0, "limit price must be positive")
+      |> maybe_add(not is_boolean(request.reduce_only), "reduce_only must be boolean")
+
+    if errors == [], do: {:ok, request}, else: {:error, Enum.reverse(errors)}
+  end
+
+  @doc "Builds a cancel request for oid or cloid order management."
+  @spec cancel_request(map()) :: {:ok, map()} | {:error, [String.t()]}
+  def cancel_request(params) when is_map(params) do
+    request = %{
+      coin: value(params, :coin),
+      asset_index: value(params, :asset_index),
+      oid: value(params, :oid),
+      cloid: value(params, :cloid)
+    }
+
+    errors =
+      []
+      |> maybe_add(not is_binary(request.coin) or request.coin == "", "coin is required")
+      |> maybe_add(is_nil(request.oid) and is_nil(request.cloid), "oid or cloid is required")
+
+    if errors == [], do: {:ok, request}, else: {:error, Enum.reverse(errors)}
+  end
+
+  @doc "Builds a leverage-control request."
+  @spec leverage_request(map()) :: {:ok, map()} | {:error, [String.t()]}
+  def leverage_request(params) when is_map(params) do
+    request = %{
+      coin: value(params, :coin),
+      asset_index: value(params, :asset_index),
+      leverage: round(numeric(value(params, :leverage, 0))),
+      is_cross: value(params, :is_cross, true)
+    }
+
+    errors =
+      []
+      |> maybe_add(not is_binary(request.coin) or request.coin == "", "coin is required")
+      |> maybe_add(
+        request.leverage < 1 or request.leverage > 50,
+        "leverage must be between 1 and 50"
+      )
+      |> maybe_add(not is_boolean(request.is_cross), "is_cross must be boolean")
+
+    if errors == [], do: {:ok, request}, else: {:error, Enum.reverse(errors)}
+  end
+
+  @doc "Builds an isolated-margin adjustment request."
+  @spec margin_request(map()) :: {:ok, map()} | {:error, [String.t()]}
+  def margin_request(params) when is_map(params) do
+    action = value(params, :action, "add")
+    amount = numeric(value(params, :amount, 0))
+
+    request = %{
+      coin: value(params, :coin),
+      asset_index: value(params, :asset_index),
+      action: action,
+      amount: amount,
+      margin_delta: if(action == "remove", do: -amount, else: amount),
+      is_buy: value(params, :is_buy, true)
+    }
+
+    errors =
+      []
+      |> maybe_add(not is_binary(request.coin) or request.coin == "", "coin is required")
+      |> maybe_add(action not in @margin_actions, "action must be add or remove")
+      |> maybe_add(amount <= 0, "amount must be positive")
+      |> maybe_add(not is_boolean(request.is_buy), "is_buy must be boolean")
+
+    if errors == [], do: {:ok, request}, else: {:error, Enum.reverse(errors)}
+  end
+
+  @doc "Builds a compact Hyperliquid order action from a validated request."
+  @spec order_action(map(), map() | keyword() | nil) :: {:ok, map()} | {:error, [String.t()]}
+  def order_action(order, meta_or_opts \\ nil) do
+    with {:ok, request} <- order_request(order),
+         {:ok, asset} <- resolve_asset(meta_or_opts, request) do
+      compact_order =
+        %{
+          a: asset,
+          b: request.is_buy,
+          p: decimal_string(request.limit_px),
+          s: decimal_string(abs(request.sz)),
+          r: request.reduce_only,
+          t: compact_order_type(request.order_type)
+        }
+        |> maybe_put(:c, request.cloid)
+
+      {:ok, %{type: "order", orders: [compact_order], grouping: request.grouping}}
+    else
+      {:error, errors} when is_list(errors) -> {:error, errors}
+      {:error, error} -> {:error, [error]}
+    end
+  end
+
+  @doc "Builds a compact Hyperliquid cancel or cancel-by-cloid action."
+  @spec cancel_action(map(), map() | keyword() | nil) :: {:ok, map()} | {:error, [String.t()]}
+  def cancel_action(cancel, meta_or_opts \\ nil) do
+    with {:ok, request} <- cancel_request(cancel),
+         {:ok, asset} <- resolve_asset(meta_or_opts, request) do
+      if request.cloid do
+        {:ok, %{type: "cancelByCloid", cancels: [%{asset: asset, cloid: request.cloid}]}}
+      else
+        {:ok, %{type: "cancel", cancels: [%{a: asset, o: request.oid}]}}
+      end
+    else
+      {:error, errors} when is_list(errors) -> {:error, errors}
+      {:error, error} -> {:error, [error]}
+    end
+  end
+
+  @doc "Builds a compact Hyperliquid updateLeverage action."
+  @spec leverage_action(map(), map() | keyword() | nil) :: {:ok, map()} | {:error, [String.t()]}
+  def leverage_action(leverage, meta_or_opts \\ nil) do
+    with {:ok, request} <- leverage_request(leverage),
+         {:ok, asset} <- resolve_asset(meta_or_opts, request) do
+      {:ok,
+       %{
+         type: "updateLeverage",
+         asset: asset,
+         isCross: request.is_cross,
+         leverage: request.leverage
+       }}
+    else
+      {:error, errors} when is_list(errors) -> {:error, errors}
+      {:error, error} -> {:error, [error]}
+    end
+  end
+
+  @doc "Builds a compact Hyperliquid updateIsolatedMargin action."
+  @spec margin_action(map(), map() | keyword() | nil) :: {:ok, map()} | {:error, [String.t()]}
+  def margin_action(margin, meta_or_opts \\ nil) do
+    with {:ok, request} <- margin_request(margin),
+         {:ok, asset} <- resolve_asset(meta_or_opts, request) do
+      {:ok,
+       %{
+         type: "updateIsolatedMargin",
+         asset: asset,
+         isBuy: request.is_buy,
+         ntli: round(request.margin_delta * 1_000_000)
+       }}
+    else
+      {:error, errors} when is_list(errors) -> {:error, errors}
+      {:error, error} -> {:error, [error]}
+    end
+  end
+
+  @doc "Returns PnL totals from current positions, fills, and funding records."
+  @spec pnl_tracking(map(), [map()], [map()]) :: map()
+  def pnl_tracking(user_state, fills \\ [], funding \\ []) do
+    open_positions = positions(user_state)
+
+    realized =
+      fills
+      |> Enum.map(&(numeric(value(&1, :closedPnl, 0)) - numeric(value(&1, :fee, 0))))
+      |> Enum.sum()
+
+    funding_total =
+      funding
+      |> Enum.map(&numeric(value(&1, :delta, value(&1, :payment, 0))))
+      |> Enum.sum()
+
+    unrealized = Enum.reduce(open_positions, 0.0, &(&1.unrealized_pnl + &2))
+    margin_used = Enum.reduce(open_positions, 0.0, &(&1.margin_used + &2))
+    total_pnl = realized + unrealized + funding_total
+
+    %{
+      open_positions: open_positions,
+      realized_pnl: realized,
+      unrealized_pnl: unrealized,
+      funding_pnl: funding_total,
+      total_pnl: total_pnl,
+      margin_used: margin_used,
+      return_on_margin: ratio(total_pnl, margin_used)
+    }
+  end
+
+  @doc "Calculates liquidation buffers and risk levels for open positions."
+  @spec liquidation_monitor(map(), map(), keyword() | map()) :: map()
+  def liquidation_monitor(user_state, mids, opts \\ []) do
+    policy = policy(opts)
+
+    monitored =
+      user_state
+      |> positions()
+      |> Enum.map(fn position ->
+        mark = market_price(mids, position.coin, position.mark_price)
+        buffer = liquidation_buffer(position, mark)
+        level = liquidation_level(buffer, policy)
+
+        position
+        |> Map.put(:mark_price, mark)
+        |> Map.put(:liquidation_buffer_pct, buffer)
+        |> Map.put(:risk_level, level)
+        |> Map.put(:liquidation_alert, level in [:warning, :critical])
+      end)
+
+    %{
+      status:
+        if(Enum.any?(monitored, & &1.liquidation_alert), do: :attention_required, else: :healthy),
+      positions: monitored,
+      alerts:
+        monitored
+        |> Enum.filter(& &1.liquidation_alert)
+        |> Enum.map(
+          &"#{&1.coin} liquidation buffer is #{Float.round(&1.liquidation_buffer_pct * 100, 2)}%"
+        )
+    }
+  end
+
+  @doc "Checks a proposed order against margin, leverage, notional, and liquidation policy."
+  @spec risk_check(map(), map(), map(), keyword() | map()) ::
+          {:ok, map()} | {:error, map() | [String.t()]}
+  def risk_check(user_state, mids, order, opts \\ []) do
+    with {:ok, request} <- order_request(order) do
+      policy = policy(opts)
+      margin = margin_summary(user_state)
+      mark = market_price(mids, request.coin, request.limit_px)
+      order_notional = request.sz * mark
+      existing_position = Enum.find(positions(user_state), &(&1.coin == request.coin))
+
+      current_position_notional =
+        if existing_position, do: abs(existing_position.position_value), else: 0.0
+
+      projected_position_notional =
+        if request.reduce_only do
+          max(current_position_notional - order_notional, 0.0)
+        else
+          current_position_notional + order_notional
+        end
+
+      projected_total_notional =
+        if request.reduce_only do
+          max(margin.total_notional - order_notional, 0.0)
+        else
+          margin.total_notional + order_notional
+        end
+
+      projected_leverage = ratio(projected_total_notional, margin.account_value)
+      order_notional_pct = ratio(order_notional, margin.account_value)
+      position_notional_pct = ratio(projected_position_notional, margin.account_value)
+
+      projected_margin_usage =
+        ratio(
+          margin.margin_used + initial_margin(order_notional, projected_leverage),
+          margin.account_value
+        )
+
+      liquidation = liquidation_monitor(user_state, mids, policy: policy)
+
+      alerts =
+        []
+        |> maybe_add(
+          margin.account_value <= policy.min_account_value,
+          "account value is below policy"
+        )
+        |> maybe_add(
+          projected_leverage > policy.max_leverage,
+          "projected leverage exceeds policy"
+        )
+        |> maybe_add(
+          order_notional_pct > policy.max_order_notional_pct,
+          "order notional exceeds policy"
+        )
+        |> maybe_add(
+          position_notional_pct > policy.max_position_notional_pct,
+          "projected position notional exceeds policy"
+        )
+        |> maybe_add(
+          projected_margin_usage > policy.max_margin_usage_pct,
+          "projected margin usage exceeds policy"
+        )
+        |> maybe_add(
+          liquidation.status != :healthy,
+          "existing position liquidation buffer is below policy"
+        )
+
+      decision = %{
+        decision: if(alerts == [], do: :approved, else: :blocked),
+        order: request,
+        mark_price: mark,
+        order_notional: order_notional,
+        order_notional_pct: order_notional_pct,
+        projected_position_notional_pct: position_notional_pct,
+        projected_leverage: projected_leverage,
+        projected_margin_usage: projected_margin_usage,
+        margin: margin,
+        liquidation: liquidation,
+        policy: policy,
+        alerts: Enum.reverse(alerts)
+      }
+
+      if decision.decision == :approved, do: {:ok, decision}, else: {:error, decision}
+    end
+  end
+
+  @doc "Builds a compact trading dashboard payload."
+  @spec dashboard(map(), keyword() | map()) :: map()
+  def dashboard(input, opts \\ []) do
+    user_state = value(input, :user_state, %{})
+    mids = value(input, :mids, %{})
+    fills = value(input, :fills, [])
+    funding = value(input, :funding, [])
+    orders = value(input, :open_orders, [])
+
+    liquidation = liquidation_monitor(user_state, mids, opts)
+
+    %{
+      status: if(liquidation.status == :healthy, do: :healthy, else: :attention_required),
+      margin: margin_summary(user_state),
+      positions: positions(user_state),
+      pnl: pnl_tracking(user_state, fills, funding),
+      liquidation: liquidation,
+      open_orders: orders,
+      open_order_count: length(orders)
+    }
+  end
+
+  defp normalize_position(%{"position" => position} = wrapped) do
+    position
+    |> Map.put_new("cumulativeFunding", value(wrapped, :cumulativeFunding, %{}))
+    |> normalize_position()
+  end
+
+  defp normalize_position(%{position: position} = wrapped) do
+    position
+    |> Map.put_new(:cumulativeFunding, value(wrapped, :cumulativeFunding, %{}))
+    |> normalize_position()
+  end
+
+  defp normalize_position(position) do
+    size = numeric(value(position, :szi, value(position, :size, 0)))
+    entry = nullable_numeric(value(position, :entryPx))
+    liquidation = nullable_numeric(value(position, :liquidationPx))
+    leverage = leverage_value(value(position, :leverage))
+
+    %{
+      coin: value(position, :coin),
+      size: size,
+      abs_size: abs(size),
+      side: if(size >= 0, do: :long, else: :short),
+      entry_price: entry,
+      position_value: numeric(value(position, :positionValue, 0)),
+      unrealized_pnl: numeric(value(position, :unrealizedPnl, 0)),
+      return_on_equity: numeric(value(position, :returnOnEquity, 0)),
+      leverage: leverage,
+      liquidation_price: liquidation,
+      margin_used: numeric(value(position, :marginUsed, 0)),
+      max_leverage: numeric(value(position, :maxLeverage, 0)),
+      mark_price: numeric(value(position, :markPx, entry || 0)),
+      cumulative_funding: numeric(value(value(position, :cumulativeFunding, %{}), :payment, 0))
+    }
+  end
+
+  defp validate_order_type(order_type) do
+    case {value(order_type, :limit), value(order_type, :trigger)} do
+      {limit, _trigger} when is_map(limit) ->
+        tif = value(limit, :tif)
+
+        if tif in @limit_tifs do
+          {%{limit: %{tif: tif}}, []}
+        else
+          {order_type, ["limit tif must be one of #{Enum.join(@limit_tifs, ", ")}"]}
+        end
+
+      {_limit, trigger} when is_map(trigger) ->
+        trigger_px = numeric(value(trigger, :triggerPx, value(trigger, :trigger_px, 0)))
+        is_market = value(trigger, :isMarket, value(trigger, :is_market))
+        tpsl = value(trigger, :tpsl)
+
+        errors =
+          []
+          |> maybe_add(trigger_px <= 0, "trigger price must be positive")
+          |> maybe_add(not is_boolean(is_market), "trigger isMarket must be boolean")
+          |> maybe_add(tpsl not in @trigger_types, "trigger tpsl must be tp or sl")
+
+        if errors == [] do
+          {%{trigger: %{triggerPx: trigger_px, isMarket: is_market, tpsl: tpsl}}, []}
+        else
+          {order_type, Enum.reverse(errors)}
+        end
+
+      _ ->
+        {order_type, ["order_type must include limit or trigger"]}
+    end
+  end
+
+  defp compact_order_type(%{limit: %{tif: tif}}), do: %{limit: %{tif: tif}}
+
+  defp compact_order_type(%{trigger: trigger}) do
+    %{
+      trigger: %{
+        isMarket: trigger.isMarket,
+        triggerPx: decimal_string(trigger.triggerPx),
+        tpsl: trigger.tpsl
+      }
+    }
+  end
+
+  defp resolve_asset(meta_or_opts, request) do
+    cond do
+      is_integer(value(request, :asset_index)) ->
+        {:ok, value(request, :asset_index)}
+
+      is_integer(value(opts_map(meta_or_opts), :asset_index)) ->
+        {:ok, value(opts_map(meta_or_opts), :asset_index)}
+
+      true ->
+        opts = opts_map(meta_or_opts)
+        meta = value(opts, :meta, meta_or_opts)
+        asset_index(meta, request.coin)
+    end
+  end
+
+  defp asset_index(meta, coin) when is_map(meta) do
+    direct = Map.get(meta, coin)
+
+    cond do
+      is_integer(direct) ->
+        {:ok, direct}
+
+      is_list(value(meta, :universe)) ->
+        meta
+        |> value(:universe)
+        |> Enum.find_index(&(value(&1, :name) == coin))
+        |> case do
+          nil -> {:error, "asset_index or meta universe entry for #{coin} is required"}
+          index -> {:ok, index}
+        end
+
+      true ->
+        {:error, "asset_index or meta universe entry for #{coin} is required"}
+    end
+  end
+
+  defp asset_index(_meta, coin),
+    do: {:error, "asset_index or meta universe entry for #{coin} is required"}
+
+  defp liquidation_buffer(%{liquidation_price: nil}, _mark), do: 1.0
+  defp liquidation_buffer(_position, mark) when mark <= 0, do: 0.0
+  defp liquidation_buffer(%{liquidation_price: liq}, mark), do: abs(mark - liq) / mark
+
+  defp liquidation_level(buffer, policy) when buffer <= policy.min_liquidation_buffer_pct / 2,
+    do: :critical
+
+  defp liquidation_level(buffer, policy) when buffer < policy.min_liquidation_buffer_pct,
+    do: :warning
+
+  defp liquidation_level(_buffer, _policy), do: :safe
+
+  defp market_price(mids, coin, fallback), do: numeric(value(mids, coin, fallback))
+
+  defp initial_margin(_notional, leverage) when leverage <= 0, do: 0.0
+  defp initial_margin(notional, leverage), do: notional / max(leverage, 1.0)
+
+  defp policy(opts), do: Map.merge(@default_policy, opts |> value(:policy, %{}) |> opts_map())
+
+  defp leverage_value(%{"value" => value, "type" => type}),
+    do: %{type: type, value: numeric(value)}
+
+  defp leverage_value(%{value: value, type: type}), do: %{type: type, value: numeric(value)}
+  defp leverage_value(value), do: %{type: nil, value: numeric(value)}
+
+  defp ratio(_numerator, denominator) when denominator in [0, 0.0], do: 0.0
+  defp ratio(numerator, denominator), do: numerator / denominator
+
+  defp maybe_add(alerts, true, message), do: [message | alerts]
+  defp maybe_add(alerts, false, _message), do: alerts
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp value(map, key, default \\ nil)
+  defp value(nil, _key, default), do: default
+  defp value(map, key, default) when is_map(map), do: map_get(map, key, default)
+  defp value(list, key, default) when is_list(list), do: Keyword.get(list, key, default)
+
+  defp map_get(map, key, default) do
+    string_key = to_string(key)
+
+    cond do
+      Map.has_key?(map, key) -> Map.fetch!(map, key)
+      Map.has_key?(map, string_key) -> Map.fetch!(map, string_key)
+      true -> default
+    end
+  end
+
+  defp opts_map(nil), do: %{}
+  defp opts_map(opts) when is_map(opts), do: opts
+  defp opts_map(opts) when is_list(opts), do: Map.new(opts)
+
+  defp nullable_numeric(nil), do: nil
+  defp nullable_numeric("nil"), do: nil
+  defp nullable_numeric(value), do: numeric(value)
+
+  defp numeric(nil), do: 0.0
+  defp numeric(value) when is_integer(value), do: value * 1.0
+  defp numeric(value) when is_float(value), do: value
+
+  defp numeric(value) when is_binary(value) do
+    case Float.parse(value) do
+      {number, _rest} -> number
+      :error -> 0.0
+    end
+  end
+
+  defp decimal_string(value) when is_integer(value), do: Integer.to_string(value)
+
+  defp decimal_string(value) when is_float(value) do
+    value
+    |> :erlang.float_to_binary(decimals: 8)
+    |> String.trim_trailing("0")
+    |> String.trim_trailing(".")
+  end
+end

--- a/lux/lib/lux/prisms/hyperliquid/hyperliquid_order_management_prism.ex
+++ b/lux/lib/lux/prisms/hyperliquid/hyperliquid_order_management_prism.ex
@@ -1,0 +1,127 @@
+defmodule Lux.Prisms.Hyperliquid.HyperliquidOrderManagementPrism do
+  @moduledoc """
+  Plans Hyperliquid perpetual order, cancel, leverage, and margin actions.
+
+  The prism validates request shape, builds the compact exchange action used by
+  Hyperliquid signing adapters, and can run a local risk check when user state
+  and mid prices are supplied. It does not handle private keys or submit live
+  orders by itself.
+  """
+
+  use Lux.Prism,
+    name: "Hyperliquid Perps Order Management",
+    description: "Validates and plans Hyperliquid order, cancel, leverage, and margin actions",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        operation: %{
+          type: :string,
+          enum: ["order", "cancel", "set_leverage", "update_margin"],
+          description: "Action to plan"
+        },
+        coin: %{type: :string, description: "Perpetual coin symbol, such as ETH"},
+        asset_index: %{type: :integer, description: "Optional asset index from Hyperliquid meta"},
+        meta: %{type: :object, description: "Optional Hyperliquid meta payload with universe"},
+        is_buy: %{type: :boolean},
+        sz: %{type: :number},
+        limit_px: %{type: :number},
+        order_type: %{type: :object},
+        reduce_only: %{type: :boolean},
+        oid: %{type: [:integer, :string]},
+        cloid: %{type: :string},
+        leverage: %{type: :integer},
+        is_cross: %{type: :boolean},
+        amount: %{type: :number},
+        action: %{type: :string, enum: ["add", "remove"]},
+        user_state: %{type: :object},
+        mids: %{type: :object},
+        policy: %{type: :object}
+      },
+      required: ["operation", "coin"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        status: %{type: :string},
+        operation: %{type: :string},
+        request: %{type: :object},
+        exchange_action: %{type: :object},
+        risk_decision: %{type: :object}
+      },
+      required: ["status", "operation", "request", "exchange_action"]
+    }
+
+  alias Lux.Integrations.Hyperliquid.Perps
+
+  def handler(%{operation: "order"} = input, _ctx) do
+    with {:ok, request} <- Perps.order_request(input),
+         {:ok, exchange_action} <- Perps.order_action(input, action_opts(input)) do
+      {:ok,
+       %{
+         status: "planned",
+         operation: "order",
+         request: request,
+         exchange_action: exchange_action,
+         risk_decision: risk_decision(input)
+       }}
+    end
+  end
+
+  def handler(%{operation: "cancel"} = input, _ctx) do
+    with {:ok, request} <- Perps.cancel_request(input),
+         {:ok, exchange_action} <- Perps.cancel_action(input, action_opts(input)) do
+      {:ok,
+       %{
+         status: "planned",
+         operation: "cancel",
+         request: request,
+         exchange_action: exchange_action
+       }}
+    end
+  end
+
+  def handler(%{operation: "set_leverage"} = input, _ctx) do
+    with {:ok, request} <- Perps.leverage_request(input),
+         {:ok, exchange_action} <- Perps.leverage_action(input, action_opts(input)) do
+      {:ok,
+       %{
+         status: "planned",
+         operation: "set_leverage",
+         request: request,
+         exchange_action: exchange_action
+       }}
+    end
+  end
+
+  def handler(%{operation: "update_margin"} = input, _ctx) do
+    with {:ok, request} <- Perps.margin_request(input),
+         {:ok, exchange_action} <- Perps.margin_action(input, action_opts(input)) do
+      {:ok,
+       %{
+         status: "planned",
+         operation: "update_margin",
+         request: request,
+         exchange_action: exchange_action
+       }}
+    end
+  end
+
+  def handler(_input, _ctx),
+    do: {:error, ["operation must be order, cancel, set_leverage, or update_margin"]}
+
+  defp action_opts(input) do
+    %{
+      meta: Map.get(input, :meta),
+      asset_index: Map.get(input, :asset_index)
+    }
+  end
+
+  defp risk_decision(%{user_state: user_state, mids: mids} = input) do
+    case Perps.risk_check(user_state, mids, input, policy: Map.get(input, :policy, %{})) do
+      {:ok, decision} -> decision
+      {:error, decision} -> decision
+    end
+  end
+
+  defp risk_decision(_input), do: nil
+end

--- a/lux/lib/lux/prisms/hyperliquid/hyperliquid_perps_dashboard_prism.ex
+++ b/lux/lib/lux/prisms/hyperliquid/hyperliquid_perps_dashboard_prism.ex
@@ -1,0 +1,81 @@
+defmodule Lux.Prisms.Hyperliquid.HyperliquidPerpsDashboardPrism do
+  @moduledoc """
+  Builds a Hyperliquid perpetual trading dashboard for positions, PnL, margin, and liquidation risk.
+
+  Callers may pass already-fetched `user_state`, `mids`, `open_orders`, `fills`,
+  and `funding` for an offline calculation. If those are omitted, the prism uses
+  the mockable Hyperliquid client to fetch public info endpoint data for `address`.
+  """
+
+  use Lux.Prism,
+    name: "Hyperliquid Perps Dashboard",
+    description: "Summarizes Hyperliquid positions, margin, PnL, orders, and liquidation risk",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        address: %{
+          type: :string,
+          description: "Wallet, subaccount, or vault address",
+          pattern: "^0x[a-fA-F0-9]{40}$"
+        },
+        user_state: %{type: :object},
+        mids: %{type: :object},
+        open_orders: %{type: :array},
+        fills: %{type: :array},
+        funding: %{type: :array},
+        policy: %{type: :object}
+      },
+      required: ["address"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        status: %{type: :string},
+        address: %{type: :string},
+        dashboard: %{type: :object}
+      },
+      required: ["status", "address", "dashboard"]
+    }
+
+  alias Lux.Integrations.Hyperliquid.Client
+  alias Lux.Integrations.Hyperliquid.Perps
+
+  def handler(%{address: address} = input, _ctx) do
+    opts = client_opts(input)
+
+    with {:ok, user_state} <-
+           fetch_or_use(input, :user_state, fn -> Client.clearinghouse_state(address, opts) end),
+         {:ok, mids} <- fetch_or_use(input, :mids, fn -> Client.all_mids(opts) end),
+         {:ok, open_orders} <-
+           fetch_or_use(input, :open_orders, fn -> Client.open_orders(address, opts) end),
+         {:ok, fills} <- fetch_or_use(input, :fills, fn -> Client.user_fills(address, opts) end) do
+      dashboard =
+        Perps.dashboard(
+          %{
+            user_state: user_state,
+            mids: mids,
+            open_orders: open_orders,
+            fills: fills,
+            funding: Map.get(input, :funding, [])
+          },
+          policy: Map.get(input, :policy, %{})
+        )
+
+      {:ok, %{status: Atom.to_string(dashboard.status), address: address, dashboard: dashboard}}
+    end
+  end
+
+  defp fetch_or_use(input, key, fetch_fun) do
+    case Map.fetch(input, key) do
+      {:ok, value} -> {:ok, value}
+      :error -> fetch_fun.()
+    end
+  end
+
+  defp client_opts(input) do
+    input
+    |> Map.take([:base_url, :headers, :plug, :receive_timeout])
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+end

--- a/lux/mix.exs
+++ b/lux/mix.exs
@@ -136,6 +136,7 @@ defmodule Lux.MixProject do
         "guides/prisms.livemd",
         "guides/signals.livemd",
         "guides/lenses.livemd",
+        "guides/hyperliquid_perps.livemd",
         "guides/language_support.md",
         "guides/language_support/python.livemd",
         "guides/language_support/nodejs.livemd",

--- a/lux/test/integration/hyperliquid_perps_workflow_test.exs
+++ b/lux/test/integration/hyperliquid_perps_workflow_test.exs
@@ -1,0 +1,117 @@
+defmodule Lux.Integrations.HyperliquidPerpsWorkflowTest do
+  use IntegrationCase, async: true
+
+  alias Lux.Integrations.Hyperliquid.Client
+  alias Lux.Integrations.Hyperliquid.Perps
+  alias Lux.Prisms.Hyperliquid.HyperliquidOrderManagementPrism
+  alias Lux.Prisms.Hyperliquid.HyperliquidPerpsDashboardPrism
+
+  @user "0x0000000000000000000000000000000000000001"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  test "loads user state, plans a safe order, and builds a trading dashboard" do
+    Req.Test.stub(HyperliquidWorkflowMock, fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      payload = Jason.decode!(body)
+
+      response =
+        case payload["type"] do
+          "meta" ->
+            %{"universe" => [%{"name" => "BTC"}, %{"name" => "ETH"}]}
+
+          "clearinghouseState" ->
+            user_state()
+
+          "allMids" ->
+            %{"ETH" => "3000"}
+
+          "openOrders" ->
+            [%{"coin" => "ETH", "oid" => 42}]
+
+          "userFills" ->
+            [%{"coin" => "ETH", "closedPnl" => "25"}]
+        end
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(response))
+    end)
+
+    opts = [plug: {Req.Test, HyperliquidWorkflowMock}]
+
+    assert {:ok, meta} = Client.meta(opts)
+    assert {:ok, user_state} = Client.clearinghouse_state(@user, opts)
+    assert {:ok, mids} = Client.all_mids(opts)
+    assert {:ok, orders} = Client.open_orders(@user, opts)
+    assert {:ok, fills} = Client.user_fills(@user, opts)
+
+    order = %{
+      operation: "order",
+      coin: "ETH",
+      meta: meta,
+      is_buy: true,
+      sz: 0.1,
+      limit_px: 3000,
+      order_type: %{limit: %{tif: "Gtc"}},
+      user_state: user_state,
+      mids: mids,
+      policy: %{max_position_notional_pct: 0.50}
+    }
+
+    assert {:ok, decision} =
+             Perps.risk_check(user_state, mids, order, policy: %{max_position_notional_pct: 0.50})
+
+    assert {:ok, planned} = HyperliquidOrderManagementPrism.handler(order, %{})
+
+    assert {:ok, dashboard_result} =
+             HyperliquidPerpsDashboardPrism.handler(
+               %{address: @user, plug: {Req.Test, HyperliquidWorkflowMock}},
+               %{}
+             )
+
+    dashboard =
+      Perps.dashboard(%{
+        user_state: user_state,
+        mids: mids,
+        fills: fills,
+        open_orders: orders
+      })
+
+    assert decision.decision == :approved
+    assert planned.exchange_action.orders |> hd() |> Map.fetch!(:a) == 1
+    assert dashboard.margin.leverage == 1.5
+    assert dashboard.pnl.total_pnl == 525.0
+    assert dashboard.open_order_count == 1
+    assert dashboard.liquidation.status == :healthy
+    assert dashboard_result.dashboard.open_order_count == 1
+  end
+
+  defp user_state do
+    %{
+      "crossMarginSummary" => %{
+        "accountValue" => "10000",
+        "totalNtlPos" => "15000",
+        "totalMarginUsed" => "2000"
+      },
+      "assetPositions" => [
+        %{
+          "position" => %{
+            "coin" => "ETH",
+            "szi" => "1",
+            "entryPx" => "2500",
+            "positionValue" => "3000",
+            "unrealizedPnl" => "500",
+            "returnOnEquity" => "0.16",
+            "leverage" => %{"type" => "cross", "value" => 3},
+            "liquidationPx" => "1500",
+            "marginUsed" => "1000"
+          }
+        }
+      ]
+    }
+  end
+end

--- a/lux/test/unit/lux/integrations/hyperliquid/client_test.exs
+++ b/lux/test/unit/lux/integrations/hyperliquid/client_test.exs
@@ -1,0 +1,104 @@
+defmodule Lux.Integrations.Hyperliquid.ClientTest do
+  use UnitAPICase, async: true
+
+  alias Lux.Integrations.Hyperliquid.Client
+
+  @user "0x0000000000000000000000000000000000000001"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "info helpers" do
+    test "calls clearinghouseState with a normalized user address" do
+      Req.Test.expect(HyperliquidClientMock, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/info"
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+
+        assert payload["type"] == "clearinghouseState"
+        assert payload["user"] == @user
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(%{
+            "crossMarginSummary" => %{"accountValue" => "1000"},
+            "assetPositions" => []
+          })
+        )
+      end)
+
+      assert {:ok, %{"crossMarginSummary" => %{"accountValue" => "1000"}}} =
+               Client.clearinghouse_state(
+                 String.upcase(@user),
+                 plug: {Req.Test, HyperliquidClientMock}
+               )
+    end
+
+    test "calls l2Book for a perpetual coin" do
+      Req.Test.expect(HyperliquidClientMock, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+
+        assert payload["type"] == "l2Book"
+        assert payload["coin"] == "ETH"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"coin" => "ETH", "levels" => [[], []]}))
+      end)
+
+      assert {:ok, %{"coin" => "ETH"}} =
+               Client.l2_book("ETH", plug: {Req.Test, HyperliquidClientMock})
+    end
+
+    test "normalizes API errors" do
+      Req.Test.expect(HyperliquidClientMock, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(422, Jason.encode!(%{"error" => "invalid request"}))
+      end)
+
+      assert {:error, {422, "invalid request"}} =
+               Client.info(%{type: "unknown"}, plug: {Req.Test, HyperliquidClientMock})
+    end
+  end
+
+  describe "exchange/2" do
+    test "submits an already signed exchange payload to /exchange" do
+      Req.Test.expect(HyperliquidClientMock, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/exchange"
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+
+        assert payload["action"]["type"] == "order"
+        assert payload["nonce"] == 1_714_000_000_000
+        assert payload["signature"]["v"] == 27
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(%{"status" => "ok", "response" => %{"type" => "order"}})
+        )
+      end)
+
+      assert {:ok, %{"status" => "ok"}} =
+               Client.exchange(
+                 %{
+                   action: %{type: "order", orders: []},
+                   nonce: 1_714_000_000_000,
+                   signature: %{r: "0x1", s: "0x2", v: 27}
+                 },
+                 plug: {Req.Test, HyperliquidClientMock}
+               )
+    end
+  end
+end

--- a/lux/test/unit/lux/integrations/hyperliquid/perps_test.exs
+++ b/lux/test/unit/lux/integrations/hyperliquid/perps_test.exs
@@ -1,0 +1,163 @@
+defmodule Lux.Integrations.Hyperliquid.PerpsTest do
+  use UnitAPICase, async: true
+
+  alias Lux.Integrations.Hyperliquid.Perps
+
+  @meta %{"universe" => [%{"name" => "BTC"}, %{"name" => "ETH"}]}
+  @user_state %{
+    "crossMarginSummary" => %{
+      "accountValue" => "10000",
+      "totalNtlPos" => "15000",
+      "totalMarginUsed" => "2000"
+    },
+    "crossMaintenanceMarginUsed" => "500",
+    "withdrawable" => "7500",
+    "assetPositions" => [
+      %{
+        "position" => %{
+          "coin" => "ETH",
+          "szi" => "1",
+          "entryPx" => "2500",
+          "positionValue" => "3000",
+          "unrealizedPnl" => "500",
+          "returnOnEquity" => "0.16",
+          "leverage" => %{"type" => "cross", "value" => 3},
+          "liquidationPx" => "2400",
+          "marginUsed" => "1000"
+        }
+      }
+    ]
+  }
+
+  describe "position and margin tracking" do
+    test "normalizes positions and summarizes margin" do
+      assert [%{coin: "ETH", side: :long, size: 1.0, liquidation_price: 2400.0}] =
+               Perps.positions(@user_state)
+
+      margin = Perps.margin_summary(@user_state)
+      assert margin.account_value == 10_000.0
+      assert margin.leverage == 1.5
+      assert margin.margin_usage == 0.2
+      assert margin.maintenance_usage == 0.05
+    end
+
+    test "tracks realized, unrealized, and funding PnL" do
+      pnl =
+        Perps.pnl_tracking(
+          @user_state,
+          [%{"closedPnl" => "125.5", "fee" => "1.5"}],
+          [%{"delta" => "-2"}]
+        )
+
+      assert pnl.realized_pnl == 124.0
+      assert pnl.unrealized_pnl == 500.0
+      assert pnl.funding_pnl == -2.0
+      assert pnl.total_pnl == 622.0
+      assert pnl.return_on_margin == 0.622
+    end
+  end
+
+  describe "request and action planning" do
+    test "validates order shape and builds compact order actions" do
+      assert {:ok, order} =
+               Perps.order_request(%{
+                 coin: "ETH",
+                 is_buy: true,
+                 sz: "0.5",
+                 limit_px: "3000",
+                 order_type: %{limit: %{tif: "Gtc"}}
+               })
+
+      assert order.sz == 0.5
+      assert order.limit_px == 3000.0
+
+      assert {:ok, action} = Perps.order_action(order, @meta)
+      assert action.type == "order"
+
+      assert [%{a: 1, b: true, p: "3000", s: "0.5", r: false, t: %{limit: %{tif: "Gtc"}}}] =
+               action.orders
+
+      assert {:error, errors} =
+               Perps.order_request(%{coin: "", is_buy: "yes", sz: 0, limit_px: 0})
+
+      assert "coin is required" in errors
+      assert "is_buy must be boolean" in errors
+    end
+
+    test "builds trigger, cancel, leverage, and isolated margin actions" do
+      assert {:ok, trigger_action} =
+               Perps.order_action(
+                 %{
+                   coin: "ETH",
+                   is_buy: false,
+                   sz: 0.25,
+                   limit_px: 2800,
+                   reduce_only: true,
+                   order_type: %{trigger: %{triggerPx: 2750, isMarket: true, tpsl: "sl"}}
+                 },
+                 @meta
+               )
+
+      assert [%{t: %{trigger: %{triggerPx: "2750", isMarket: true, tpsl: "sl"}}}] =
+               trigger_action.orders
+
+      assert {:ok, %{type: "cancel", cancels: [%{a: 1, o: 42}]}} =
+               Perps.cancel_action(%{coin: "ETH", oid: 42}, @meta)
+
+      assert {:ok, %{type: "updateLeverage", asset: 1, isCross: true, leverage: 4}} =
+               Perps.leverage_action(%{coin: "ETH", leverage: 4}, @meta)
+
+      assert {:ok, %{type: "updateIsolatedMargin", asset: 1, isBuy: true, ntli: -125_000_000}} =
+               Perps.margin_action(%{coin: "ETH", amount: 125, action: "remove"}, @meta)
+    end
+  end
+
+  describe "risk controls" do
+    test "blocks orders when liquidation buffer is too small" do
+      assert {:error, decision} =
+               Perps.risk_check(
+                 @user_state,
+                 %{"ETH" => "2500"},
+                 %{coin: "ETH", is_buy: true, sz: 0.1, limit_px: 2500}
+               )
+
+      assert decision.decision == :blocked
+      assert "existing position liquidation buffer is below policy" in decision.alerts
+      assert decision.liquidation.status == :attention_required
+    end
+
+    test "approves small orders when policy passes" do
+      safer_state =
+        put_in(@user_state, ["assetPositions", Access.at(0), "position", "liquidationPx"], "1500")
+
+      assert {:ok, decision} =
+               Perps.risk_check(
+                 safer_state,
+                 %{"ETH" => "3000"},
+                 %{coin: "ETH", is_buy: true, sz: 0.1, limit_px: 3000},
+                 policy: %{max_position_notional_pct: 0.50}
+               )
+
+      assert decision.decision == :approved
+      assert decision.order_notional == 300.0
+      assert decision.projected_leverage == 1.53
+    end
+  end
+
+  describe "dashboard/2" do
+    test "builds a compact trading dashboard" do
+      dashboard =
+        Perps.dashboard(%{
+          user_state: @user_state,
+          mids: %{"ETH" => "2500"},
+          fills: [%{"closedPnl" => "10"}],
+          open_orders: [%{"coin" => "ETH"}]
+        })
+
+      assert dashboard.margin.account_value == 10_000.0
+      assert dashboard.pnl.total_pnl == 510.0
+      assert dashboard.open_order_count == 1
+      assert dashboard.liquidation.status == :attention_required
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/hyperliquid/perps_prisms_test.exs
+++ b/lux/test/unit/lux/prisms/hyperliquid/perps_prisms_test.exs
@@ -1,0 +1,102 @@
+defmodule Lux.Prisms.Hyperliquid.PerpsPrismsTest do
+  use UnitAPICase, async: true
+
+  alias Lux.Prisms.Hyperliquid.HyperliquidOrderManagementPrism
+  alias Lux.Prisms.Hyperliquid.HyperliquidPerpsDashboardPrism
+
+  @address "0x0000000000000000000000000000000000000001"
+  @meta %{"universe" => [%{"name" => "BTC"}, %{"name" => "ETH"}]}
+  @user_state %{
+    "crossMarginSummary" => %{
+      "accountValue" => "10000",
+      "totalNtlPos" => "15000",
+      "totalMarginUsed" => "2000"
+    },
+    "assetPositions" => [
+      %{
+        "position" => %{
+          "coin" => "ETH",
+          "szi" => "1",
+          "entryPx" => "2500",
+          "positionValue" => "3000",
+          "unrealizedPnl" => "500",
+          "returnOnEquity" => "0.16",
+          "leverage" => %{"type" => "cross", "value" => 3},
+          "liquidationPx" => "1500",
+          "marginUsed" => "1000"
+        }
+      }
+    ]
+  }
+
+  test "order management prism plans an order with risk verification" do
+    assert {:ok, result} =
+             HyperliquidOrderManagementPrism.handler(
+               %{
+                 operation: "order",
+                 coin: "ETH",
+                 meta: @meta,
+                 is_buy: true,
+                 sz: 0.1,
+                 limit_px: 3000,
+                 order_type: %{limit: %{tif: "Gtc"}},
+                 user_state: @user_state,
+                 mids: %{"ETH" => "3000"},
+                 policy: %{max_position_notional_pct: 0.50}
+               },
+               %{}
+             )
+
+    assert result.status == "planned"
+    assert result.exchange_action.type == "order"
+    assert result.risk_decision.decision == :approved
+  end
+
+  test "order management prism plans leverage and margin controls" do
+    assert {:ok, leverage} =
+             HyperliquidOrderManagementPrism.handler(
+               %{operation: "set_leverage", coin: "ETH", asset_index: 1, leverage: 5},
+               %{}
+             )
+
+    assert leverage.exchange_action == %{
+             type: "updateLeverage",
+             asset: 1,
+             isCross: true,
+             leverage: 5
+           }
+
+    assert {:ok, margin} =
+             HyperliquidOrderManagementPrism.handler(
+               %{
+                 operation: "update_margin",
+                 coin: "ETH",
+                 asset_index: 1,
+                 amount: 100,
+                 action: "add"
+               },
+               %{}
+             )
+
+    assert margin.exchange_action.ntli == 100_000_000
+  end
+
+  test "dashboard prism builds an offline perps summary" do
+    assert {:ok, result} =
+             HyperliquidPerpsDashboardPrism.handler(
+               %{
+                 address: @address,
+                 user_state: @user_state,
+                 mids: %{"ETH" => "3000"},
+                 open_orders: [%{"coin" => "ETH", "oid" => 42}],
+                 fills: [%{"coin" => "ETH", "closedPnl" => "25"}],
+                 policy: %{max_position_notional_pct: 0.50}
+               },
+               %{}
+             )
+
+    assert result.status == "healthy"
+    assert result.dashboard.open_order_count == 1
+    assert result.dashboard.pnl.total_pnl == 525.0
+  end
+end


### PR DESCRIPTION
Fixes #82

## Summary
- Adds a Req-based Hyperliquid REST client for public `/info` reads and already-signed `/exchange` payload submission.
- Adds deterministic perpetual-trading helpers for order, cancel, leverage, and isolated-margin action planning; position normalization; margin/PnL tracking; liquidation monitoring; and policy risk checks.
- Adds agent prisms for Hyperliquid order-management planning and a perps dashboard, plus a Livebook guide and mock-backed unit/integration tests.

## Validation
- `mix format --check-formatted lib/lux/integrations/hyperliquid.ex lib/lux/integrations/hyperliquid/client.ex lib/lux/integrations/hyperliquid/perps.ex lib/lux/prisms/hyperliquid/hyperliquid_order_management_prism.ex lib/lux/prisms/hyperliquid/hyperliquid_perps_dashboard_prism.ex test/unit/lux/integrations/hyperliquid/client_test.exs test/unit/lux/integrations/hyperliquid/perps_test.exs test/unit/lux/prisms/hyperliquid/perps_prisms_test.exs test/integration/hyperliquid_perps_workflow_test.exs mix.exs`
- `mix credo --strict lib/lux/integrations/hyperliquid.ex lib/lux/integrations/hyperliquid/client.ex lib/lux/integrations/hyperliquid/perps.ex lib/lux/prisms/hyperliquid/hyperliquid_order_management_prism.ex lib/lux/prisms/hyperliquid/hyperliquid_perps_dashboard_prism.ex test/unit/lux/integrations/hyperliquid/client_test.exs test/unit/lux/integrations/hyperliquid/perps_test.exs test/unit/lux/prisms/hyperliquid/perps_prisms_test.exs test/integration/hyperliquid_perps_workflow_test.exs`
- `mix test test/unit/lux/integrations/hyperliquid test/unit/lux/prisms/hyperliquid/perps_prisms_test.exs --include unit`
- `mix test test/integration/hyperliquid_perps_workflow_test.exs --include integration`
- `MIX_ENV=prod mix compile --force`
- `mix test.unit`