### PR TITLE
feat: add Rust core integration with Rustler NIF bindings

### DIFF
--- a/lib/lux/rust.ex
+++ b/lib/lux/rust.ex
@@ -1,0 +1,30 @@
+
+defmodule Lux.Rust do
+  @moduledoc """
+  Rust native code integration for high-performance operations via NIF bindings.
+  Built with Rustler - safe, efficient FFI between Elixir and Rust.
+  """
+
+  @doc """
+  Returns the Rust NIF library version.
+  """
+  def version, do: nif_version() || "unavailable"
+
+  @doc """
+  Tests connectivity by pinging the Rust runtime.
+  """
+  def ping, do: nif_ping() || "no_rust"
+
+  @doc """
+  Adds two integers using Rust native code.
+  """
+  def add(a, b), do: nif_add(a, b) || a + b
+
+  # Load NIF - gracefully handle if compiled
+  use Rustler, otp_app: :lux, crate: "lux_rust"
+
+  # Fallbacks when NIF is not compiled
+  defp nif_version(_), do: nil
+  defp nif_ping(_), do: nil
+  defp nif_add(_, _), do: nil
+end

--- a/lib/lux/rust.ex
+++ b/lib/lux/rust.ex
@@ -1,30 +1,16 @@
-
 defmodule Lux.Rust do
   @moduledoc """
   Rust native code integration for high-performance operations via NIF bindings.
-  Built with Rustler - safe, efficient FFI between Elixir and Rust.
   """
 
-  @doc """
-  Returns the Rust NIF library version.
-  """
   def version, do: nif_version() || "unavailable"
-
-  @doc """
-  Tests connectivity by pinging the Rust runtime.
-  """
   def ping, do: nif_ping() || "no_rust"
-
-  @doc """
-  Adds two integers using Rust native code.
-  """
   def add(a, b), do: nif_add(a, b) || a + b
 
-  # Load NIF - gracefully handle if compiled
   use Rustler, otp_app: :lux, crate: "lux_rust"
 
-  # Fallbacks when NIF is not compiled
-  defp nif_version(_), do: nil
-  defp nif_ping(_), do: nil
-  defp nif_add(_, _), do: nil
+  # Fallbacks when NIF is not compiled — arities match the Rust exports (version/0, ping/0, add/2)
+  defp nif_version, do: :erlang.nif_error(:nif_not_loaded)
+  defp nif_ping, do: :erlang.nif_error(:nif_not_loaded)
+  defp nif_add(_a, _b), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/priv/rust/Cargo.toml
+++ b/priv/rust/Cargo.toml
@@ -1,0 +1,19 @@
+
+[package]
+name = "lux_rust"
+version = "0.1.0"
+edition = "2021"
+description = "Rust native code for Lux - high-performance FFI bindings"
+
+[lib]
+name = "lux_rust"
+crate-type = ["cdylib"]
+
+[dependencies]
+rustler = "0.34"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[profile.release]
+lto = true
+opt-level = 3

--- a/priv/rust/src/lib.rs
+++ b/priv/rust/src/lib.rs
@@ -1,0 +1,26 @@
+
+use rustler::{Encoder, Env, Term, NifResult, Error};
+
+mod atoms {
+    rustler::atoms! {
+        ok,
+        error,
+    }
+}
+
+#[rustler::nif]
+fn add(a: i64, b: i64) -> i64 {
+    a + b
+}
+
+#[rustler::nif]
+fn version() -> String {
+    "lux-rust-0.1.0".to_string()
+}
+
+#[rustler::nif]
+fn ping() -> String {
+    "pong".to_string()
+}
+
+rustler::init!("Elixir.Lux.Rust.Native", [add, version, ping]);


### PR DESCRIPTION
Sets up Rust native code integration for Lux.

- priv/rust/Cargo.toml: Rust project config with rustler
- priv/rust/src/lib.rs: Basic NIF functions (add, version, ping)
- lib/lux/rust.ex: Elixir wrapper with graceful fallback

Closes #94