### PR TITLE
Add Twitter API v2 core integration

### DIFF
--- a/lux/benchmarks/twitter_client_benchmark.exs
+++ b/lux/benchmarks/twitter_client_benchmark.exs
@@ -1,0 +1,17 @@
+Mix.install([{:benchee, "~> 1.3"}])
+
+alias Lux.Integrations.Twitter.Client
+
+Benchee.run(%{
+  "authorization_url/1" => fn ->
+    Client.authorization_url(%{
+      client_id: "client",
+      redirect_uri: "https://example.com/callback",
+      state: "state",
+      code_verifier: "verifier"
+    })
+  end,
+  "pkce_pair/1" => fn ->
+    Client.pkce_pair("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+  end
+})

--- a/lux/config/runtime.exs
+++ b/lux/config/runtime.exs
@@ -22,6 +22,7 @@ if config_env() in [:dev, :test] do
     openweather: env!("OPENWEATHER_API_KEY", :string!, "missing open weather"),
     transpose: env!("TRANSPOSE_API_KEY", :string!, "missing transpose"),
     discord: env!("DISCORD_API_KEY", :string!, "missing discord"),
+    twitter_bearer: env!("TWITTER_BEARER_TOKEN", :string!, required: false),
     etherscan: env!("ETHERSCAN_API_KEY", :string!, "missing etherscan"),
     etherscan_pro: env!("ETHERSCAN_API_KEY_PRO", :string!, required: false) == "true",
     telegram_bot: env!("TELEGRAM_BOT_TOKEN", :string!, required: false),

--- a/lux/config/runtime.exs
+++ b/lux/config/runtime.exs
@@ -28,7 +28,8 @@ if config_env() in [:dev, :test] do
     telegram_bot: env!("TELEGRAM_BOT_TOKEN", :string!, required: false),
     integration_openai: env!("INTEGRATION_OPENAI_API_KEY", :string!, "missing open ai"),
     integration_anthropic: env!("INTEGRATION_ANTHROPIC_API_KEY", :string!, "missing anthropic"),
-    integration_openweather: env!("INTEGRATION_OPENWEATHER_API_KEY", :string!, "missing open weather"),
+    integration_openweather:
+      env!("INTEGRATION_OPENWEATHER_API_KEY", :string!, "missing open weather"),
     integration_transpose: env!("INTEGRATION_TRANSPOSE_API_KEY", :string!, "missing transpose"),
     integration_discord: env!("INTEGRATION_DISCORD_API_KEY", :string!, "missing discord"),
     integration_telegram_bot: env!("INTEGRATION_TELEGRAM_BOT_TOKEN", :string!, required: false),
@@ -37,6 +38,10 @@ if config_env() in [:dev, :test] do
   config :lux, Lux.Integrations.Allora,
     base_url: env!("ALLORA_BASE_URL", :string!, "https://api.upshot.xyz/v2"),
     chain_slug: env!("ALLORA_CHAIN_SLUG", :string!, "testnet")
+
+  config :lux, Lux.Integrations.Twitter,
+    api_url: env!("TWITTER_API_URL", :string!, "https://api.x.com"),
+    authorize_url: env!("TWITTER_AUTHORIZE_URL", :string!, "https://x.com/i/oauth2/authorize")
 
   config :lux, :accounts,
     wallet_address: env!("WALLET_ADDRESS", :string!),
@@ -61,12 +66,14 @@ end
 if config_env() == :test do
   # Add Hammer configuration
   config :hammer,
-    backend: {Hammer.Backend.ETS,
-      [
-        expiry_ms: 60_000 * 60 * 4,       # 4 hours
-        cleanup_interval_ms: 60_000 * 10,  # 10 minutes
-        pool_size: 1,
-        pool_max_overflow: 2
-      ]
-    }
+    backend:
+      {Hammer.Backend.ETS,
+       [
+         # 4 hours
+         expiry_ms: 60_000 * 60 * 4,
+         # 10 minutes
+         cleanup_interval_ms: 60_000 * 10,
+         pool_size: 1,
+         pool_max_overflow: 2
+       ]}
 end

--- a/lux/guides/twitter_api_core.livemd
+++ b/lux/guides/twitter_api_core.livemd
@@ -3,6 +3,27 @@
 This guide shows how Lux agents can use X/Twitter API v2 without putting live
 credentials in tests or examples.
 
+## Runtime Configuration
+
+The client defaults to the current X API host, `https://api.x.com`. If an app
+or account still needs the legacy Twitter host for v2 endpoints, set
+`TWITTER_API_URL=https://api.twitter.com` or configure the integration directly:
+
+```elixir
+config :lux, Lux.Integrations.Twitter,
+  api_url: "https://api.x.com",
+  authorize_url: "https://x.com/i/oauth2/authorize"
+```
+
+Minimal credential shapes by mode:
+
+- App-only reads: `TWITTER_BEARER_TOKEN`
+- OAuth 2.0 PKCE: `TWITTER_CLIENT_ID`, `TWITTER_REDIRECT_URI`, generated
+  verifier/challenge, short-lived `access_token`, and optionally
+  `TWITTER_CLIENT_SECRET` plus `refresh_token`
+- Write/media/follow operations: a user OAuth `access_token`; app-only bearer
+  tokens are intentionally rejected for mutation paths
+
 ## OAuth 2.0 PKCE
 
 ```elixir
@@ -117,6 +138,42 @@ Lux.Integrations.Twitter.Client.search_recent(
   %{access_token: tokens["access_token"], with_rate_limit: true}
 )
 ```
+
+## Media Upload
+
+Chunked media upload is exposed one step at a time so agents can persist the
+server response between calls:
+
+```elixir
+{:ok, init} =
+  Lux.Prisms.Twitter.Media.UploadMedia.handler(
+    %{
+      action: :init,
+      total_bytes: 1_024_000,
+      media_type: "video/mp4",
+      media_category: "tweet_video",
+      access_token: tokens["access_token"]
+    },
+    %{}
+  )
+
+media_id = get_in(init, ["data", "id"]) || init["media_id_string"] || init["media_id"]
+
+Lux.Prisms.Twitter.Media.UploadMedia.handler(
+  %{action: :append, media_id: media_id, segment_index: 0, media: chunk, access_token: tokens["access_token"]},
+  %{}
+)
+
+Lux.Prisms.Twitter.Media.UploadMedia.handler(
+  %{action: :finalize, media_id: media_id, access_token: tokens["access_token"]},
+  %{}
+)
+```
+
+For status polling, pass only the returned `media_id`. Response shapes can
+include either nested `data.id` values or legacy-style `media_id_string`
+depending on the endpoint/account behavior, so production agents should store
+the full response payload as well as the extracted media ID.
 
 ## Tests
 

--- a/lux/guides/twitter_api_core.livemd
+++ b/lux/guides/twitter_api_core.livemd
@@ -17,6 +17,19 @@ authorization_url =
   })
 ```
 
+Agents can also build the same URL through a prism:
+
+```elixir
+Lux.Prisms.Twitter.Auth.BuildAuthorizationUrl.handler(
+  %{
+    client_id: System.fetch_env!("TWITTER_CLIENT_ID"),
+    redirect_uri: "https://example.com/callback",
+    state: "csrf-token"
+  },
+  %{}
+)
+```
+
 After the callback, exchange the authorization code:
 
 ```elixir
@@ -64,6 +77,11 @@ Lux.Prisms.Twitter.Tweets.QuoteTweet.handler(
 Lux.Lenses.Twitter.GetTweet.focus(%{
   tweet_id: "123",
   tweet_fields: ["created_at", "public_metrics"],
+  access_token: tokens["access_token"]
+})
+
+Lux.Lenses.Twitter.GetMe.focus(%{
+  user_fields: ["username", "verified"],
   access_token: tokens["access_token"]
 })
 

--- a/lux/guides/twitter_api_core.livemd
+++ b/lux/guides/twitter_api_core.livemd
@@ -1,0 +1,92 @@
+# X/Twitter API Core Integration
+
+This guide shows how Lux agents can use X/Twitter API v2 without putting live
+credentials in tests or examples.
+
+## OAuth 2.0 PKCE
+
+```elixir
+pkce = Lux.Integrations.Twitter.Client.pkce_pair()
+
+authorization_url =
+  Lux.Integrations.Twitter.Client.authorization_url(%{
+    client_id: System.fetch_env!("TWITTER_CLIENT_ID"),
+    redirect_uri: "https://example.com/callback",
+    state: "csrf-token",
+    code_verifier: pkce.verifier
+  })
+```
+
+After the callback, exchange the authorization code:
+
+```elixir
+{:ok, tokens} =
+  Lux.Integrations.Twitter.Client.token_request(:authorization_code, %{
+    client_id: System.fetch_env!("TWITTER_CLIENT_ID"),
+    client_secret: System.get_env("TWITTER_CLIENT_SECRET"),
+    redirect_uri: "https://example.com/callback",
+    code: callback_code,
+    code_verifier: pkce.verifier
+  })
+```
+
+## Posts
+
+```elixir
+{:ok, post} =
+  Lux.Prisms.Twitter.Tweets.CreateTweet.handler(
+    %{
+      text: "Shipping through Lux",
+      access_token: tokens["access_token"]
+    },
+    %{name: "SocialAgent"}
+  )
+```
+
+Replies, quote posts, media attachments, edits, deletion, and threads are all
+supported:
+
+```elixir
+Lux.Prisms.Twitter.Tweets.CreateThread.handler(
+  %{texts: ["First post", "Second post"], access_token: tokens["access_token"]},
+  %{}
+)
+
+Lux.Prisms.Twitter.Tweets.QuoteTweet.handler(
+  %{text: "Useful context", quoted_tweet_id: "123", access_token: tokens["access_token"]},
+  %{}
+)
+```
+
+## Reading and Search
+
+```elixir
+Lux.Lenses.Twitter.GetTweet.focus(%{
+  tweet_id: "123",
+  tweet_fields: ["created_at", "public_metrics"],
+  access_token: tokens["access_token"]
+})
+
+Lux.Lenses.Twitter.SearchRecent.focus(%{
+  query: "lux lang:en",
+  max_results: 10,
+  access_token: tokens["access_token"]
+})
+```
+
+## Rate Limits
+
+Pass `with_rate_limit: true` to receive the parsed X rate-limit response
+headers next to the body:
+
+```elixir
+Lux.Integrations.Twitter.Client.search_recent(
+  "lux",
+  %{max_results: 10},
+  %{access_token: tokens["access_token"], with_rate_limit: true}
+)
+```
+
+## Tests
+
+The unit tests use `Req.Test` and never require live Twitter credentials.

--- a/lux/guides/twitter_api_core.livemd
+++ b/lux/guides/twitter_api_core.livemd
@@ -85,6 +85,17 @@ Lux.Lenses.Twitter.GetMe.focus(%{
   access_token: tokens["access_token"]
 })
 
+Lux.Lenses.Twitter.GetFollowers.focus(%{
+  user_id: "123",
+  max_results: 25,
+  access_token: tokens["access_token"]
+})
+
+Lux.Lenses.Twitter.GetFollowing.focus(%{
+  user_id: "123",
+  access_token: tokens["access_token"]
+})
+
 Lux.Lenses.Twitter.SearchRecent.focus(%{
   query: "lux lang:en",
   max_results: 10,
@@ -95,7 +106,9 @@ Lux.Lenses.Twitter.SearchRecent.focus(%{
 ## Rate Limits
 
 Pass `with_rate_limit: true` to receive the parsed X rate-limit response
-headers next to the body:
+headers next to the body. A `429` response returns `{:error, {:rate_limited,
+details}}` with the same parsed limit, reset, and retry-after metadata so agents
+can pause or reschedule instead of losing the failure context.
 
 ```elixir
 Lux.Integrations.Twitter.Client.search_recent(

--- a/lux/lib/lux/integrations/twitter.ex
+++ b/lux/lib/lux/integrations/twitter.ex
@@ -12,6 +12,7 @@ defmodule Lux.Integrations.Twitter do
     "tweet.read",
     "tweet.write",
     "tweet.moderate.write",
+    "media.write",
     "users.read",
     "follows.read",
     "follows.write",

--- a/lux/lib/lux/integrations/twitter.ex
+++ b/lux/lib/lux/integrations/twitter.ex
@@ -1,0 +1,32 @@
+defmodule Lux.Integrations.Twitter do
+  @moduledoc """
+  Shared configuration helpers for X/Twitter API v2 integrations.
+
+  The integration keeps credentials out of tests and supports direct overrides
+  in each client call so agents can run with short-lived OAuth tokens.
+  """
+
+  @api_url "https://api.x.com"
+  @authorize_url "https://x.com/i/oauth2/authorize"
+  @default_scopes [
+    "tweet.read",
+    "tweet.write",
+    "tweet.moderate.write",
+    "users.read",
+    "follows.read",
+    "follows.write",
+    "offline.access"
+  ]
+
+  def api_url, do: Application.get_env(:lux, __MODULE__, [])[:api_url] || @api_url
+
+  def authorize_url,
+    do: Application.get_env(:lux, __MODULE__, [])[:authorize_url] || @authorize_url
+
+  def default_scopes, do: @default_scopes
+
+  def bearer_token do
+    Application.get_env(:lux, :api_keys, [])
+    |> Keyword.get(:twitter_bearer)
+  end
+end

--- a/lux/lib/lux/integrations/twitter/client.ex
+++ b/lux/lib/lux/integrations/twitter/client.ex
@@ -4,8 +4,8 @@ defmodule Lux.Integrations.Twitter.Client do
 
   The client covers the core issue surface: OAuth 2.0 PKCE, token refresh,
   tweet create/read/delete/edit/quote/thread operations, chunked media upload,
-  user lookup/follow management, rate-limit metadata, and testable request
-  injection through `Req.Test`.
+  user lookup/social-graph/follow management, structured rate-limit handling,
+  and testable request injection through `Req.Test`.
   """
 
   alias Lux.Integrations.Twitter
@@ -176,6 +176,16 @@ defmodule Lux.Integrations.Twitter.Client do
     request(:get, query_path("/2/users/by/username/#{username}", params), opts)
   end
 
+  @spec get_followers(String.t(), opts(), opts()) :: result()
+  def get_followers(user_id, params \\ %{}, opts \\ %{}) do
+    request(:get, query_path("/2/users/#{user_id}/followers", params), opts)
+  end
+
+  @spec get_following(String.t(), opts(), opts()) :: result()
+  def get_following(user_id, params \\ %{}, opts \\ %{}) do
+    request(:get, query_path("/2/users/#{user_id}/following", params), opts)
+  end
+
   @spec follow_user(String.t(), String.t(), opts()) :: result()
   def follow_user(source_user_id, target_user_id, opts \\ %{}) do
     request(
@@ -331,6 +341,10 @@ defmodule Lux.Integrations.Twitter.Client do
 
   defp handle_response({:ok, %{status: 401}}, _opts), do: {:error, :invalid_token}
 
+  defp handle_response({:ok, %{status: 429, body: body} = response}, _opts) do
+    {:error, {:rate_limited, %{body: body, rate_limit: rate_limit(response.headers)}}}
+  end
+
   defp handle_response(
          {:ok, %{status: status, body: %{"title" => title, "detail" => detail}}},
          _opts
@@ -347,16 +361,49 @@ defmodule Lux.Integrations.Twitter.Client do
   defp handle_response({:error, error}, _opts), do: {:error, error}
 
   defp rate_limit(headers) do
+    reset = header(headers, "x-rate-limit-reset")
+    remaining = parse_int(header(headers, "x-rate-limit-remaining"))
+
     %{
-      limit: header(headers, "x-rate-limit-limit"),
-      remaining: header(headers, "x-rate-limit-remaining"),
-      reset: header(headers, "x-rate-limit-reset")
+      limit: parse_int(header(headers, "x-rate-limit-limit")),
+      remaining: remaining,
+      reset: parse_int(reset),
+      reset_at: unix_datetime(reset),
+      retry_after: parse_int(header(headers, "retry-after")),
+      rate_limited?: remaining == 0
     }
+    |> drop_nil()
   end
 
   defp header(headers, name) do
     headers
     |> Enum.find_value(fn {key, value} -> if String.downcase(key) == name, do: value end)
+    |> first_header_value()
+  end
+
+  defp first_header_value([value | _]), do: value
+  defp first_header_value(value), do: value
+
+  defp parse_int(nil), do: nil
+
+  defp parse_int(value) when is_integer(value), do: value
+
+  defp parse_int(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, ""} -> integer
+      _other -> nil
+    end
+  end
+
+  defp unix_datetime(nil), do: nil
+
+  defp unix_datetime(value) do
+    value
+    |> parse_int()
+    |> case do
+      nil -> nil
+      timestamp -> DateTime.from_unix!(timestamp)
+    end
   end
 
   defp maybe_put(options, _key, nil), do: options

--- a/lux/lib/lux/integrations/twitter/client.ex
+++ b/lux/lib/lux/integrations/twitter/client.ex
@@ -245,7 +245,7 @@ defmodule Lux.Integrations.Twitter.Client do
       fields =
         multipart_fields(%{
           segment_index: value(params, :segment_index, 0)
-        }) ++ [{:media, value(params, :media), filename: value(params, :filename, "media.bin")}]
+        }) ++ [{:media, {value(params, :media), filename: value(params, :filename, "media.bin")}}]
 
       request(:post, "#{@media_path}/#{media_id}/append", put_multipart(opts, fields))
     end

--- a/lux/lib/lux/integrations/twitter/client.ex
+++ b/lux/lib/lux/integrations/twitter/client.ex
@@ -106,7 +106,9 @@ defmodule Lux.Integrations.Twitter.Client do
 
   @spec create_tweet(opts(), opts()) :: result()
   def create_tweet(params, opts \\ %{}) do
-    request(:post, "/2/tweets", put_payload(opts, tweet_payload(params)))
+    with :ok <- require_access_token(opts) do
+      request(:post, "/2/tweets", put_payload(opts, tweet_payload(params)))
+    end
   end
 
   @spec edit_tweet(String.t(), opts(), opts()) :: result()
@@ -118,7 +120,11 @@ defmodule Lux.Integrations.Twitter.Client do
   end
 
   @spec delete_tweet(String.t(), opts()) :: result()
-  def delete_tweet(tweet_id, opts \\ %{}), do: request(:delete, "/2/tweets/#{tweet_id}", opts)
+  def delete_tweet(tweet_id, opts \\ %{}) do
+    with :ok <- require_access_token(opts) do
+      request(:delete, "/2/tweets/#{tweet_id}", opts)
+    end
+  end
 
   @spec get_tweet(String.t(), opts(), opts()) :: result()
   def get_tweet(tweet_id, params \\ %{}, opts \\ %{}) do
@@ -188,55 +194,76 @@ defmodule Lux.Integrations.Twitter.Client do
 
   @spec follow_user(String.t(), String.t(), opts()) :: result()
   def follow_user(source_user_id, target_user_id, opts \\ %{}) do
-    request(
-      :post,
-      "/2/users/#{source_user_id}/following",
-      put_payload(opts, %{target_user_id: target_user_id})
-    )
+    with :ok <- require_access_token(opts) do
+      request(
+        :post,
+        "/2/users/#{source_user_id}/following",
+        put_payload(opts, %{target_user_id: target_user_id})
+      )
+    end
   end
 
   @spec unfollow_user(String.t(), String.t(), opts()) :: result()
   def unfollow_user(source_user_id, target_user_id, opts \\ %{}) do
-    request(:delete, "/2/users/#{source_user_id}/following/#{target_user_id}", opts)
+    with :ok <- require_access_token(opts) do
+      request(:delete, "/2/users/#{source_user_id}/following/#{target_user_id}", opts)
+    end
   end
 
   @spec media_upload(:init | :append | :finalize | :status, opts(), opts()) :: result()
   def media_upload(action, params, opts \\ %{})
 
   def media_upload(:init, params, opts) do
-    fields =
-      multipart_fields(%{
-        command: "INIT",
-        total_bytes: value(params, :total_bytes),
-        media_type: value(params, :media_type),
-        media_category: value(params, :media_category)
-      })
+    with :ok <- require_access_token(opts) do
+      fields =
+        multipart_fields(%{
+          command: "INIT",
+          total_bytes: value(params, :total_bytes),
+          media_type: value(params, :media_type),
+          media_category: value(params, :media_category)
+        })
 
-    request(:post, @media_path, put_multipart(opts, fields))
+      request(:post, @media_path, put_multipart(opts, fields))
+    end
   end
 
   def media_upload(:append, params, opts) do
-    fields =
-      multipart_fields(%{
-        command: "APPEND",
-        media_id: value(params, :media_id),
-        segment_index: value(params, :segment_index, 0)
-      }) ++ [{:media, value(params, :media), filename: value(params, :filename, "media.bin")}]
+    with :ok <- require_access_token(opts) do
+      fields =
+        multipart_fields(%{
+          command: "APPEND",
+          media_id: value(params, :media_id),
+          segment_index: value(params, :segment_index, 0)
+        }) ++ [{:media, value(params, :media), filename: value(params, :filename, "media.bin")}]
 
-    request(:post, @media_path, put_multipart(opts, fields))
+      request(:post, @media_path, put_multipart(opts, fields))
+    end
   end
 
   def media_upload(:finalize, params, opts) do
-    fields = multipart_fields(%{command: "FINALIZE", media_id: value(params, :media_id)})
-    request(:post, @media_path, put_multipart(opts, fields))
+    with :ok <- require_access_token(opts) do
+      fields = multipart_fields(%{command: "FINALIZE", media_id: value(params, :media_id)})
+      request(:post, @media_path, put_multipart(opts, fields))
+    end
   end
 
   def media_upload(:status, params, opts) do
-    request(
-      :get,
-      query_path(@media_path, %{command: "STATUS", media_id: value(params, :media_id)}),
-      opts
-    )
+    with :ok <- require_access_token(opts) do
+      request(
+        :get,
+        query_path(@media_path, %{command: "STATUS", media_id: value(params, :media_id)}),
+        opts
+      )
+    end
+  end
+
+  defp require_access_token(opts) do
+    opts = normalize(opts)
+
+    case opts[:access_token] do
+      token when is_binary(token) and token != "" -> :ok
+      _missing -> {:error, :access_token_required}
+    end
   end
 
   defp token_opts(opts, form) do

--- a/lux/lib/lux/integrations/twitter/client.ex
+++ b/lux/lib/lux/integrations/twitter/client.ex
@@ -322,12 +322,15 @@ defmodule Lux.Integrations.Twitter.Client do
 
   defp headers(opts) do
     token = opts[:access_token] || opts[:bearer_token] || Twitter.bearer_token()
-    base = [{"Content-Type", "application/json"} | List.wrap(opts[:headers])]
+    base = default_content_type(opts) ++ List.wrap(opts[:headers])
 
     if opts[:auth] == false or is_nil(token),
       do: base,
       else: [{"Authorization", "Bearer #{token}"} | base]
   end
+
+  defp default_content_type(%{json: _json}), do: [{"Content-Type", "application/json"}]
+  defp default_content_type(_opts), do: []
 
   defp handle_response({:ok, %{status: status, body: body} = response}, opts)
        when status in 200..299 do

--- a/lux/lib/lux/integrations/twitter/client.ex
+++ b/lux/lib/lux/integrations/twitter/client.ex
@@ -15,6 +15,7 @@ defmodule Lux.Integrations.Twitter.Client do
 
   @token_path "/2/oauth2/token"
   @media_path "/2/media/upload"
+  @media_initialize_path "/2/media/upload/initialize"
 
   @spec request(atom(), String.t(), opts()) :: result()
   def request(method, path, opts \\ %{}) do
@@ -75,33 +76,35 @@ defmodule Lux.Integrations.Twitter.Client do
   def token_request(:authorization_code, opts) do
     opts = normalize(opts)
 
-    form =
-      %{
-        grant_type: "authorization_code",
-        code: opts[:code],
-        redirect_uri: opts[:redirect_uri],
-        client_id: opts[:client_id],
-        code_verifier: opts[:code_verifier]
-      }
-      |> drop_nil()
-      |> Map.to_list()
+    with :ok <- require_fields(opts, [:client_id, :code, :redirect_uri, :code_verifier]) do
+      form =
+        %{
+          grant_type: "authorization_code",
+          code: opts[:code],
+          redirect_uri: opts[:redirect_uri],
+          client_id: opts[:client_id],
+          code_verifier: opts[:code_verifier]
+        }
+        |> Map.to_list()
 
-    request(:post, @token_path, token_opts(opts, form))
+      request(:post, @token_path, token_opts(opts, form))
+    end
   end
 
   def token_request(:refresh_token, opts) do
     opts = normalize(opts)
 
-    form =
-      %{
-        grant_type: "refresh_token",
-        refresh_token: opts[:refresh_token],
-        client_id: opts[:client_id]
-      }
-      |> drop_nil()
-      |> Map.to_list()
+    with :ok <- require_fields(opts, [:client_id, :refresh_token]) do
+      form =
+        %{
+          grant_type: "refresh_token",
+          refresh_token: opts[:refresh_token],
+          client_id: opts[:client_id]
+        }
+        |> Map.to_list()
 
-    request(:post, @token_path, token_opts(opts, form))
+      request(:post, @token_path, token_opts(opts, form))
+    end
   end
 
   @spec create_tweet(opts(), opts()) :: result()
@@ -147,10 +150,15 @@ defmodule Lux.Integrations.Twitter.Client do
           {:cont, {:ok, id, [response | responses]}}
 
         {:ok, response} ->
-          {:halt, {:error, {:missing_tweet_id, response}}}
+          {:halt,
+           {:error,
+            {:partial_thread_failure,
+             %{reason: {:missing_tweet_id, response}, published: Enum.reverse(responses)}}}}
 
         {:error, reason} ->
-          {:halt, {:error, reason}}
+          {:halt,
+           {:error,
+            {:partial_thread_failure, %{reason: reason, published: Enum.reverse(responses)}}}}
       end
     end)
     |> case do
@@ -215,47 +223,53 @@ defmodule Lux.Integrations.Twitter.Client do
 
   def media_upload(:init, params, opts) do
     with :ok <- require_access_token(opts) do
-      fields =
-        multipart_fields(%{
-          command: "INIT",
+      payload =
+        %{
           total_bytes: value(params, :total_bytes),
           media_type: value(params, :media_type),
-          media_category: value(params, :media_category)
-        })
+          media_category: value(params, :media_category),
+          additional_owners: value(params, :additional_owners),
+          shared: value(params, :shared)
+        }
+        |> drop_nil()
 
-      request(:post, @media_path, put_multipart(opts, fields))
+      request(:post, @media_initialize_path, put_payload(opts, payload))
     end
   end
 
   def media_upload(:append, params, opts) do
-    with :ok <- require_access_token(opts) do
+    with :ok <- require_access_token(opts),
+         :ok <- require_fields(params, [:media_id, :media]) do
+      media_id = value(params, :media_id)
+
       fields =
         multipart_fields(%{
-          command: "APPEND",
-          media_id: value(params, :media_id),
           segment_index: value(params, :segment_index, 0)
         }) ++ [{:media, value(params, :media), filename: value(params, :filename, "media.bin")}]
 
-      request(:post, @media_path, put_multipart(opts, fields))
+      request(:post, "#{@media_path}/#{media_id}/append", put_multipart(opts, fields))
     end
   end
 
   def media_upload(:finalize, params, opts) do
-    with :ok <- require_access_token(opts) do
-      fields = multipart_fields(%{command: "FINALIZE", media_id: value(params, :media_id)})
-      request(:post, @media_path, put_multipart(opts, fields))
+    with :ok <- require_access_token(opts),
+         :ok <- require_fields(params, [:media_id]) do
+      request(:post, "#{@media_path}/#{value(params, :media_id)}/finalize", opts)
     end
   end
 
   def media_upload(:status, params, opts) do
-    with :ok <- require_access_token(opts) do
+    with :ok <- require_access_token(opts),
+         :ok <- require_fields(params, [:media_id]) do
       request(
         :get,
-        query_path(@media_path, %{command: "STATUS", media_id: value(params, :media_id)}),
+        query_path(@media_path, %{media_id: value(params, :media_id)}),
         opts
       )
     end
   end
+
+  def media_upload(action, _params, _opts), do: {:error, {:unsupported_media_action, action}}
 
   defp require_access_token(opts) do
     opts = normalize(opts)
@@ -264,6 +278,19 @@ defmodule Lux.Integrations.Twitter.Client do
       token when is_binary(token) and token != "" -> :ok
       _missing -> {:error, :access_token_required}
     end
+  end
+
+  defp require_fields(opts, fields) do
+    missing =
+      Enum.filter(fields, fn field ->
+        case opts[field] do
+          value when is_binary(value) -> value == ""
+          nil -> true
+          _value -> false
+        end
+      end)
+
+    if missing == [], do: :ok, else: {:error, {:missing_required_fields, missing}}
   end
 
   defp token_opts(opts, form) do
@@ -376,19 +403,27 @@ defmodule Lux.Integrations.Twitter.Client do
   end
 
   defp handle_response(
-         {:ok, %{status: status, body: %{"title" => title, "detail" => detail}}},
-         _opts
+         {:ok, %{status: status, body: %{"title" => title, "detail" => detail}} = response},
+         opts
        ),
-       do: {:error, {status, "#{title}: #{detail}"}}
+       do: {:error, error_payload(status, "#{title}: #{detail}", response, opts)}
 
-  defp handle_response({:ok, %{status: status, body: %{"detail" => detail}}}, _opts),
-    do: {:error, {status, detail}}
+  defp handle_response({:ok, %{status: status, body: %{"detail" => detail}} = response}, opts),
+    do: {:error, error_payload(status, detail, response, opts)}
 
-  defp handle_response({:ok, %{status: status, body: %{"errors" => errors}}}, _opts),
-    do: {:error, {status, errors}}
+  defp handle_response({:ok, %{status: status, body: %{"errors" => errors}} = response}, opts),
+    do: {:error, error_payload(status, errors, response, opts)}
 
-  defp handle_response({:ok, %{status: status, body: body}}, _opts), do: {:error, {status, body}}
+  defp handle_response({:ok, %{status: status, body: body} = response}, opts),
+    do: {:error, error_payload(status, body, response, opts)}
+
   defp handle_response({:error, error}, _opts), do: {:error, error}
+
+  defp error_payload(status, reason, response, %{with_rate_limit: true}) do
+    %{status: status, reason: reason, rate_limit: rate_limit(response.headers)}
+  end
+
+  defp error_payload(status, reason, _response, _opts), do: {status, reason}
 
   defp rate_limit(headers) do
     reset = header(headers, "x-rate-limit-reset")

--- a/lux/lib/lux/integrations/twitter/client.ex
+++ b/lux/lib/lux/integrations/twitter/client.ex
@@ -1,0 +1,379 @@
+defmodule Lux.Integrations.Twitter.Client do
+  @moduledoc """
+  HTTP client and OAuth helpers for X/Twitter API v2.
+
+  The client covers the core issue surface: OAuth 2.0 PKCE, token refresh,
+  tweet create/read/delete/edit/quote/thread operations, chunked media upload,
+  user lookup/follow management, rate-limit metadata, and testable request
+  injection through `Req.Test`.
+  """
+
+  alias Lux.Integrations.Twitter
+
+  @type opts :: map() | keyword()
+  @type result :: {:ok, term()} | {:error, term()}
+
+  @token_path "/2/oauth2/token"
+  @media_path "/2/media/upload"
+
+  @spec request(atom(), String.t(), opts()) :: result()
+  def request(method, path, opts \\ %{}) do
+    opts = normalize(opts)
+
+    [
+      method: method,
+      url: url(path, opts),
+      headers: headers(opts),
+      retry: opts[:retry] || false
+    ]
+    |> maybe_put(:json, opts[:json])
+    |> maybe_put(:form, opts[:form])
+    |> maybe_put(:form_multipart, opts[:form_multipart])
+    |> Keyword.merge(Application.get_env(:lux, __MODULE__, []))
+    |> maybe_put(:plug, opts[:plug])
+    |> Req.new()
+    |> Req.request()
+    |> handle_response(opts)
+  end
+
+  @spec pkce_pair(String.t() | nil) :: map()
+  def pkce_pair(verifier \\ nil) do
+    verifier = verifier || random_verifier()
+
+    %{
+      verifier: verifier,
+      challenge:
+        :crypto.hash(:sha256, verifier)
+        |> Base.url_encode64(padding: false),
+      method: "S256"
+    }
+  end
+
+  @spec authorization_url(opts()) :: String.t()
+  def authorization_url(opts) do
+    opts = normalize(opts)
+    pkce = pkce_pair(opts[:code_verifier])
+    scopes = opts[:scopes] || opts[:scope] || Twitter.default_scopes()
+
+    query =
+      %{
+        response_type: "code",
+        client_id: opts[:client_id],
+        redirect_uri: opts[:redirect_uri],
+        state: opts[:state],
+        scope: encode_scope(scopes),
+        code_challenge: pkce.challenge,
+        code_challenge_method: pkce.method
+      }
+      |> drop_nil()
+      |> URI.encode_query()
+
+    "#{Twitter.authorize_url()}?#{query}"
+  end
+
+  @spec token_request(:authorization_code | :refresh_token, opts()) :: result()
+  def token_request(:authorization_code, opts) do
+    opts = normalize(opts)
+
+    form =
+      %{
+        grant_type: "authorization_code",
+        code: opts[:code],
+        redirect_uri: opts[:redirect_uri],
+        client_id: opts[:client_id],
+        code_verifier: opts[:code_verifier]
+      }
+      |> drop_nil()
+      |> Map.to_list()
+
+    request(:post, @token_path, token_opts(opts, form))
+  end
+
+  def token_request(:refresh_token, opts) do
+    opts = normalize(opts)
+
+    form =
+      %{
+        grant_type: "refresh_token",
+        refresh_token: opts[:refresh_token],
+        client_id: opts[:client_id]
+      }
+      |> drop_nil()
+      |> Map.to_list()
+
+    request(:post, @token_path, token_opts(opts, form))
+  end
+
+  @spec create_tweet(opts(), opts()) :: result()
+  def create_tweet(params, opts \\ %{}) do
+    request(:post, "/2/tweets", put_payload(opts, tweet_payload(params)))
+  end
+
+  @spec edit_tweet(String.t(), opts(), opts()) :: result()
+  def edit_tweet(previous_tweet_id, params, opts \\ %{}) do
+    params
+    |> normalize()
+    |> Map.put(:edit_options, %{previous_post_id: previous_tweet_id})
+    |> create_tweet(opts)
+  end
+
+  @spec delete_tweet(String.t(), opts()) :: result()
+  def delete_tweet(tweet_id, opts \\ %{}), do: request(:delete, "/2/tweets/#{tweet_id}", opts)
+
+  @spec get_tweet(String.t(), opts(), opts()) :: result()
+  def get_tweet(tweet_id, params \\ %{}, opts \\ %{}) do
+    request(:get, query_path("/2/tweets/#{tweet_id}", params), opts)
+  end
+
+  @spec quote_tweet(String.t(), String.t(), opts()) :: result()
+  def quote_tweet(text, quoted_tweet_id, opts \\ %{}) do
+    create_tweet(%{text: text, quote_tweet_id: quoted_tweet_id}, opts)
+  end
+
+  @spec create_thread([String.t()], opts()) :: result()
+  def create_thread(texts, opts \\ %{}) when is_list(texts) do
+    Enum.reduce_while(texts, {:ok, nil, []}, fn text, {:ok, previous_id, responses} ->
+      params =
+        if previous_id, do: %{text: text, reply_to_tweet_id: previous_id}, else: %{text: text}
+
+      case create_tweet(params, opts) do
+        {:ok, %{"data" => %{"id" => id}} = response} ->
+          {:cont, {:ok, id, [response | responses]}}
+
+        {:ok, response} ->
+          {:halt, {:error, {:missing_tweet_id, response}}}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, _last_id, responses} -> {:ok, Enum.reverse(responses)}
+      error -> error
+    end
+  end
+
+  @spec search_recent(String.t(), opts(), opts()) :: result()
+  def search_recent(query, params \\ %{}, opts \\ %{}) do
+    request(
+      :get,
+      query_path("/2/tweets/search/recent", Map.put(normalize(params), :query, query)),
+      opts
+    )
+  end
+
+  @spec get_me(opts(), opts()) :: result()
+  def get_me(params \\ %{}, opts \\ %{}),
+    do: request(:get, query_path("/2/users/me", params), opts)
+
+  @spec get_user(String.t(), opts(), opts()) :: result()
+  def get_user(user_id, params \\ %{}, opts \\ %{}) do
+    request(:get, query_path("/2/users/#{user_id}", params), opts)
+  end
+
+  @spec get_user_by_username(String.t(), opts(), opts()) :: result()
+  def get_user_by_username(username, params \\ %{}, opts \\ %{}) do
+    request(:get, query_path("/2/users/by/username/#{username}", params), opts)
+  end
+
+  @spec follow_user(String.t(), String.t(), opts()) :: result()
+  def follow_user(source_user_id, target_user_id, opts \\ %{}) do
+    request(
+      :post,
+      "/2/users/#{source_user_id}/following",
+      put_payload(opts, %{target_user_id: target_user_id})
+    )
+  end
+
+  @spec unfollow_user(String.t(), String.t(), opts()) :: result()
+  def unfollow_user(source_user_id, target_user_id, opts \\ %{}) do
+    request(:delete, "/2/users/#{source_user_id}/following/#{target_user_id}", opts)
+  end
+
+  @spec media_upload(:init | :append | :finalize | :status, opts(), opts()) :: result()
+  def media_upload(action, params, opts \\ %{})
+
+  def media_upload(:init, params, opts) do
+    fields =
+      multipart_fields(%{
+        command: "INIT",
+        total_bytes: value(params, :total_bytes),
+        media_type: value(params, :media_type),
+        media_category: value(params, :media_category)
+      })
+
+    request(:post, @media_path, put_multipart(opts, fields))
+  end
+
+  def media_upload(:append, params, opts) do
+    fields =
+      multipart_fields(%{
+        command: "APPEND",
+        media_id: value(params, :media_id),
+        segment_index: value(params, :segment_index, 0)
+      }) ++ [{:media, value(params, :media), filename: value(params, :filename, "media.bin")}]
+
+    request(:post, @media_path, put_multipart(opts, fields))
+  end
+
+  def media_upload(:finalize, params, opts) do
+    fields = multipart_fields(%{command: "FINALIZE", media_id: value(params, :media_id)})
+    request(:post, @media_path, put_multipart(opts, fields))
+  end
+
+  def media_upload(:status, params, opts) do
+    request(
+      :get,
+      query_path(@media_path, %{command: "STATUS", media_id: value(params, :media_id)}),
+      opts
+    )
+  end
+
+  defp token_opts(opts, form) do
+    opts
+    |> Map.put(:auth, false)
+    |> Map.put(:form, form)
+    |> maybe_basic_auth()
+  end
+
+  defp maybe_basic_auth(%{client_id: client_id, client_secret: client_secret} = opts)
+       when is_binary(client_id) and is_binary(client_secret) do
+    token = Base.encode64("#{client_id}:#{client_secret}")
+
+    Map.update(
+      opts,
+      :headers,
+      [{"Authorization", "Basic #{token}"}],
+      &[{"Authorization", "Basic #{token}"} | &1]
+    )
+  end
+
+  defp maybe_basic_auth(opts), do: opts
+
+  defp tweet_payload(params) do
+    params = normalize(params)
+
+    %{
+      text: params[:text],
+      reply: maybe_map(:in_reply_to_tweet_id, params[:reply_to_tweet_id]),
+      quote_tweet_id: params[:quote_tweet_id],
+      media: maybe_map(:media_ids, params[:media_ids]),
+      edit_options: params[:edit_options]
+    }
+    |> drop_nil()
+  end
+
+  defp maybe_map(_key, nil), do: nil
+  defp maybe_map(key, value), do: %{key => value}
+
+  defp query_path(path, params) do
+    params = normalize(params) |> encode_params()
+
+    case URI.encode_query(params) do
+      "" -> path
+      query -> "#{path}?#{query}"
+    end
+  end
+
+  defp encode_params(params) do
+    Enum.reduce(params, %{}, fn
+      {_key, nil}, acc ->
+        acc
+
+      {key, values}, acc when is_list(values) ->
+        Map.put(acc, dashed_key(key), Enum.join(values, ","))
+
+      {key, value}, acc ->
+        Map.put(acc, dashed_key(key), value)
+    end)
+  end
+
+  defp dashed_key(:tweet_fields), do: "tweet.fields"
+  defp dashed_key(:user_fields), do: "user.fields"
+  defp dashed_key(:media_fields), do: "media.fields"
+  defp dashed_key(:place_fields), do: "place.fields"
+  defp dashed_key(:poll_fields), do: "poll.fields"
+  defp dashed_key(key), do: to_string(key)
+
+  defp put_payload(opts, payload), do: opts |> normalize() |> Map.put(:json, payload)
+  defp put_multipart(opts, fields), do: opts |> normalize() |> Map.put(:form_multipart, fields)
+
+  defp multipart_fields(map) do
+    map
+    |> drop_nil()
+    |> Enum.map(fn {key, value} -> {key, to_string(value)} end)
+  end
+
+  defp url(path, opts) do
+    if String.starts_with?(path, "http"),
+      do: path,
+      else: "#{opts[:base_url] || Twitter.api_url()}#{path}"
+  end
+
+  defp headers(opts) do
+    token = opts[:access_token] || opts[:bearer_token] || Twitter.bearer_token()
+    base = [{"Content-Type", "application/json"} | List.wrap(opts[:headers])]
+
+    if opts[:auth] == false or is_nil(token),
+      do: base,
+      else: [{"Authorization", "Bearer #{token}"} | base]
+  end
+
+  defp handle_response({:ok, %{status: status, body: body} = response}, opts)
+       when status in 200..299 do
+    body =
+      if opts[:with_rate_limit],
+        do: %{body: body, rate_limit: rate_limit(response.headers)},
+        else: body
+
+    {:ok, body}
+  end
+
+  defp handle_response({:ok, %{status: 401}}, _opts), do: {:error, :invalid_token}
+
+  defp handle_response(
+         {:ok, %{status: status, body: %{"title" => title, "detail" => detail}}},
+         _opts
+       ),
+       do: {:error, {status, "#{title}: #{detail}"}}
+
+  defp handle_response({:ok, %{status: status, body: %{"detail" => detail}}}, _opts),
+    do: {:error, {status, detail}}
+
+  defp handle_response({:ok, %{status: status, body: %{"errors" => errors}}}, _opts),
+    do: {:error, {status, errors}}
+
+  defp handle_response({:ok, %{status: status, body: body}}, _opts), do: {:error, {status, body}}
+  defp handle_response({:error, error}, _opts), do: {:error, error}
+
+  defp rate_limit(headers) do
+    %{
+      limit: header(headers, "x-rate-limit-limit"),
+      remaining: header(headers, "x-rate-limit-remaining"),
+      reset: header(headers, "x-rate-limit-reset")
+    }
+  end
+
+  defp header(headers, name) do
+    headers
+    |> Enum.find_value(fn {key, value} -> if String.downcase(key) == name, do: value end)
+  end
+
+  defp maybe_put(options, _key, nil), do: options
+  defp maybe_put(options, key, value), do: Keyword.put(options, key, value)
+
+  defp drop_nil(map), do: Map.reject(map, fn {_key, value} -> is_nil(value) end)
+  defp normalize(value) when is_map(value), do: value
+  defp normalize(value) when is_list(value), do: Map.new(value)
+
+  defp value(params, key, default \\ nil), do: normalize(params) |> Map.get(key, default)
+
+  defp encode_scope(scopes) when is_list(scopes), do: Enum.join(scopes, " ")
+  defp encode_scope(scope), do: scope
+
+  defp random_verifier do
+    32
+    |> :crypto.strong_rand_bytes()
+    |> Base.url_encode64(padding: false)
+  end
+end

--- a/lux/lib/lux/lenses/twitter/get_followers.ex
+++ b/lux/lib/lux/lenses/twitter/get_followers.ex
@@ -2,6 +2,7 @@ defmodule Lux.Lenses.Twitter.GetFollowers do
   @moduledoc "Reads followers for an X/Twitter user."
 
   alias Lux.Integrations.Twitter.Client
+  alias Lux.Lenses.Twitter.Input
 
   def view do
     Lux.Lens.new(
@@ -23,10 +24,17 @@ defmodule Lux.Lenses.Twitter.GetFollowers do
 
   def focus(input, opts \\ [])
 
-  def focus(%{user_id: user_id} = input, _opts) do
-    opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
-    params = Map.drop(input, [:user_id, :access_token, :bearer_token, :plug, :with_rate_limit])
-    Client.get_followers(user_id, params, opts)
+  def focus(input, _opts) when is_map(input) do
+    input = Input.normalize(input)
+    user_id = input[:user_id]
+
+    if is_nil(user_id) do
+      {:error, "Missing user_id"}
+    else
+      opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+      params = Map.drop(input, [:user_id, :access_token, :bearer_token, :plug, :with_rate_limit])
+      Client.get_followers(user_id, params, opts)
+    end
   end
 
   def focus(_input, _opts), do: {:error, "Missing user_id"}

--- a/lux/lib/lux/lenses/twitter/get_followers.ex
+++ b/lux/lib/lux/lenses/twitter/get_followers.ex
@@ -1,0 +1,33 @@
+defmodule Lux.Lenses.Twitter.GetFollowers do
+  @moduledoc "Reads followers for an X/Twitter user."
+
+  alias Lux.Integrations.Twitter.Client
+
+  def view do
+    Lux.Lens.new(
+      name: "Get Twitter Followers",
+      module_name: inspect(__MODULE__),
+      description: "Reads followers for a user through X/Twitter API v2",
+      schema: %{
+        type: :object,
+        properties: %{
+          user_id: %{type: :string},
+          user_fields: %{type: :array, items: %{type: :string}},
+          max_results: %{type: :integer},
+          pagination_token: %{type: :string}
+        },
+        required: ["user_id"]
+      }
+    )
+  end
+
+  def focus(input, opts \\ [])
+
+  def focus(%{user_id: user_id} = input, _opts) do
+    opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+    params = Map.drop(input, [:user_id, :access_token, :bearer_token, :plug, :with_rate_limit])
+    Client.get_followers(user_id, params, opts)
+  end
+
+  def focus(_input, _opts), do: {:error, "Missing user_id"}
+end

--- a/lux/lib/lux/lenses/twitter/get_following.ex
+++ b/lux/lib/lux/lenses/twitter/get_following.ex
@@ -1,0 +1,33 @@
+defmodule Lux.Lenses.Twitter.GetFollowing do
+  @moduledoc "Reads accounts followed by an X/Twitter user."
+
+  alias Lux.Integrations.Twitter.Client
+
+  def view do
+    Lux.Lens.new(
+      name: "Get Twitter Following",
+      module_name: inspect(__MODULE__),
+      description: "Reads accounts followed by a user through X/Twitter API v2",
+      schema: %{
+        type: :object,
+        properties: %{
+          user_id: %{type: :string},
+          user_fields: %{type: :array, items: %{type: :string}},
+          max_results: %{type: :integer},
+          pagination_token: %{type: :string}
+        },
+        required: ["user_id"]
+      }
+    )
+  end
+
+  def focus(input, opts \\ [])
+
+  def focus(%{user_id: user_id} = input, _opts) do
+    opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+    params = Map.drop(input, [:user_id, :access_token, :bearer_token, :plug, :with_rate_limit])
+    Client.get_following(user_id, params, opts)
+  end
+
+  def focus(_input, _opts), do: {:error, "Missing user_id"}
+end

--- a/lux/lib/lux/lenses/twitter/get_following.ex
+++ b/lux/lib/lux/lenses/twitter/get_following.ex
@@ -2,6 +2,7 @@ defmodule Lux.Lenses.Twitter.GetFollowing do
   @moduledoc "Reads accounts followed by an X/Twitter user."
 
   alias Lux.Integrations.Twitter.Client
+  alias Lux.Lenses.Twitter.Input
 
   def view do
     Lux.Lens.new(
@@ -23,10 +24,17 @@ defmodule Lux.Lenses.Twitter.GetFollowing do
 
   def focus(input, opts \\ [])
 
-  def focus(%{user_id: user_id} = input, _opts) do
-    opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
-    params = Map.drop(input, [:user_id, :access_token, :bearer_token, :plug, :with_rate_limit])
-    Client.get_following(user_id, params, opts)
+  def focus(input, _opts) when is_map(input) do
+    input = Input.normalize(input)
+    user_id = input[:user_id]
+
+    if is_nil(user_id) do
+      {:error, "Missing user_id"}
+    else
+      opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+      params = Map.drop(input, [:user_id, :access_token, :bearer_token, :plug, :with_rate_limit])
+      Client.get_following(user_id, params, opts)
+    end
   end
 
   def focus(_input, _opts), do: {:error, "Missing user_id"}

--- a/lux/lib/lux/lenses/twitter/get_me.ex
+++ b/lux/lib/lux/lenses/twitter/get_me.ex
@@ -2,6 +2,7 @@ defmodule Lux.Lenses.Twitter.GetMe do
   @moduledoc "Reads the authenticated X/Twitter user's profile."
 
   alias Lux.Integrations.Twitter.Client
+  alias Lux.Lenses.Twitter.Input
 
   def view do
     Lux.Lens.new(
@@ -16,6 +17,7 @@ defmodule Lux.Lenses.Twitter.GetMe do
   end
 
   def focus(input \\ %{}, _opts \\ []) do
+    input = Input.normalize(input)
     opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
     params = Map.drop(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
     Client.get_me(params, opts)

--- a/lux/lib/lux/lenses/twitter/get_me.ex
+++ b/lux/lib/lux/lenses/twitter/get_me.ex
@@ -1,0 +1,23 @@
+defmodule Lux.Lenses.Twitter.GetMe do
+  @moduledoc "Reads the authenticated X/Twitter user's profile."
+
+  alias Lux.Integrations.Twitter.Client
+
+  def view do
+    Lux.Lens.new(
+      name: "Get Authenticated Twitter User",
+      module_name: inspect(__MODULE__),
+      description: "Reads the authenticated user's profile through X/Twitter API v2",
+      schema: %{
+        type: :object,
+        properties: %{user_fields: %{type: :array, items: %{type: :string}}}
+      }
+    )
+  end
+
+  def focus(input \\ %{}, _opts \\ []) do
+    opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+    params = Map.drop(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+    Client.get_me(params, opts)
+  end
+end

--- a/lux/lib/lux/lenses/twitter/get_tweet.ex
+++ b/lux/lib/lux/lenses/twitter/get_tweet.ex
@@ -1,0 +1,20 @@
+defmodule Lux.Lenses.Twitter.GetTweet do
+  @moduledoc "Reads an X/Twitter post by ID."
+
+  alias Lux.Integrations.Twitter.Client
+
+  def view do
+    Lux.Lens.new(
+      name: "Get Twitter Post",
+      module_name: inspect(__MODULE__),
+      description: "Reads a post through X/Twitter API v2",
+      schema: %{type: :object, properties: %{tweet_id: %{type: :string}}, required: ["tweet_id"]}
+    )
+  end
+
+  def focus(%{tweet_id: tweet_id} = input, _opts \\ []) do
+    opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+    params = Map.drop(input, [:tweet_id, :access_token, :bearer_token, :plug, :with_rate_limit])
+    Client.get_tweet(tweet_id, params, opts)
+  end
+end

--- a/lux/lib/lux/lenses/twitter/get_tweet.ex
+++ b/lux/lib/lux/lenses/twitter/get_tweet.ex
@@ -2,6 +2,7 @@ defmodule Lux.Lenses.Twitter.GetTweet do
   @moduledoc "Reads an X/Twitter post by ID."
 
   alias Lux.Integrations.Twitter.Client
+  alias Lux.Lenses.Twitter.Input
 
   def view do
     Lux.Lens.new(
@@ -12,9 +13,16 @@ defmodule Lux.Lenses.Twitter.GetTweet do
     )
   end
 
-  def focus(%{tweet_id: tweet_id} = input, _opts \\ []) do
-    opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
-    params = Map.drop(input, [:tweet_id, :access_token, :bearer_token, :plug, :with_rate_limit])
-    Client.get_tweet(tweet_id, params, opts)
+  def focus(input, _opts \\ []) do
+    input = Input.normalize(input)
+    tweet_id = input[:tweet_id]
+
+    if is_nil(tweet_id) do
+      {:error, "Missing tweet_id"}
+    else
+      opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+      params = Map.drop(input, [:tweet_id, :access_token, :bearer_token, :plug, :with_rate_limit])
+      Client.get_tweet(tweet_id, params, opts)
+    end
   end
 end

--- a/lux/lib/lux/lenses/twitter/get_user.ex
+++ b/lux/lib/lux/lenses/twitter/get_user.ex
@@ -1,0 +1,25 @@
+defmodule Lux.Lenses.Twitter.GetUser do
+  @moduledoc "Reads an X/Twitter user by ID or username."
+
+  alias Lux.Integrations.Twitter.Client
+
+  def view do
+    Lux.Lens.new(
+      name: "Get Twitter User",
+      module_name: inspect(__MODULE__),
+      description: "Reads a user through X/Twitter API v2",
+      schema: %{type: :object, properties: %{user_id: %{type: :string}, username: %{type: :string}}}
+    )
+  end
+
+  def focus(input, _opts \\ []) do
+    opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+    params = Map.drop(input, [:user_id, :username, :access_token, :bearer_token, :plug, :with_rate_limit])
+
+    cond do
+      input[:user_id] -> Client.get_user(input[:user_id], params, opts)
+      input[:username] -> Client.get_user_by_username(input[:username], params, opts)
+      true -> {:error, "Missing user_id or username"}
+    end
+  end
+end

--- a/lux/lib/lux/lenses/twitter/get_user.ex
+++ b/lux/lib/lux/lenses/twitter/get_user.ex
@@ -2,19 +2,33 @@ defmodule Lux.Lenses.Twitter.GetUser do
   @moduledoc "Reads an X/Twitter user by ID or username."
 
   alias Lux.Integrations.Twitter.Client
+  alias Lux.Lenses.Twitter.Input
 
   def view do
     Lux.Lens.new(
       name: "Get Twitter User",
       module_name: inspect(__MODULE__),
       description: "Reads a user through X/Twitter API v2",
-      schema: %{type: :object, properties: %{user_id: %{type: :string}, username: %{type: :string}}}
+      schema: %{
+        type: :object,
+        properties: %{user_id: %{type: :string}, username: %{type: :string}}
+      }
     )
   end
 
   def focus(input, _opts \\ []) do
+    input = Input.normalize(input)
     opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
-    params = Map.drop(input, [:user_id, :username, :access_token, :bearer_token, :plug, :with_rate_limit])
+
+    params =
+      Map.drop(input, [
+        :user_id,
+        :username,
+        :access_token,
+        :bearer_token,
+        :plug,
+        :with_rate_limit
+      ])
 
     cond do
       input[:user_id] -> Client.get_user(input[:user_id], params, opts)

--- a/lux/lib/lux/lenses/twitter/input.ex
+++ b/lux/lib/lux/lenses/twitter/input.ex
@@ -1,0 +1,36 @@
+defmodule Lux.Lenses.Twitter.Input do
+  @moduledoc false
+
+  @key_map %{
+    "access_token" => :access_token,
+    "bearer_token" => :bearer_token,
+    "expansions" => :expansions,
+    "max_results" => :max_results,
+    "media.fields" => :media_fields,
+    "media_fields" => :media_fields,
+    "pagination_token" => :pagination_token,
+    "place.fields" => :place_fields,
+    "place_fields" => :place_fields,
+    "plug" => :plug,
+    "poll.fields" => :poll_fields,
+    "poll_fields" => :poll_fields,
+    "query" => :query,
+    "tweet.fields" => :tweet_fields,
+    "tweet_fields" => :tweet_fields,
+    "tweet_id" => :tweet_id,
+    "user.fields" => :user_fields,
+    "user_fields" => :user_fields,
+    "user_id" => :user_id,
+    "username" => :username,
+    "with_rate_limit" => :with_rate_limit
+  }
+
+  def normalize(input) when is_map(input) do
+    Map.new(input, fn
+      {key, value} when is_binary(key) -> {Map.get(@key_map, key, key), value}
+      pair -> pair
+    end)
+  end
+
+  def normalize(_input), do: %{}
+end

--- a/lux/lib/lux/lenses/twitter/search_recent.ex
+++ b/lux/lib/lux/lenses/twitter/search_recent.ex
@@ -1,0 +1,20 @@
+defmodule Lux.Lenses.Twitter.SearchRecent do
+  @moduledoc "Searches recent X/Twitter posts."
+
+  alias Lux.Integrations.Twitter.Client
+
+  def view do
+    Lux.Lens.new(
+      name: "Search Recent Twitter Posts",
+      module_name: inspect(__MODULE__),
+      description: "Searches recent posts through X/Twitter API v2",
+      schema: %{type: :object, properties: %{query: %{type: :string}}, required: ["query"]}
+    )
+  end
+
+  def focus(%{query: query} = input, _opts \\ []) do
+    opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+    params = Map.drop(input, [:query, :access_token, :bearer_token, :plug, :with_rate_limit])
+    Client.search_recent(query, params, opts)
+  end
+end

--- a/lux/lib/lux/lenses/twitter/search_recent.ex
+++ b/lux/lib/lux/lenses/twitter/search_recent.ex
@@ -2,6 +2,7 @@ defmodule Lux.Lenses.Twitter.SearchRecent do
   @moduledoc "Searches recent X/Twitter posts."
 
   alias Lux.Integrations.Twitter.Client
+  alias Lux.Lenses.Twitter.Input
 
   def view do
     Lux.Lens.new(
@@ -12,9 +13,16 @@ defmodule Lux.Lenses.Twitter.SearchRecent do
     )
   end
 
-  def focus(%{query: query} = input, _opts \\ []) do
-    opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
-    params = Map.drop(input, [:query, :access_token, :bearer_token, :plug, :with_rate_limit])
-    Client.search_recent(query, params, opts)
+  def focus(input, _opts \\ []) do
+    input = Input.normalize(input)
+    query = input[:query]
+
+    if is_nil(query) do
+      {:error, "Missing query"}
+    else
+      opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+      params = Map.drop(input, [:query, :access_token, :bearer_token, :plug, :with_rate_limit])
+      Client.search_recent(query, params, opts)
+    end
   end
 end

--- a/lux/lib/lux/prisms/twitter/auth/build_authorization_url.ex
+++ b/lux/lib/lux/prisms/twitter/auth/build_authorization_url.ex
@@ -1,0 +1,27 @@
+defmodule Lux.Prisms.Twitter.Auth.BuildAuthorizationUrl do
+  @moduledoc "Builds an OAuth 2.0 PKCE authorization URL for X/Twitter."
+
+  use Lux.Prism,
+    name: "Build Twitter OAuth URL",
+    description: "Builds an X/Twitter OAuth 2.0 PKCE authorization URL",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        client_id: %{type: :string},
+        redirect_uri: %{type: :string},
+        state: %{type: :string},
+        code_verifier: %{type: :string},
+        scopes: %{type: :array, items: %{type: :string}}
+      },
+      required: ["client_id", "redirect_uri", "state"]
+    }
+
+  alias Lux.Integrations.Twitter.Client
+
+  def handler(input, _context) do
+    pkce = Client.pkce_pair(input[:code_verifier])
+    url = Client.authorization_url(Map.put(input, :code_verifier, pkce.verifier))
+
+    {:ok, %{authorization_url: url, code_verifier: pkce.verifier, code_challenge: pkce.challenge}}
+  end
+end

--- a/lux/lib/lux/prisms/twitter/auth/exchange_token.ex
+++ b/lux/lib/lux/prisms/twitter/auth/exchange_token.ex
@@ -21,17 +21,18 @@ defmodule Lux.Prisms.Twitter.Auth.ExchangeToken do
   alias Lux.Integrations.Twitter.Client
 
   def handler(%{grant_type: grant_type} = input, _context) do
-    grant_type =
-      grant_type
-      |> normalize_grant_type()
-
-    Client.token_request(grant_type, Map.delete(input, :grant_type))
+    case normalize_grant_type(grant_type) do
+      {:ok, grant_type} -> Client.token_request(grant_type, Map.delete(input, :grant_type))
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   def handler(_input, _context), do: {:error, "Missing grant_type"}
 
-  defp normalize_grant_type(value) when is_atom(value), do: value
+  defp normalize_grant_type(value) when value in [:authorization_code, :refresh_token],
+    do: {:ok, value}
 
-  defp normalize_grant_type("authorization_code"), do: :authorization_code
-  defp normalize_grant_type("refresh_token"), do: :refresh_token
+  defp normalize_grant_type("authorization_code"), do: {:ok, :authorization_code}
+  defp normalize_grant_type("refresh_token"), do: {:ok, :refresh_token}
+  defp normalize_grant_type(value), do: {:error, {:unsupported_grant_type, value}}
 end

--- a/lux/lib/lux/prisms/twitter/auth/exchange_token.ex
+++ b/lux/lib/lux/prisms/twitter/auth/exchange_token.ex
@@ -1,0 +1,37 @@
+defmodule Lux.Prisms.Twitter.Auth.ExchangeToken do
+  @moduledoc "Exchanges an authorization code or refresh token for X/Twitter OAuth tokens."
+
+  use Lux.Prism,
+    name: "Exchange Twitter OAuth Token",
+    description: "Exchanges an X/Twitter OAuth code or refresh token",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        grant_type: %{type: :string, enum: ["authorization_code", "refresh_token"]},
+        client_id: %{type: :string},
+        client_secret: %{type: :string},
+        redirect_uri: %{type: :string},
+        code: %{type: :string},
+        code_verifier: %{type: :string},
+        refresh_token: %{type: :string}
+      },
+      required: ["grant_type", "client_id"]
+    }
+
+  alias Lux.Integrations.Twitter.Client
+
+  def handler(%{grant_type: grant_type} = input, _context) do
+    grant_type =
+      grant_type
+      |> normalize_grant_type()
+
+    Client.token_request(grant_type, Map.delete(input, :grant_type))
+  end
+
+  def handler(_input, _context), do: {:error, "Missing grant_type"}
+
+  defp normalize_grant_type(value) when is_atom(value), do: value
+
+  defp normalize_grant_type("authorization_code"), do: :authorization_code
+  defp normalize_grant_type("refresh_token"), do: :refresh_token
+end

--- a/lux/lib/lux/prisms/twitter/media/upload_media.ex
+++ b/lux/lib/lux/prisms/twitter/media/upload_media.ex
@@ -1,0 +1,31 @@
+defmodule Lux.Prisms.Twitter.Media.UploadMedia do
+  @moduledoc "Runs a single INIT, APPEND, FINALIZE, or STATUS step in the X/Twitter chunked media upload flow."
+
+  use Lux.Prism,
+    name: "Twitter Media Upload Step",
+    description: "Uploads media through X/Twitter API v2 chunked upload",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        action: %{type: :string, enum: ["init", "append", "finalize", "status"]},
+        media_id: %{type: :string},
+        media: %{type: :string},
+        access_token: %{type: :string}
+      },
+      required: ["action"]
+    }
+
+  alias Lux.Integrations.Twitter.Client
+
+  def handler(%{action: action} = input, _context) do
+    action = if is_binary(action), do: String.to_existing_atom(action), else: action
+    opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+    params = Map.drop(input, [:action, :access_token, :bearer_token, :plug, :with_rate_limit])
+
+    Client.media_upload(action, params, opts)
+  rescue
+    ArgumentError -> {:error, "Unsupported media upload action"}
+  end
+
+  def handler(_input, _context), do: {:error, "Missing action"}
+end

--- a/lux/lib/lux/prisms/twitter/tweets/create_thread.ex
+++ b/lux/lib/lux/prisms/twitter/tweets/create_thread.ex
@@ -1,0 +1,23 @@
+defmodule Lux.Prisms.Twitter.Tweets.CreateThread do
+  @moduledoc "Creates an X/Twitter thread by posting each item as a reply to the previous post."
+
+  use Lux.Prism,
+    name: "Create Twitter Thread",
+    description: "Creates a thread through X/Twitter API v2",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        texts: %{type: :array, items: %{type: :string}, minItems: 1},
+        access_token: %{type: :string}
+      },
+      required: ["texts"]
+    }
+
+  alias Lux.Integrations.Twitter.Client
+
+  def handler(%{texts: texts} = input, _context) when is_list(texts) do
+    Client.create_thread(texts, Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit]))
+  end
+
+  def handler(_input, _context), do: {:error, "Missing texts"}
+end

--- a/lux/lib/lux/prisms/twitter/tweets/create_tweet.ex
+++ b/lux/lib/lux/prisms/twitter/tweets/create_tweet.ex
@@ -1,0 +1,27 @@
+defmodule Lux.Prisms.Twitter.Tweets.CreateTweet do
+  @moduledoc "Creates an X/Twitter post, including replies, quote posts, media, and edit payloads."
+
+  use Lux.Prism,
+    name: "Create Twitter Post",
+    description: "Creates a post through X/Twitter API v2",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        text: %{type: :string, minLength: 1, maxLength: 280},
+        reply_to_tweet_id: %{type: :string},
+        quote_tweet_id: %{type: :string},
+        media_ids: %{type: :array, items: %{type: :string}},
+        access_token: %{type: :string}
+      },
+      required: ["text"]
+    }
+
+  alias Lux.Integrations.Twitter.Client
+
+  def handler(input, _context) do
+    opts = take_opts(input)
+    input |> Map.drop([:access_token, :bearer_token, :plug]) |> Client.create_tweet(opts)
+  end
+
+  defp take_opts(input), do: Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+end

--- a/lux/lib/lux/prisms/twitter/tweets/delete_tweet.ex
+++ b/lux/lib/lux/prisms/twitter/tweets/delete_tweet.ex
@@ -1,0 +1,20 @@
+defmodule Lux.Prisms.Twitter.Tweets.DeleteTweet do
+  @moduledoc "Deletes an X/Twitter post by ID."
+
+  use Lux.Prism,
+    name: "Delete Twitter Post",
+    description: "Deletes a post through X/Twitter API v2",
+    input_schema: %{
+      type: :object,
+      properties: %{tweet_id: %{type: :string}, access_token: %{type: :string}},
+      required: ["tweet_id"]
+    }
+
+  alias Lux.Integrations.Twitter.Client
+
+  def handler(%{tweet_id: tweet_id} = input, _context) do
+    Client.delete_tweet(tweet_id, Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit]))
+  end
+
+  def handler(_input, _context), do: {:error, "Missing tweet_id"}
+end

--- a/lux/lib/lux/prisms/twitter/tweets/edit_tweet.ex
+++ b/lux/lib/lux/prisms/twitter/tweets/edit_tweet.ex
@@ -1,0 +1,21 @@
+defmodule Lux.Prisms.Twitter.Tweets.EditTweet do
+  @moduledoc "Edits an X/Twitter post using the API v2 edit_options payload."
+
+  use Lux.Prism,
+    name: "Edit Twitter Post",
+    description: "Creates an edit replacement for an existing X/Twitter post",
+    input_schema: %{
+      type: :object,
+      properties: %{previous_tweet_id: %{type: :string}, text: %{type: :string}, access_token: %{type: :string}},
+      required: ["previous_tweet_id", "text"]
+    }
+
+  alias Lux.Integrations.Twitter.Client
+
+  def handler(%{previous_tweet_id: previous_id} = input, _context) do
+    opts = Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+    input |> Map.drop([:previous_tweet_id, :access_token, :bearer_token, :plug]) |> then(&Client.edit_tweet(previous_id, &1, opts))
+  end
+
+  def handler(_input, _context), do: {:error, "Missing previous_tweet_id"}
+end

--- a/lux/lib/lux/prisms/twitter/tweets/quote_tweet.ex
+++ b/lux/lib/lux/prisms/twitter/tweets/quote_tweet.ex
@@ -1,0 +1,20 @@
+defmodule Lux.Prisms.Twitter.Tweets.QuoteTweet do
+  @moduledoc "Creates a quote post for an existing X/Twitter post."
+
+  use Lux.Prism,
+    name: "Quote Twitter Post",
+    description: "Creates a quote post through X/Twitter API v2",
+    input_schema: %{
+      type: :object,
+      properties: %{text: %{type: :string}, quoted_tweet_id: %{type: :string}, access_token: %{type: :string}},
+      required: ["text", "quoted_tweet_id"]
+    }
+
+  alias Lux.Integrations.Twitter.Client
+
+  def handler(%{text: text, quoted_tweet_id: quoted_id} = input, _context) do
+    Client.quote_tweet(text, quoted_id, Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit]))
+  end
+
+  def handler(_input, _context), do: {:error, "Missing text or quoted_tweet_id"}
+end

--- a/lux/lib/lux/prisms/twitter/users/follow_user.ex
+++ b/lux/lib/lux/prisms/twitter/users/follow_user.ex
@@ -1,0 +1,24 @@
+defmodule Lux.Prisms.Twitter.Users.FollowUser do
+  @moduledoc "Follows a target X/Twitter user from an authenticated source user."
+
+  use Lux.Prism,
+    name: "Follow Twitter User",
+    description: "Follows a user through X/Twitter API v2",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        source_user_id: %{type: :string},
+        target_user_id: %{type: :string},
+        access_token: %{type: :string}
+      },
+      required: ["source_user_id", "target_user_id"]
+    }
+
+  alias Lux.Integrations.Twitter.Client
+
+  def handler(%{source_user_id: source_id, target_user_id: target_id} = input, _context) do
+    Client.follow_user(source_id, target_id, Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit]))
+  end
+
+  def handler(_input, _context), do: {:error, "Missing source_user_id or target_user_id"}
+end

--- a/lux/lib/lux/prisms/twitter/users/unfollow_user.ex
+++ b/lux/lib/lux/prisms/twitter/users/unfollow_user.ex
@@ -1,0 +1,28 @@
+defmodule Lux.Prisms.Twitter.Users.UnfollowUser do
+  @moduledoc "Unfollows a target X/Twitter user from an authenticated source user."
+
+  use Lux.Prism,
+    name: "Unfollow Twitter User",
+    description: "Unfollows a user through X/Twitter API v2",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        source_user_id: %{type: :string},
+        target_user_id: %{type: :string},
+        access_token: %{type: :string}
+      },
+      required: ["source_user_id", "target_user_id"]
+    }
+
+  alias Lux.Integrations.Twitter.Client
+
+  def handler(%{source_user_id: source_id, target_user_id: target_id} = input, _context) do
+    Client.unfollow_user(
+      source_id,
+      target_id,
+      Map.take(input, [:access_token, :bearer_token, :plug, :with_rate_limit])
+    )
+  end
+
+  def handler(_input, _context), do: {:error, "Missing source_user_id or target_user_id"}
+end

--- a/lux/mix.exs
+++ b/lux/mix.exs
@@ -136,6 +136,7 @@ defmodule Lux.MixProject do
         "guides/prisms.livemd",
         "guides/signals.livemd",
         "guides/lenses.livemd",
+        "guides/twitter_api_core.livemd",
         "guides/language_support.md",
         "guides/language_support/python.livemd",
         "guides/language_support/nodejs.livemd",

--- a/lux/test/unit/lux/integrations/twitter/client_test.exs
+++ b/lux/test/unit/lux/integrations/twitter/client_test.exs
@@ -276,7 +276,7 @@ defmodule Lux.Integrations.Twitter.ClientTest do
                   limit: 300,
                   remaining: 299,
                   reset: 1_770_000_000,
-                  reset_at: ~U[2026-02-24 11:20:00Z],
+                  reset_at: ~U[2026-02-02 02:40:00Z],
                   rate_limited?: false
                 }
               }} =
@@ -309,7 +309,7 @@ defmodule Lux.Integrations.Twitter.ClientTest do
                    limit: 300,
                    remaining: 0,
                    reset: 1_770_000_000,
-                   reset_at: ~U[2026-02-24 11:20:00Z],
+                   reset_at: ~U[2026-02-02 02:40:00Z],
                    retry_after: 900,
                    rate_limited?: true
                  }

--- a/lux/test/unit/lux/integrations/twitter/client_test.exs
+++ b/lux/test/unit/lux/integrations/twitter/client_test.exs
@@ -35,6 +35,7 @@ defmodule Lux.Integrations.Twitter.ClientTest do
       assert query["redirect_uri"] == "https://example.com/callback"
       assert query["response_type"] == "code"
       assert query["scope"] =~ "tweet.write"
+      assert query["scope"] =~ "media.write"
       assert query["code_challenge_method"] == "S256"
     end
 
@@ -77,6 +78,14 @@ defmodule Lux.Integrations.Twitter.ClientTest do
   end
 
   describe "tweets" do
+    test "rejects write operations without a user access token" do
+      assert {:error, :access_token_required} =
+               Client.create_tweet(%{text: "hello"}, %{bearer_token: "app-only"})
+
+      assert {:error, :access_token_required} =
+               Client.delete_tweet("tweet-1", %{bearer_token: "app-only"})
+    end
+
     test "creates a post with reply, quote, media, and edit options" do
       Req.Test.expect(__MODULE__, fn conn ->
         assert conn.method == "POST"
@@ -331,6 +340,17 @@ defmodule Lux.Integrations.Twitter.ClientTest do
                  %{total_bytes: 1024, media_type: "video/mp4", media_category: "tweet_video"},
                  %{access_token: "access-1", plug: {Req.Test, __MODULE__}}
                )
+    end
+
+    test "rejects media and follow mutations without a user access token" do
+      assert {:error, :access_token_required} =
+               Client.media_upload(:init, %{total_bytes: 1024}, %{bearer_token: "app-only"})
+
+      assert {:error, :access_token_required} =
+               Client.follow_user("user-1", "user-2", %{bearer_token: "app-only"})
+
+      assert {:error, :access_token_required} =
+               Client.unfollow_user("user-1", "user-2", %{bearer_token: "app-only"})
     end
   end
 end

--- a/lux/test/unit/lux/integrations/twitter/client_test.exs
+++ b/lux/test/unit/lux/integrations/twitter/client_test.exs
@@ -1,0 +1,250 @@
+defmodule Lux.Integrations.Twitter.ClientTest do
+  use UnitAPICase, async: true
+
+  alias Lux.Integrations.Twitter.Client
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "OAuth 2.0 PKCE" do
+    test "builds RFC-compatible challenge" do
+      pkce = Client.pkce_pair("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+
+      assert pkce.verifier == "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+      assert pkce.challenge == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+      assert pkce.method == "S256"
+    end
+
+    test "builds authorization URL with default scopes" do
+      url =
+        Client.authorization_url(%{
+          client_id: "client-1",
+          redirect_uri: "https://example.com/callback",
+          state: "state-1",
+          code_verifier: "verifier-1"
+        })
+
+      uri = URI.parse(url)
+      query = URI.decode_query(uri.query)
+
+      assert uri.host == "x.com"
+      assert uri.path == "/i/oauth2/authorize"
+      assert query["client_id"] == "client-1"
+      assert query["redirect_uri"] == "https://example.com/callback"
+      assert query["response_type"] == "code"
+      assert query["scope"] =~ "tweet.write"
+      assert query["code_challenge_method"] == "S256"
+    end
+
+    test "exchanges authorization code with form body and optional basic auth" do
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/2/oauth2/token"
+
+        assert Plug.Conn.get_req_header(conn, "authorization") == [
+                 "Basic Y2xpZW50LTE6c2VjcmV0LTE="
+               ]
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        form = URI.decode_query(body)
+
+        assert form["grant_type"] == "authorization_code"
+        assert form["client_id"] == "client-1"
+        assert form["code"] == "code-1"
+        assert form["code_verifier"] == "verifier-1"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"access_token" => "access-1"}))
+      end)
+
+      assert {:ok, %{"access_token" => "access-1"}} =
+               Client.token_request(:authorization_code, %{
+                 client_id: "client-1",
+                 client_secret: "secret-1",
+                 redirect_uri: "https://example.com/callback",
+                 code: "code-1",
+                 code_verifier: "verifier-1",
+                 plug: {Req.Test, __MODULE__}
+               })
+    end
+  end
+
+  describe "tweets" do
+    test "creates a post with reply, quote, media, and edit options" do
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/2/tweets"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer access-1"]
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        json = Jason.decode!(body)
+
+        assert json["text"] == "updated text"
+        assert json["reply"]["in_reply_to_tweet_id"] == "parent-1"
+        assert json["quote_tweet_id"] == "quote-1"
+        assert json["media"]["media_ids"] == ["media-1"]
+        assert json["edit_options"]["previous_post_id"] == "old-1"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(201, Jason.encode!(%{"data" => %{"id" => "tweet-1"}}))
+      end)
+
+      assert {:ok, %{"data" => %{"id" => "tweet-1"}}} =
+               Client.edit_tweet(
+                 "old-1",
+                 %{
+                   text: "updated text",
+                   reply_to_tweet_id: "parent-1",
+                   quote_tweet_id: "quote-1",
+                   media_ids: ["media-1"]
+                 },
+                 %{access_token: "access-1", plug: {Req.Test, __MODULE__}}
+               )
+    end
+
+    test "creates a thread by chaining replies" do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      Req.Test.expect(__MODULE__, 2, fn conn ->
+        index = Agent.get_and_update(counter, fn value -> {value, value + 1} end)
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        json = Jason.decode!(body)
+
+        if index == 0 do
+          assert json["text"] == "first"
+          refute Map.has_key?(json, "reply")
+        else
+          assert json["text"] == "second"
+          assert json["reply"]["in_reply_to_tweet_id"] == "tweet-1"
+        end
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(201, Jason.encode!(%{"data" => %{"id" => "tweet-#{index + 1}"}}))
+      end)
+
+      assert {:ok, [%{"data" => %{"id" => "tweet-1"}}, %{"data" => %{"id" => "tweet-2"}}]} =
+               Client.create_thread(["first", "second"], %{
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__}
+               })
+    end
+
+    test "deletes and looks up tweets with query params" do
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "DELETE"
+        assert conn.request_path == "/2/tweets/tweet-1"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => %{"deleted" => true}}))
+      end)
+
+      assert {:ok, %{"data" => %{"deleted" => true}}} =
+               Client.delete_tweet("tweet-1", %{access_token: "access-1", plug: {Req.Test, __MODULE__}})
+
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/2/tweets/tweet-1"
+        assert conn.query_string == "tweet.fields=created_at%2Cpublic_metrics"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => %{"id" => "tweet-1"}}))
+      end)
+
+      assert {:ok, %{"data" => %{"id" => "tweet-1"}}} =
+               Client.get_tweet("tweet-1", %{tweet_fields: ["created_at", "public_metrics"]}, %{
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__}
+               })
+    end
+  end
+
+  describe "users, search, media, and rate limits" do
+    test "reads authenticated user and manages follows" do
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/2/users/me"
+        assert conn.query_string == "user.fields=username"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => %{"id" => "user-1"}}))
+      end)
+
+      assert {:ok, %{"data" => %{"id" => "user-1"}}} =
+               Client.get_me(%{user_fields: ["username"]}, %{access_token: "access-1", plug: {Req.Test, __MODULE__}})
+
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/2/users/user-1/following"
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert Jason.decode!(body)["target_user_id"] == "user-2"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => %{"following" => true}}))
+      end)
+
+      assert {:ok, %{"data" => %{"following" => true}}} =
+               Client.follow_user("user-1", "user-2", %{access_token: "access-1", plug: {Req.Test, __MODULE__}})
+    end
+
+    test "searches recent tweets and exposes rate limit headers" do
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/2/tweets/search/recent"
+        assert conn.query_string == "max_results=10&query=lux"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.put_resp_header("x-rate-limit-limit", "300")
+        |> Plug.Conn.put_resp_header("x-rate-limit-remaining", "299")
+        |> Plug.Conn.put_resp_header("x-rate-limit-reset", "1770000000")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => []}))
+      end)
+
+      assert {:ok,
+              %{
+                body: %{"data" => []},
+                rate_limit: %{limit: "300", remaining: "299", reset: "1770000000"}
+              }} =
+               Client.search_recent("lux", %{max_results: 10}, %{
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__},
+                 with_rate_limit: true
+               })
+    end
+
+    test "initializes chunked media upload" do
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/2/media/upload"
+        assert [content_type] = Plug.Conn.get_req_header(conn, "content-type")
+        assert content_type =~ "multipart/form-data"
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert body =~ "INIT"
+        assert body =~ "tweet_video"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(202, Jason.encode!(%{"data" => %{"id" => "media-1"}}))
+      end)
+
+      assert {:ok, %{"data" => %{"id" => "media-1"}}} =
+               Client.media_upload(
+                 :init,
+                 %{total_bytes: 1024, media_type: "video/mp4", media_category: "tweet_video"},
+                 %{access_token: "access-1", plug: {Req.Test, __MODULE__}}
+               )
+    end
+  end
+end

--- a/lux/test/unit/lux/integrations/twitter/client_test.exs
+++ b/lux/test/unit/lux/integrations/twitter/client_test.exs
@@ -47,6 +47,10 @@ defmodule Lux.Integrations.Twitter.ClientTest do
                  "Basic Y2xpZW50LTE6c2VjcmV0LTE="
                ]
 
+        assert Plug.Conn.get_req_header(conn, "content-type") == [
+                 "application/x-www-form-urlencoded"
+               ]
+
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         form = URI.decode_query(body)
 

--- a/lux/test/unit/lux/integrations/twitter/client_test.exs
+++ b/lux/test/unit/lux/integrations/twitter/client_test.exs
@@ -146,7 +146,10 @@ defmodule Lux.Integrations.Twitter.ClientTest do
       end)
 
       assert {:ok, %{"data" => %{"deleted" => true}}} =
-               Client.delete_tweet("tweet-1", %{access_token: "access-1", plug: {Req.Test, __MODULE__}})
+               Client.delete_tweet("tweet-1", %{
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__}
+               })
 
       Req.Test.expect(__MODULE__, fn conn ->
         assert conn.method == "GET"
@@ -179,7 +182,10 @@ defmodule Lux.Integrations.Twitter.ClientTest do
       end)
 
       assert {:ok, %{"data" => %{"id" => "user-1"}}} =
-               Client.get_me(%{user_fields: ["username"]}, %{access_token: "access-1", plug: {Req.Test, __MODULE__}})
+               Client.get_me(%{user_fields: ["username"]}, %{
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__}
+               })
 
       Req.Test.expect(__MODULE__, fn conn ->
         assert conn.method == "POST"
@@ -194,7 +200,10 @@ defmodule Lux.Integrations.Twitter.ClientTest do
       end)
 
       assert {:ok, %{"data" => %{"following" => true}}} =
-               Client.follow_user("user-1", "user-2", %{access_token: "access-1", plug: {Req.Test, __MODULE__}})
+               Client.follow_user("user-1", "user-2", %{
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__}
+               })
     end
 
     test "searches recent tweets and exposes rate limit headers" do
@@ -214,12 +223,85 @@ defmodule Lux.Integrations.Twitter.ClientTest do
       assert {:ok,
               %{
                 body: %{"data" => []},
-                rate_limit: %{limit: "300", remaining: "299", reset: "1770000000"}
+                rate_limit: %{
+                  limit: 300,
+                  remaining: 299,
+                  reset: 1_770_000_000,
+                  reset_at: ~U[2026-02-24 11:20:00Z],
+                  rate_limited?: false
+                }
               }} =
                Client.search_recent("lux", %{max_results: 10}, %{
                  access_token: "access-1",
                  plug: {Req.Test, __MODULE__},
                  with_rate_limit: true
+               })
+    end
+
+    test "returns structured rate limit errors" do
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/2/tweets/search/recent"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.put_resp_header("x-rate-limit-limit", "300")
+        |> Plug.Conn.put_resp_header("x-rate-limit-remaining", "0")
+        |> Plug.Conn.put_resp_header("x-rate-limit-reset", "1770000000")
+        |> Plug.Conn.put_resp_header("retry-after", "900")
+        |> Plug.Conn.send_resp(429, Jason.encode!(%{"title" => "Too Many Requests"}))
+      end)
+
+      assert {:error,
+              {:rate_limited,
+               %{
+                 body: %{"title" => "Too Many Requests"},
+                 rate_limit: %{
+                   limit: 300,
+                   remaining: 0,
+                   reset: 1_770_000_000,
+                   reset_at: ~U[2026-02-24 11:20:00Z],
+                   retry_after: 900,
+                   rate_limited?: true
+                 }
+               }}} =
+               Client.search_recent("lux", %{}, %{
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__}
+               })
+    end
+
+    test "reads followers and following for user profile management" do
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/2/users/user-1/followers"
+        assert conn.query_string == "max_results=10&user.fields=username"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => [%{"id" => "follower-1"}]}))
+      end)
+
+      assert {:ok, %{"data" => [%{"id" => "follower-1"}]}} =
+               Client.get_followers(
+                 "user-1",
+                 %{max_results: 10, user_fields: ["username"]},
+                 %{access_token: "access-1", plug: {Req.Test, __MODULE__}}
+               )
+
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/2/users/user-1/following"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => [%{"id" => "following-1"}]}))
+      end)
+
+      assert {:ok, %{"data" => [%{"id" => "following-1"}]}} =
+               Client.get_following("user-1", %{}, %{
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__}
                })
     end
 

--- a/lux/test/unit/lux/integrations/twitter/client_test.exs
+++ b/lux/test/unit/lux/integrations/twitter/client_test.exs
@@ -75,6 +75,14 @@ defmodule Lux.Integrations.Twitter.ClientTest do
                  plug: {Req.Test, __MODULE__}
                })
     end
+
+    test "preflights grant-specific token request fields" do
+      assert {:error, {:missing_required_fields, [:code, :redirect_uri, :code_verifier]}} =
+               Client.token_request(:authorization_code, %{client_id: "client-1"})
+
+      assert {:error, {:missing_required_fields, [:refresh_token]}} =
+               Client.token_request(:refresh_token, %{client_id: "client-1"})
+    end
   end
 
   describe "tweets" do
@@ -142,6 +150,34 @@ defmodule Lux.Integrations.Twitter.ClientTest do
       end)
 
       assert {:ok, [%{"data" => %{"id" => "tweet-1"}}, %{"data" => %{"id" => "tweet-2"}}]} =
+               Client.create_thread(["first", "second"], %{
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__}
+               })
+    end
+
+    test "thread errors include already published posts" do
+      Req.Test.expect(__MODULE__, 2, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        json = Jason.decode!(body)
+
+        if json["text"] == "first" do
+          conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.send_resp(201, Jason.encode!(%{"data" => %{"id" => "tweet-1"}}))
+        else
+          conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.send_resp(403, Jason.encode!(%{"detail" => "missing scope"}))
+        end
+      end)
+
+      assert {:error,
+              {:partial_thread_failure,
+               %{
+                 reason: {403, "missing scope"},
+                 published: [%{"data" => %{"id" => "tweet-1"}}]
+               }}} =
                Client.create_thread(["first", "second"], %{
                  access_token: "access-1",
                  plug: {Req.Test, __MODULE__}
@@ -318,16 +354,17 @@ defmodule Lux.Integrations.Twitter.ClientTest do
                })
     end
 
-    test "initializes chunked media upload" do
+    test "initializes chunked media upload with the documented v2 endpoint" do
       Req.Test.expect(__MODULE__, fn conn ->
         assert conn.method == "POST"
-        assert conn.request_path == "/2/media/upload"
-        assert [content_type] = Plug.Conn.get_req_header(conn, "content-type")
-        assert content_type =~ "multipart/form-data"
+        assert conn.request_path == "/2/media/upload/initialize"
+        assert Plug.Conn.get_req_header(conn, "content-type") == ["application/json"]
 
         {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert body =~ "INIT"
-        assert body =~ "tweet_video"
+        json = Jason.decode!(body)
+        assert json["total_bytes"] == 1024
+        assert json["media_type"] == "video/mp4"
+        assert json["media_category"] == "tweet_video"
 
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
@@ -340,6 +377,98 @@ defmodule Lux.Integrations.Twitter.ClientTest do
                  %{total_bytes: 1024, media_type: "video/mp4", media_category: "tweet_video"},
                  %{access_token: "access-1", plug: {Req.Test, __MODULE__}}
                )
+    end
+
+    test "appends and finalizes media uploads with documented media id paths" do
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/2/media/upload/media-1/append"
+        assert [content_type] = Plug.Conn.get_req_header(conn, "content-type")
+        assert content_type =~ "multipart/form-data"
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert body =~ "segment_index"
+        refute body =~ "media_id"
+        refute body =~ "APPEND"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => %{"expires_at" => 1_770_000_000}}))
+      end)
+
+      assert {:ok, %{"data" => %{"expires_at" => 1_770_000_000}}} =
+               Client.media_upload(
+                 :append,
+                 %{media_id: "media-1", segment_index: 0, media: "bytes"},
+                 %{access_token: "access-1", plug: {Req.Test, __MODULE__}}
+               )
+
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/2/media/upload/media-1/finalize"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => %{"id" => "media-1"}}))
+      end)
+
+      assert {:ok, %{"data" => %{"id" => "media-1"}}} =
+               Client.media_upload(:finalize, %{media_id: "media-1"}, %{
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__}
+               })
+    end
+
+    test "checks media upload status with the documented media_id query" do
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/2/media/upload"
+        assert conn.query_string == "media_id=media-1"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => %{"id" => "media-1"}}))
+      end)
+
+      assert {:ok, %{"data" => %{"id" => "media-1"}}} =
+               Client.media_upload(:status, %{media_id: "media-1"}, %{
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__}
+               })
+    end
+
+    test "preflights media id requirements for chunked upload follow-ups" do
+      assert {:error, {:missing_required_fields, [:media_id]}} =
+               Client.media_upload(:finalize, %{}, %{access_token: "access-1"})
+
+      assert {:error, {:missing_required_fields, [:media_id, :media]}} =
+               Client.media_upload(:append, %{}, %{access_token: "access-1"})
+    end
+
+    test "preserves rate-limit context on permission errors when requested" do
+      Req.Test.expect(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/2/tweets"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.put_resp_header("x-rate-limit-limit", "50")
+        |> Plug.Conn.put_resp_header("x-rate-limit-remaining", "49")
+        |> Plug.Conn.put_resp_header("x-rate-limit-reset", "1770000000")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{"detail" => "missing required scope"}))
+      end)
+
+      assert {:error,
+              %{
+                status: 403,
+                reason: "missing required scope",
+                rate_limit: %{limit: 50, remaining: 49, reset: 1_770_000_000}
+              }} =
+               Client.create_tweet(%{text: "hello"}, %{
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__},
+                 with_rate_limit: true
+               })
     end
 
     test "rejects media and follow mutations without a user access token" do

--- a/lux/test/unit/lux/integrations/twitter/client_test.exs
+++ b/lux/test/unit/lux/integrations/twitter/client_test.exs
@@ -1,11 +1,43 @@
 defmodule Lux.Integrations.Twitter.ClientTest do
   use UnitAPICase, async: true
 
+  alias Lux.Integrations.Twitter
   alias Lux.Integrations.Twitter.Client
 
   setup do
     Req.Test.verify_on_exit!()
     :ok
+  end
+
+  describe "configuration" do
+    test "uses the configured API URL for request paths" do
+      previous = Application.get_env(:lux, Twitter)
+
+      try do
+        Application.put_env(:lux, Twitter, api_url: "https://api.twitter.com")
+
+        Req.Test.expect(__MODULE__, fn conn ->
+          assert conn.method == "GET"
+          assert conn.request_path == "/2/tweets/search/recent"
+
+          conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => []}))
+        end)
+
+        assert {:ok, %{"data" => []}} =
+                 Client.search_recent("lux", %{}, %{
+                   access_token: "access-1",
+                   plug: {Req.Test, __MODULE__}
+                 })
+      after
+        if previous do
+          Application.put_env(:lux, Twitter, previous)
+        else
+          Application.delete_env(:lux, Twitter)
+        end
+      end
+    end
   end
 
   describe "OAuth 2.0 PKCE" do

--- a/lux/test/unit/lux/lenses/twitter/twitter_lenses_test.exs
+++ b/lux/test/unit/lux/lenses/twitter/twitter_lenses_test.exs
@@ -2,6 +2,8 @@ defmodule Lux.Lenses.TwitterTest do
   use UnitAPICase, async: true
 
   alias Lux.Lenses.Twitter.GetTweet
+  alias Lux.Lenses.Twitter.GetFollowers
+  alias Lux.Lenses.Twitter.GetFollowing
   alias Lux.Lenses.Twitter.GetMe
   alias Lux.Lenses.Twitter.GetUser
   alias Lux.Lenses.Twitter.SearchRecent
@@ -84,6 +86,42 @@ defmodule Lux.Lenses.TwitterTest do
              SearchRecent.focus(%{
                query: "lux",
                max_results: 10,
+               access_token: "access-1",
+               plug: {Req.Test, __MODULE__}
+             })
+  end
+
+  test "followers and following lenses expose user social graph reads" do
+    Req.Test.expect(__MODULE__, fn conn ->
+      assert conn.method == "GET"
+      assert conn.request_path == "/2/users/user-1/followers"
+      assert conn.query_string == "max_results=5"
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => [%{"id" => "follower-1"}]}))
+    end)
+
+    assert {:ok, %{"data" => [%{"id" => "follower-1"}]}} =
+             GetFollowers.focus(%{
+               user_id: "user-1",
+               max_results: 5,
+               access_token: "access-1",
+               plug: {Req.Test, __MODULE__}
+             })
+
+    Req.Test.expect(__MODULE__, fn conn ->
+      assert conn.method == "GET"
+      assert conn.request_path == "/2/users/user-1/following"
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => [%{"id" => "following-1"}]}))
+    end)
+
+    assert {:ok, %{"data" => [%{"id" => "following-1"}]}} =
+             GetFollowing.focus(%{
+               user_id: "user-1",
                access_token: "access-1",
                plug: {Req.Test, __MODULE__}
              })

--- a/lux/test/unit/lux/lenses/twitter/twitter_lenses_test.exs
+++ b/lux/test/unit/lux/lenses/twitter/twitter_lenses_test.exs
@@ -1,0 +1,55 @@
+defmodule Lux.Lenses.TwitterTest do
+  use UnitAPICase, async: true
+
+  alias Lux.Lenses.Twitter.GetTweet
+  alias Lux.Lenses.Twitter.GetUser
+  alias Lux.Lenses.Twitter.SearchRecent
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  test "get tweet lens reads by id" do
+    Req.Test.expect(__MODULE__, fn conn ->
+      assert conn.method == "GET"
+      assert conn.request_path == "/2/tweets/tweet-1"
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => %{"id" => "tweet-1"}}))
+    end)
+
+    assert {:ok, %{"data" => %{"id" => "tweet-1"}}} =
+             GetTweet.focus(%{tweet_id: "tweet-1", access_token: "access-1", plug: {Req.Test, __MODULE__}})
+  end
+
+  test "get user lens supports username lookup" do
+    Req.Test.expect(__MODULE__, fn conn ->
+      assert conn.method == "GET"
+      assert conn.request_path == "/2/users/by/username/spectral"
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => %{"username" => "spectral"}}))
+    end)
+
+    assert {:ok, %{"data" => %{"username" => "spectral"}}} =
+             GetUser.focus(%{username: "spectral", access_token: "access-1", plug: {Req.Test, __MODULE__}})
+  end
+
+  test "search recent lens forwards query params" do
+    Req.Test.expect(__MODULE__, fn conn ->
+      assert conn.method == "GET"
+      assert conn.request_path == "/2/tweets/search/recent"
+      assert conn.query_string == "max_results=10&query=lux"
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => []}))
+    end)
+
+    assert {:ok, %{"data" => []}} =
+             SearchRecent.focus(%{query: "lux", max_results: 10, access_token: "access-1", plug: {Req.Test, __MODULE__}})
+  end
+end

--- a/lux/test/unit/lux/lenses/twitter/twitter_lenses_test.exs
+++ b/lux/test/unit/lux/lenses/twitter/twitter_lenses_test.exs
@@ -2,6 +2,7 @@ defmodule Lux.Lenses.TwitterTest do
   use UnitAPICase, async: true
 
   alias Lux.Lenses.Twitter.GetTweet
+  alias Lux.Lenses.Twitter.GetMe
   alias Lux.Lenses.Twitter.GetUser
   alias Lux.Lenses.Twitter.SearchRecent
 
@@ -21,7 +22,11 @@ defmodule Lux.Lenses.TwitterTest do
     end)
 
     assert {:ok, %{"data" => %{"id" => "tweet-1"}}} =
-             GetTweet.focus(%{tweet_id: "tweet-1", access_token: "access-1", plug: {Req.Test, __MODULE__}})
+             GetTweet.focus(%{
+               tweet_id: "tweet-1",
+               access_token: "access-1",
+               plug: {Req.Test, __MODULE__}
+             })
   end
 
   test "get user lens supports username lookup" do
@@ -35,7 +40,33 @@ defmodule Lux.Lenses.TwitterTest do
     end)
 
     assert {:ok, %{"data" => %{"username" => "spectral"}}} =
-             GetUser.focus(%{username: "spectral", access_token: "access-1", plug: {Req.Test, __MODULE__}})
+             GetUser.focus(%{
+               username: "spectral",
+               access_token: "access-1",
+               plug: {Req.Test, __MODULE__}
+             })
+  end
+
+  test "get me lens reads the authenticated profile" do
+    Req.Test.expect(__MODULE__, fn conn ->
+      assert conn.method == "GET"
+      assert conn.request_path == "/2/users/me"
+      assert conn.query_string == "user.fields=username%2Cverified"
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(
+        200,
+        Jason.encode!(%{"data" => %{"id" => "me", "username" => "spectral"}})
+      )
+    end)
+
+    assert {:ok, %{"data" => %{"username" => "spectral"}}} =
+             GetMe.focus(%{
+               user_fields: ["username", "verified"],
+               access_token: "access-1",
+               plug: {Req.Test, __MODULE__}
+             })
   end
 
   test "search recent lens forwards query params" do
@@ -50,6 +81,11 @@ defmodule Lux.Lenses.TwitterTest do
     end)
 
     assert {:ok, %{"data" => []}} =
-             SearchRecent.focus(%{query: "lux", max_results: 10, access_token: "access-1", plug: {Req.Test, __MODULE__}})
+             SearchRecent.focus(%{
+               query: "lux",
+               max_results: 10,
+               access_token: "access-1",
+               plug: {Req.Test, __MODULE__}
+             })
   end
 end

--- a/lux/test/unit/lux/lenses/twitter/twitter_lenses_test.exs
+++ b/lux/test/unit/lux/lenses/twitter/twitter_lenses_test.exs
@@ -91,6 +91,35 @@ defmodule Lux.Lenses.TwitterTest do
              })
   end
 
+  test "search recent lens accepts string-key schema input with token and rate limit metadata" do
+    Req.Test.expect(__MODULE__, fn conn ->
+      assert conn.method == "GET"
+      assert conn.request_path == "/2/tweets/search/recent"
+      assert conn.query_string == "max_results=10&query=lux"
+      assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer access-1"]
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.put_resp_header("x-rate-limit-limit", "300")
+      |> Plug.Conn.put_resp_header("x-rate-limit-remaining", "299")
+      |> Plug.Conn.put_resp_header("x-rate-limit-reset", "1770000000")
+      |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => []}))
+    end)
+
+    assert {:ok,
+            %{
+              body: %{"data" => []},
+              rate_limit: %{limit: 300, remaining: 299}
+            }} =
+             SearchRecent.focus(%{
+               "query" => "lux",
+               "max_results" => 10,
+               "access_token" => "access-1",
+               "with_rate_limit" => true,
+               "plug" => {Req.Test, __MODULE__}
+             })
+  end
+
   test "followers and following lenses expose user social graph reads" do
     Req.Test.expect(__MODULE__, fn conn ->
       assert conn.method == "GET"

--- a/lux/test/unit/lux/prisms/twitter/tweets_test.exs
+++ b/lux/test/unit/lux/prisms/twitter/tweets_test.exs
@@ -1,9 +1,12 @@
 defmodule Lux.Prisms.Twitter.TweetsTest do
   use UnitAPICase, async: true
 
+  alias Lux.Prisms.Twitter.Auth.BuildAuthorizationUrl
+  alias Lux.Prisms.Twitter.Auth.ExchangeToken
   alias Lux.Prisms.Twitter.Tweets.CreateThread
   alias Lux.Prisms.Twitter.Tweets.CreateTweet
   alias Lux.Prisms.Twitter.Tweets.DeleteTweet
+  alias Lux.Prisms.Twitter.Users.UnfollowUser
 
   setup do
     Req.Test.verify_on_exit!()
@@ -24,7 +27,10 @@ defmodule Lux.Prisms.Twitter.TweetsTest do
     end)
 
     assert {:ok, %{"data" => %{"id" => "tweet-1"}}} =
-             CreateTweet.handler(%{text: "hello", access_token: "access-1", plug: {Req.Test, __MODULE__}}, %{})
+             CreateTweet.handler(
+               %{text: "hello", access_token: "access-1", plug: {Req.Test, __MODULE__}},
+               %{}
+             )
   end
 
   test "delete tweet prism validates required input" do
@@ -50,6 +56,72 @@ defmodule Lux.Prisms.Twitter.TweetsTest do
     end)
 
     assert {:ok, [%{"data" => %{"id" => "tweet-1"}}, %{"data" => %{"id" => "tweet-2"}}]} =
-             CreateThread.handler(%{texts: ["one", "two"], access_token: "access-1", plug: {Req.Test, __MODULE__}}, %{})
+             CreateThread.handler(
+               %{texts: ["one", "two"], access_token: "access-1", plug: {Req.Test, __MODULE__}},
+               %{}
+             )
+  end
+
+  test "auth URL prism exposes verifier and challenge" do
+    assert {:ok, %{authorization_url: url, code_verifier: verifier, code_challenge: challenge}} =
+             BuildAuthorizationUrl.handler(
+               %{
+                 client_id: "client-1",
+                 redirect_uri: "https://example.com/callback",
+                 state: "state-1"
+               },
+               %{}
+             )
+
+    assert verifier
+    assert challenge
+    assert URI.parse(url).host == "x.com"
+  end
+
+  test "token exchange prism passes refresh token requests to client" do
+    Req.Test.expect(__MODULE__, fn conn ->
+      assert conn.method == "POST"
+      assert conn.request_path == "/2/oauth2/token"
+
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      assert URI.decode_query(body)["grant_type"] == "refresh_token"
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(%{"access_token" => "access-2"}))
+    end)
+
+    assert {:ok, %{"access_token" => "access-2"}} =
+             ExchangeToken.handler(
+               %{
+                 grant_type: "refresh_token",
+                 client_id: "client-1",
+                 refresh_token: "refresh-1",
+                 plug: {Req.Test, __MODULE__}
+               },
+               %{}
+             )
+  end
+
+  test "unfollow user prism calls the user-management endpoint" do
+    Req.Test.expect(__MODULE__, fn conn ->
+      assert conn.method == "DELETE"
+      assert conn.request_path == "/2/users/user-1/following/user-2"
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => %{"following" => false}}))
+    end)
+
+    assert {:ok, %{"data" => %{"following" => false}}} =
+             UnfollowUser.handler(
+               %{
+                 source_user_id: "user-1",
+                 target_user_id: "user-2",
+                 access_token: "access-1",
+                 plug: {Req.Test, __MODULE__}
+               },
+               %{}
+             )
   end
 end

--- a/lux/test/unit/lux/prisms/twitter/tweets_test.exs
+++ b/lux/test/unit/lux/prisms/twitter/tweets_test.exs
@@ -1,0 +1,55 @@
+defmodule Lux.Prisms.Twitter.TweetsTest do
+  use UnitAPICase, async: true
+
+  alias Lux.Prisms.Twitter.Tweets.CreateThread
+  alias Lux.Prisms.Twitter.Tweets.CreateTweet
+  alias Lux.Prisms.Twitter.Tweets.DeleteTweet
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  test "create tweet prism passes agent input to the Twitter client" do
+    Req.Test.expect(__MODULE__, fn conn ->
+      assert conn.method == "POST"
+      assert conn.request_path == "/2/tweets"
+
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      assert Jason.decode!(body) == %{"text" => "hello"}
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(201, Jason.encode!(%{"data" => %{"id" => "tweet-1"}}))
+    end)
+
+    assert {:ok, %{"data" => %{"id" => "tweet-1"}}} =
+             CreateTweet.handler(%{text: "hello", access_token: "access-1", plug: {Req.Test, __MODULE__}}, %{})
+  end
+
+  test "delete tweet prism validates required input" do
+    assert {:error, "Missing tweet_id"} = DeleteTweet.handler(%{}, %{})
+  end
+
+  test "thread prism creates replies in order" do
+    Req.Test.expect(__MODULE__, 2, fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      json = Jason.decode!(body)
+
+      id =
+        if json["text"] == "one" do
+          "tweet-1"
+        else
+          assert json["reply"]["in_reply_to_tweet_id"] == "tweet-1"
+          "tweet-2"
+        end
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(201, Jason.encode!(%{"data" => %{"id" => id}}))
+    end)
+
+    assert {:ok, [%{"data" => %{"id" => "tweet-1"}}, %{"data" => %{"id" => "tweet-2"}}]} =
+             CreateThread.handler(%{texts: ["one", "two"], access_token: "access-1", plug: {Req.Test, __MODULE__}}, %{})
+  end
+end

--- a/lux/test/unit/lux/prisms/twitter/tweets_test.exs
+++ b/lux/test/unit/lux/prisms/twitter/tweets_test.exs
@@ -103,6 +103,14 @@ defmodule Lux.Prisms.Twitter.TweetsTest do
              )
   end
 
+  test "token exchange prism rejects unsupported grant types without raising" do
+    assert {:error, {:unsupported_grant_type, "client_credentials"}} =
+             ExchangeToken.handler(
+               %{grant_type: "client_credentials", client_id: "client-1"},
+               %{}
+             )
+  end
+
   test "unfollow user prism calls the user-management endpoint" do
     Req.Test.expect(__MODULE__, fn conn ->
       assert conn.method == "DELETE"


### PR DESCRIPTION
## Summary

Implements the core X/Twitter API v2 integration requested in #58 with a narrow Lux-native package:

- OAuth 2.0 PKCE authorization URL and token/refresh helpers
- agent-facing OAuth prisms for authorization URL building and token exchange
- tweet create, delete, edit, quote, thread, lookup, and recent search helpers
- chunked media upload steps: INIT, APPEND, FINALIZE, STATUS
- user lookup, authenticated-profile lookup, followers/following reads, follow, and unfollow helpers
- structured rate-limit handling: parsed limit/reset/retry-after metadata plus explicit `{:rate_limited, details}` errors for 429 responses
- agent-facing Lux prisms for tweet/media/auth/user actions
- agent-facing Twitter lens modules for tweet/user/social-graph/search reads
- Livebook guide and a small benchmark entry
- mocked `Req.Test` unit coverage with no live Twitter credentials

## Latest hardening

Commit `05512aa` closes two acceptance-risk gaps I found after comparing the bounty criteria and competing PRs:

- upgrades rate limits from raw header exposure to parsed management metadata and structured 429 errors agents can reschedule from
- adds first-class followers/following social-graph reads through both the client and Lux lenses, with mocked tests and guide examples

## Verification

- `mix format --check-formatted`
- `git diff --check`
- `MIX_ENV=prod mix compile` passes locally under conda Elixir 1.19/OTP 29; remaining warnings are pre-existing project warnings outside the Twitter integration
- Targeted HTTP smoke checks against `Req.Test` passed before this hardening for tweet creation, thread chaining, search lens routing, OAuth URL/token exchange, authenticated-profile lookup, and unfollow routing
- Added mocked tests for structured rate-limit errors plus followers/following reads; local `MIX_ENV=test mix test ...` is still blocked before project tests execute by the existing Credo/Elixir mismatch described below

Full `mix test` could not be completed in this local environment because the available conda runtime is Elixir 1.19/OTP 29 while the repository pins Elixir 1.18/OTP 27; the test/dev dependency `credo` fails during dependency compilation before the new tests run. The implementation and tests are written to the repository's existing `UnitAPICase`/`Req.Test` style so CI on the pinned runtime should exercise them normally.

Refs #58
