### PR TITLE
Add YouTube core live workflow planner

### DIFF
--- a/lux/guides/youtube_core_live_streaming.md
+++ b/lux/guides/youtube_core_live_streaming.md
@@ -1,0 +1,32 @@
+# YouTube Core Integration and Live Streaming
+
+This guide shows the credential boundary for planning YouTube Data API v3 and live-streaming operations in Lux.
+
+The YouTube live workflow is intentionally dry-run first. Agents can build an auditable plan for OAuth, upload, live broadcast setup, stream binding, live chat monitoring, health checks, and broadcast transitions without requiring real channel credentials in tests.
+
+```elixir
+alias Lux.Integrations.YouTube.LiveStreaming
+
+{:ok, workflow} =
+  LiveStreaming.plan_broadcast_workflow(%{
+    title: "Lux market briefing",
+    scheduled_start_time: "2026-06-06T12:00:00Z",
+    privacy_status: "unlisted",
+    broadcast_id: "broadcast-1",
+    stream_id: "stream-1",
+    live_chat_id: "chat-1",
+    target_life_cycle_status: "testing"
+  })
+```
+
+The returned workflow includes request envelopes for:
+
+- OAuth authorization, token exchange, and refresh.
+- `channels.list` for channel validation.
+- `videos.insert` resumable upload startup.
+- `liveBroadcasts.insert`, `liveStreams.insert`, and `liveBroadcasts.bind`.
+- `liveChat/messages` polling and safe chat message drafting.
+- `liveStreams.list` health polling.
+- `liveBroadcasts.transition` with lifecycle guardrails.
+
+Live side effects are not executed by the planner. A credentialed adapter must supply OAuth tokens, review moderation and transition guardrails, then explicitly execute the selected request envelopes.

--- a/lux/lib/lux/integrations/youtube.ex
+++ b/lux/lib/lux/integrations/youtube.ex
@@ -1,0 +1,17 @@
+defmodule Lux.Integrations.YouTube do
+  @moduledoc """
+  Common settings for YouTube Data API v3 integrations.
+  """
+
+  alias Lux.Integrations.YouTube.Client
+
+  @doc """
+  Common JSON headers for YouTube Data API calls.
+  """
+  def headers, do: [{"Content-Type", "application/json"}]
+
+  @doc """
+  Default OAuth scopes for channel, upload, live-streaming, and chat workflows.
+  """
+  def scopes, do: Client.default_scopes()
+end

--- a/lux/lib/lux/integrations/youtube/client.ex
+++ b/lux/lib/lux/integrations/youtube/client.ex
@@ -146,6 +146,55 @@ defmodule Lux.Integrations.YouTube.Client do
   end
 
   @doc """
+  Builds a chunk upload request for an established resumable upload session.
+
+  The upload URL must be the `Location` response header returned by the initial
+  resumable videos.insert request.
+  """
+  @spec resumable_chunk_request(map()) :: map()
+  def resumable_chunk_request(opts) do
+    upload_url = fetch!(opts, :upload_url)
+    content_length = fetch_integer!(opts, :content_length)
+    range_start = get_integer(opts, :range_start, 0)
+    range_end = get_integer(opts, :range_end, range_start + content_length - 1)
+    total_length = get_integer(opts, :total_length, content_length)
+
+    %{
+      method: :put,
+      url: upload_url,
+      query: %{},
+      headers:
+        upload_session_headers(get(opts, :access_token, nil), [
+          {"Content-Type", get(opts, :content_type, "video/mp4")},
+          {"Content-Length", to_string(content_length)},
+          {"Content-Range", "bytes #{range_start}-#{range_end}/#{total_length}"}
+        ]),
+      body: get(opts, :body, :video_binary)
+    }
+  end
+
+  @doc """
+  Builds a status probe request for resuming an interrupted upload session.
+  """
+  @spec resumable_resume_request(map()) :: map()
+  def resumable_resume_request(opts) do
+    upload_url = fetch!(opts, :upload_url)
+    total_length = fetch_integer!(opts, :total_length)
+
+    %{
+      method: :put,
+      url: upload_url,
+      query: %{},
+      headers:
+        upload_session_headers(get(opts, :access_token, nil), [
+          {"Content-Length", "0"},
+          {"Content-Range", "bytes */#{total_length}"}
+        ]),
+      body: ""
+    }
+  end
+
+  @doc """
   Returns the default OAuth scopes needed for channel, upload, live, and chat APIs.
   """
   @spec default_scopes() :: [String.t()]
@@ -184,6 +233,12 @@ defmodule Lux.Integrations.YouTube.Client do
     ]
   end
 
+  defp upload_session_headers(nil, headers), do: headers
+
+  defp upload_session_headers(access_token, headers) do
+    [{"Authorization", "Bearer #{access_token}"} | headers]
+  end
+
   defp normalize_query(query) do
     query
     |> Enum.reject(fn {_key, value} -> is_nil(value) or value == "" end)
@@ -216,6 +271,33 @@ defmodule Lux.Integrations.YouTube.Client do
       value -> value
     end
   end
+
+  defp fetch_integer!(map, key) do
+    case integer(fetch!(map, key)) do
+      nil -> raise ArgumentError, "invalid YouTube option #{key}"
+      value -> value
+    end
+  end
+
+  defp get_integer(map, key, default) do
+    case integer(get(map, key, default)) do
+      nil -> default
+      value -> value
+    end
+  end
+
+  defp integer(value) when is_integer(value), do: value
+  defp integer(value) when is_float(value), do: trunc(value)
+
+  defp integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {number, ""} -> number
+      {number, rest} -> if String.trim(rest) == "", do: number, else: nil
+      _ -> nil
+    end
+  end
+
+  defp integer(_value), do: nil
 
   defp maybe_add_plug(options, nil), do: options
   defp maybe_add_plug(options, plug), do: Keyword.put(options, :plug, plug)

--- a/lux/lib/lux/integrations/youtube/client.ex
+++ b/lux/lib/lux/integrations/youtube/client.ex
@@ -1,0 +1,222 @@
+defmodule Lux.Integrations.YouTube.Client do
+  @moduledoc """
+  Request helpers for YouTube Data API v3 and OAuth token flows.
+
+  The module keeps request construction explicit so tests and agents can validate
+  Data API calls without requiring live YouTube credentials.
+  """
+
+  @api_endpoint "https://www.googleapis.com/youtube/v3"
+  @upload_endpoint "https://www.googleapis.com/upload/youtube/v3"
+  @oauth_authorize_endpoint "https://accounts.google.com/o/oauth2/v2/auth"
+  @oauth_token_endpoint "https://oauth2.googleapis.com/token"
+
+  @default_scopes [
+    "https://www.googleapis.com/auth/youtube",
+    "https://www.googleapis.com/auth/youtube.upload",
+    "https://www.googleapis.com/auth/youtube.force-ssl"
+  ]
+
+  @type request_opts :: %{
+          optional(:access_token) => String.t(),
+          optional(:query) => map(),
+          optional(:json) => map(),
+          optional(:headers) => [{String.t(), String.t()}],
+          optional(:plug) => {module(), term()},
+          optional(:base_url) => String.t()
+        }
+
+  @doc """
+  Builds the OAuth 2.0 authorization URL for YouTube channel access.
+  """
+  @spec authorization_url(map()) :: String.t()
+  def authorization_url(opts) do
+    query =
+      %{
+        client_id: fetch!(opts, :client_id),
+        redirect_uri: fetch!(opts, :redirect_uri),
+        response_type: "code",
+        access_type: get(opts, :access_type, "offline"),
+        prompt: get(opts, :prompt, "consent"),
+        scope: get(opts, :scopes, @default_scopes) |> Enum.join(" "),
+        state: get(opts, :state, nil)
+      }
+      |> Enum.reject(fn {_key, value} -> is_nil(value) or value == "" end)
+      |> URI.encode_query()
+
+    @oauth_authorize_endpoint <> "?" <> query
+  end
+
+  @doc """
+  Builds an OAuth token request for authorization-code or refresh-token exchange.
+  """
+  @spec token_request(:authorization_code | :refresh_token, map()) :: map()
+  def token_request(:authorization_code, opts) do
+    %{
+      method: :post,
+      url: @oauth_token_endpoint,
+      headers: [{"Content-Type", "application/x-www-form-urlencoded"}],
+      form: %{
+        client_id: fetch!(opts, :client_id),
+        client_secret: fetch!(opts, :client_secret),
+        code: fetch!(opts, :code),
+        grant_type: "authorization_code",
+        redirect_uri: fetch!(opts, :redirect_uri)
+      }
+    }
+  end
+
+  def token_request(:refresh_token, opts) do
+    %{
+      method: :post,
+      url: @oauth_token_endpoint,
+      headers: [{"Content-Type", "application/x-www-form-urlencoded"}],
+      form: %{
+        client_id: fetch!(opts, :client_id),
+        client_secret: fetch!(opts, :client_secret),
+        grant_type: "refresh_token",
+        refresh_token: fetch!(opts, :refresh_token)
+      }
+    }
+  end
+
+  @doc """
+  Builds a YouTube Data API request map without executing it.
+  """
+  @spec build_request(atom(), String.t(), request_opts()) :: map()
+  def build_request(method, path, opts \\ %{}) do
+    access_token = get(opts, :access_token, nil)
+    base_url = get(opts, :base_url, @api_endpoint)
+    query = get(opts, :query, %{}) |> normalize_query()
+    json = get(opts, :json, nil)
+
+    %{
+      method: method,
+      url: base_url <> path,
+      query: query,
+      headers: build_headers(access_token, get(opts, :headers, [])),
+      json: json
+    }
+  end
+
+  @doc """
+  Executes a YouTube Data API request.
+  """
+  @spec request(atom(), String.t(), request_opts()) :: {:ok, map()} | {:error, term()}
+  def request(method, path, opts \\ %{}) do
+    method
+    |> build_request(path, opts)
+    |> Map.to_list()
+    |> Keyword.merge(Application.get_env(:lux, __MODULE__, []))
+    |> maybe_add_plug(get(opts, :plug, nil))
+    |> Req.new()
+    |> Req.request()
+    |> normalize_response()
+  end
+
+  @doc """
+  Builds the initial resumable upload request for videos.insert.
+  """
+  @spec resumable_upload_request(map()) :: map()
+  def resumable_upload_request(opts) do
+    metadata =
+      %{
+        snippet: %{
+          title: fetch!(opts, :title),
+          description: get(opts, :description, ""),
+          tags: get(opts, :tags, []),
+          categoryId: get(opts, :category_id, "22")
+        },
+        status: %{
+          privacyStatus: get(opts, :privacy_status, "private"),
+          selfDeclaredMadeForKids: get(opts, :made_for_kids, false)
+        }
+      }
+
+    build_request(:post, "/videos", %{
+      access_token: get(opts, :access_token, nil),
+      base_url: @upload_endpoint,
+      query: %{uploadType: "resumable", part: "snippet,status"},
+      headers: [
+        {"X-Upload-Content-Type", get(opts, :content_type, "video/mp4")},
+        {"X-Upload-Content-Length", to_string(get(opts, :content_length, 0))}
+      ],
+      json: metadata
+    })
+  end
+
+  @doc """
+  Returns the default OAuth scopes needed for channel, upload, live, and chat APIs.
+  """
+  @spec default_scopes() :: [String.t()]
+  def default_scopes, do: @default_scopes
+
+  defp normalize_response({:ok, %{status: status} = response}) when status in 200..299 do
+    {:ok, response.body || %{}}
+  end
+
+  defp normalize_response({:ok, %{status: 401}}), do: {:error, :invalid_token}
+
+  defp normalize_response({:ok, %{status: 403, body: %{"error" => error}}}) do
+    {:error, {:forbidden, extract_error_message(error)}}
+  end
+
+  defp normalize_response({:ok, %{status: 429, body: body}}), do: {:error, {:rate_limited, body}}
+
+  defp normalize_response({:ok, %{status: status, body: %{"error" => error}}}) do
+    {:error, {status, extract_error_message(error)}}
+  end
+
+  defp normalize_response({:ok, %{status: status, body: body}}), do: {:error, {status, body}}
+  defp normalize_response({:error, error}), do: {:error, error}
+
+  defp extract_error_message(%{"message" => message}), do: message
+  defp extract_error_message(%{message: message}), do: message
+  defp extract_error_message(error), do: error
+
+  defp build_headers(nil, headers), do: [{"Content-Type", "application/json"} | headers]
+
+  defp build_headers(access_token, headers) do
+    [
+      {"Authorization", "Bearer #{access_token}"},
+      {"Content-Type", "application/json"}
+      | headers
+    ]
+  end
+
+  defp normalize_query(query) do
+    query
+    |> Enum.reject(fn {_key, value} -> is_nil(value) or value == "" end)
+    |> Map.new(fn {key, value} -> {camelize_key(key), normalize_query_value(value)} end)
+  end
+
+  defp normalize_query_value(value) when is_list(value), do: Enum.join(value, ",")
+  defp normalize_query_value(value), do: value
+
+  defp camelize_key(key) when is_atom(key) do
+    key
+    |> Atom.to_string()
+    |> camelize_key()
+  end
+
+  defp camelize_key(key) when is_binary(key) do
+    [first | rest] = String.split(key, "_")
+
+    Enum.join([first | Enum.map(rest, &String.capitalize/1)], "")
+  end
+
+  defp get(map, key, default) when is_map(map) do
+    Map.get(map, key, Map.get(map, Atom.to_string(key), default))
+  end
+
+  defp fetch!(map, key) do
+    case get(map, key, nil) do
+      nil -> raise ArgumentError, "missing required YouTube option #{key}"
+      "" -> raise ArgumentError, "missing required YouTube option #{key}"
+      value -> value
+    end
+  end
+
+  defp maybe_add_plug(options, nil), do: options
+  defp maybe_add_plug(options, plug), do: Keyword.put(options, :plug, plug)
+end

--- a/lux/lib/lux/integrations/youtube/live_streaming.ex
+++ b/lux/lib/lux/integrations/youtube/live_streaming.ex
@@ -1,0 +1,391 @@
+defmodule Lux.Integrations.YouTube.LiveStreaming do
+  @moduledoc """
+  Deterministic YouTube live-streaming workflow planning.
+
+  This module builds auditable YouTube Data API v3 request plans for OAuth,
+  uploads, live broadcasts, live streams, live chat, health monitoring, and
+  broadcast transitions. The returned plans are safe to test without credentials
+  and can be executed by a credentialed adapter later.
+  """
+
+  alias Lux.Integrations.YouTube.Client
+
+  @allowed_transitions %{
+    "created" => ["testing", "live"],
+    "ready" => ["testing", "live"],
+    "testing" => ["live", "complete"],
+    "live" => ["complete"]
+  }
+
+  @doc """
+  Builds a complete dry-run workflow for YouTube core integration and live setup.
+  """
+  @spec plan_broadcast_workflow(map()) :: {:ok, map()} | {:error, String.t()}
+  def plan_broadcast_workflow(params) when is_map(params) do
+    with {:ok, title} <- required(params, :title),
+         {:ok, scheduled_start_time} <- required(params, :scheduled_start_time) do
+      workflow = %{
+        mode: :dry_run,
+        oauth: oauth_plan(params),
+        channel: channel_request(params),
+        upload: upload_plan(params),
+        broadcast: broadcast_plan(params, title, scheduled_start_time),
+        stream: stream_plan(params),
+        bind: bind_plan(params),
+        live_chat: live_chat_plan(params),
+        health_monitor: health_monitor_plan(params),
+        transition: transition_plan(params),
+        quality_controls: quality_controls(params),
+        execution_boundary: %{
+          live_side_effects: false,
+          note:
+            "Plans are deterministic request envelopes. A caller must supply OAuth credentials and explicitly execute requests."
+        }
+      }
+
+      {:ok, workflow}
+    end
+  end
+
+  @doc """
+  Normalizes YouTube live chat messages and classifies moderation work.
+  """
+  @spec analyze_chat_messages([map()], map()) :: map()
+  def analyze_chat_messages(messages, opts \\ %{}) do
+    blocked_terms = params_list(opts, :blocked_terms)
+    highlight_terms = params_list(opts, :highlight_terms)
+
+    normalized =
+      Enum.map(messages, fn message ->
+        text = get(message, :text, get(message, :display_message, ""))
+        lower = String.downcase(to_string(text))
+
+        flags =
+          []
+          |> maybe_flag(:blocked_term, contains_any?(lower, blocked_terms))
+          |> maybe_flag(:highlight, contains_any?(lower, highlight_terms))
+          |> maybe_flag(:link, String.contains?(lower, "http://") or String.contains?(lower, "https://"))
+          |> maybe_flag(:empty, String.trim(to_string(text)) == "")
+
+        %{
+          id: get(message, :id, nil),
+          author: get(message, :author, "unknown"),
+          text: text,
+          flags: flags,
+          action: moderation_action(flags)
+        }
+      end)
+
+    %{
+      messages: normalized,
+      action_counts: Enum.frequencies_by(normalized, & &1.action),
+      requires_review: Enum.any?(normalized, &(&1.action in [:hold, :remove, :highlight]))
+    }
+  end
+
+  @doc """
+  Classifies stream health from YouTube health status and local metric samples.
+  """
+  @spec health_snapshot(map()) :: map()
+  def health_snapshot(params) do
+    status = get(params, :status, "unknown")
+    bitrate = numeric(get(params, :bitrate_kbps, 0))
+    dropped_frames = numeric(get(params, :dropped_frames, 0))
+    latency_ms = numeric(get(params, :latency_ms, 0))
+
+    issues =
+      []
+      |> maybe_issue("youtube_status_#{status}", status in ["bad", "noData", "error"])
+      |> maybe_issue("low_bitrate", bitrate > 0 and bitrate < numeric(get(params, :min_bitrate_kbps, 2_500)))
+      |> maybe_issue("dropped_frames", dropped_frames > numeric(get(params, :max_dropped_frames, 30)))
+      |> maybe_issue("high_latency", latency_ms > numeric(get(params, :max_latency_ms, 10_000)))
+
+    %{
+      status: if(issues == [], do: :healthy, else: :attention_required),
+      youtube_status: status,
+      metrics: %{
+        bitrate_kbps: bitrate,
+        dropped_frames: dropped_frames,
+        latency_ms: latency_ms
+      },
+      issues: issues,
+      poll_interval_seconds: numeric(get(params, :poll_interval_seconds, 30))
+    }
+  end
+
+  @doc """
+  Builds a safe transition plan for YouTube live broadcast lifecycle changes.
+  """
+  @spec transition_plan(map()) :: map()
+  def transition_plan(params) do
+    broadcast_id = get(params, :broadcast_id, nil)
+    current = get(params, :current_life_cycle_status, "ready")
+    target = get(params, :target_life_cycle_status, "testing")
+    allowed = Map.get(@allowed_transitions, current, [])
+
+    %{
+      allowed: target in allowed,
+      current_life_cycle_status: current,
+      target_life_cycle_status: target,
+      request:
+        Client.build_request(:post, "/liveBroadcasts/transition", %{
+          access_token: get(params, :access_token, nil),
+          query: %{broadcast_status: target, id: broadcast_id, part: "status"}
+        }),
+      guardrails: transition_guardrails(current, target, allowed)
+    }
+  end
+
+  defp oauth_plan(params) do
+    %{
+      scopes: Client.default_scopes(),
+      authorization_url:
+        maybe_authorization_url(params, [:client_id, :redirect_uri]),
+      token_exchange:
+        maybe_token_request(:authorization_code, params, [:client_id, :client_secret, :code, :redirect_uri]),
+      refresh:
+        maybe_token_request(:refresh_token, params, [:client_id, :client_secret, :refresh_token])
+    }
+  end
+
+  defp channel_request(params) do
+    Client.build_request(:get, "/channels", %{
+      access_token: get(params, :access_token, nil),
+      query: %{part: "snippet,contentDetails,statistics", mine: true}
+    })
+  end
+
+  defp upload_plan(params) do
+    %{
+      resumable_start:
+        Client.resumable_upload_request(%{
+          access_token: get(params, :access_token, nil),
+          title: get(params, :video_title, get(params, :title, "Untitled live archive")),
+          description: get(params, :video_description, ""),
+          tags: params_list(params, :tags),
+          privacy_status: get(params, :privacy_status, "private"),
+          category_id: get(params, :category_id, "22"),
+          content_type: get(params, :content_type, "video/mp4"),
+          content_length: get(params, :content_length, 0)
+        }),
+      status_request:
+        Client.build_request(:get, "/videos", %{
+          access_token: get(params, :access_token, nil),
+          query: %{part: "snippet,status,liveStreamingDetails", id: get(params, :video_id, nil)}
+        })
+    }
+  end
+
+  defp broadcast_plan(params, title, scheduled_start_time) do
+    body = %{
+      snippet: %{
+        title: title,
+        description: get(params, :description, ""),
+        scheduledStartTime: scheduled_start_time,
+        scheduledEndTime: get(params, :scheduled_end_time, nil)
+      },
+      status: %{
+        privacyStatus: get(params, :privacy_status, "private"),
+        selfDeclaredMadeForKids: get(params, :made_for_kids, false)
+      },
+      contentDetails: %{
+        enableAutoStart: get(params, :enable_auto_start, false),
+        enableAutoStop: get(params, :enable_auto_stop, true),
+        enableDvr: get(params, :enable_dvr, true),
+        recordFromStart: get(params, :record_from_start, true)
+      }
+    }
+
+    %{
+      insert:
+        Client.build_request(:post, "/liveBroadcasts", %{
+          access_token: get(params, :access_token, nil),
+          query: %{part: "snippet,status,contentDetails"},
+          json: body
+        }),
+      list:
+        Client.build_request(:get, "/liveBroadcasts", %{
+          access_token: get(params, :access_token, nil),
+          query: %{part: "snippet,status,contentDetails", broadcast_status: "all", mine: true}
+        })
+    }
+  end
+
+  defp stream_plan(params) do
+    body = %{
+      snippet: %{title: get(params, :stream_title, get(params, :title, "Lux live stream"))},
+      cdn: %{
+        frameRate: get(params, :frame_rate, "variable"),
+        ingestionType: get(params, :ingestion_type, "rtmp"),
+        resolution: get(params, :resolution, "variable")
+      }
+    }
+
+    %{
+      insert:
+        Client.build_request(:post, "/liveStreams", %{
+          access_token: get(params, :access_token, nil),
+          query: %{part: "snippet,cdn,status"},
+          json: body
+        }),
+      status:
+        Client.build_request(:get, "/liveStreams", %{
+          access_token: get(params, :access_token, nil),
+          query: %{part: "snippet,cdn,status", id: get(params, :stream_id, nil)}
+        })
+    }
+  end
+
+  defp bind_plan(params) do
+    Client.build_request(:post, "/liveBroadcasts/bind", %{
+      access_token: get(params, :access_token, nil),
+      query: %{
+        id: get(params, :broadcast_id, nil),
+        stream_id: get(params, :stream_id, nil),
+        part: "id,contentDetails"
+      }
+    })
+  end
+
+  defp live_chat_plan(params) do
+    chat_id = get(params, :live_chat_id, nil)
+
+    %{
+      list:
+        Client.build_request(:get, "/liveChat/messages", %{
+          access_token: get(params, :access_token, nil),
+          query: %{live_chat_id: chat_id, part: "snippet,authorDetails", max_results: 200}
+        }),
+      send:
+        Client.build_request(:post, "/liveChat/messages", %{
+          access_token: get(params, :access_token, nil),
+          query: %{part: "snippet"},
+          json: %{
+            snippet: %{
+              liveChatId: chat_id,
+              type: "textMessageEvent",
+              textMessageDetails: %{messageText: get(params, :chat_message, "")}
+            }
+          }
+        }),
+      moderation: analyze_chat_messages(get(params, :chat_messages, []), params)
+    }
+  end
+
+  defp health_monitor_plan(params) do
+    %{
+      request:
+        Client.build_request(:get, "/liveStreams", %{
+          access_token: get(params, :access_token, nil),
+          query: %{part: "status", id: get(params, :stream_id, nil)}
+        }),
+      snapshot: health_snapshot(get(params, :health, %{}))
+    }
+  end
+
+  defp quality_controls(params) do
+    %{
+      primary_stream: %{
+        stream_id: get(params, :stream_id, nil),
+        resolution: get(params, :resolution, "variable"),
+        frame_rate: get(params, :frame_rate, "variable")
+      },
+      backup_streams:
+        get(params, :backup_streams, [])
+        |> Enum.map(fn stream ->
+          %{
+            stream_id: get(stream, :stream_id, nil),
+            resolution: get(stream, :resolution, "variable"),
+            frame_rate: get(stream, :frame_rate, "variable"),
+            ready: get(stream, :ready, false)
+          }
+        end),
+      failover_ready: Enum.any?(get(params, :backup_streams, []), &get(&1, :ready, false)),
+      checks: [
+        "confirm OAuth token scope before executing mutating calls",
+        "poll stream health before transition to live",
+        "review live chat moderation actions before sending or removing messages",
+        "keep backup stream ready before public broadcasts"
+      ]
+    }
+  end
+
+  defp maybe_authorization_url(params, keys) do
+    if all_present?(params, keys), do: Client.authorization_url(params), else: nil
+  end
+
+  defp maybe_token_request(type, params, keys) do
+    if all_present?(params, keys), do: Client.token_request(type, params), else: nil
+  end
+
+  defp all_present?(params, keys) do
+    Enum.all?(keys, fn key ->
+      value = get(params, key, nil)
+      not is_nil(value) and value != ""
+    end)
+  end
+
+  defp transition_guardrails(current, target, allowed) do
+    cond do
+      target in allowed ->
+        ["poll liveStreams.status before transition", "confirm broadcast contentDetails are bound to a stream"]
+
+      current == "complete" ->
+        ["completed broadcasts cannot be transitioned again"]
+
+      true ->
+        ["invalid transition #{current} -> #{target}; allowed targets are #{Enum.join(allowed, ", ")}"]
+    end
+  end
+
+  defp required(params, key) do
+    case get(params, key, nil) do
+      nil -> {:error, "Missing required YouTube live parameter #{key}"}
+      "" -> {:error, "Missing required YouTube live parameter #{key}"}
+      value -> {:ok, value}
+    end
+  end
+
+  defp params_list(params, key) do
+    case get(params, key, []) do
+      value when is_list(value) -> value
+      value when is_binary(value) -> [value]
+      _ -> []
+    end
+  end
+
+  defp contains_any?(_text, []), do: false
+  defp contains_any?(text, terms), do: Enum.any?(terms, &String.contains?(text, String.downcase(to_string(&1))))
+
+  defp maybe_flag(flags, flag, true), do: [flag | flags]
+  defp maybe_flag(flags, _flag, false), do: flags
+
+  defp moderation_action(flags) do
+    cond do
+      :empty in flags -> :hold
+      :blocked_term in flags -> :remove
+      :link in flags -> :hold
+      :highlight in flags -> :highlight
+      true -> :allow
+    end
+  end
+
+  defp maybe_issue(issues, issue, true), do: [issue | issues]
+  defp maybe_issue(issues, _issue, false), do: issues
+
+  defp numeric(value) when is_integer(value), do: value
+  defp numeric(value) when is_float(value), do: value
+
+  defp numeric(value) when is_binary(value) do
+    case Float.parse(value) do
+      {number, _rest} -> number
+      :error -> 0
+    end
+  end
+
+  defp numeric(_value), do: 0
+
+  defp get(map, key, default) when is_map(map) do
+    Map.get(map, key, Map.get(map, Atom.to_string(key), default))
+  end
+end

--- a/lux/lib/lux/integrations/youtube/live_streaming.ex
+++ b/lux/lib/lux/integrations/youtube/live_streaming.ex
@@ -118,22 +118,33 @@ defmodule Lux.Integrations.YouTube.LiveStreaming do
   """
   @spec transition_plan(map()) :: map()
   def transition_plan(params) do
-    broadcast_id = get(params, :broadcast_id, nil)
     current = get(params, :current_life_cycle_status, "ready")
     target = get(params, :target_life_cycle_status, "testing")
     allowed = Map.get(@allowed_transitions, current, [])
 
-    %{
-      allowed: target in allowed,
-      current_life_cycle_status: current,
-      target_life_cycle_status: target,
-      request:
-        Client.build_request(:post, "/liveBroadcasts/transition", %{
-          access_token: get(params, :access_token, nil),
-          query: %{broadcast_status: target, id: broadcast_id, part: "status"}
-        }),
-      guardrails: transition_guardrails(current, target, allowed)
-    }
+    case required_values(params, [:broadcast_id]) do
+      {:ok, %{broadcast_id: broadcast_id}} ->
+        %{
+          allowed: target in allowed,
+          current_life_cycle_status: current,
+          target_life_cycle_status: target,
+          request:
+            Client.build_request(:post, "/liveBroadcasts/transition", %{
+              access_token: get(params, :access_token, nil),
+              query: %{broadcast_status: target, id: broadcast_id, part: "status"}
+            }),
+          guardrails: transition_guardrails(current, target, allowed)
+        }
+
+      {:error, error, missing} ->
+        %{
+          allowed: false,
+          current_life_cycle_status: current,
+          target_life_cycle_status: target,
+          request: guarded_request(:transition_broadcast, error, missing),
+          guardrails: [error | transition_guardrails(current, target, allowed)]
+        }
+    end
   end
 
   defp oauth_plan(params) do
@@ -168,11 +179,20 @@ defmodule Lux.Integrations.YouTube.LiveStreaming do
           content_type: get(params, :content_type, "video/mp4"),
           content_length: get(params, :content_length, 0)
         }),
+      upload_session: %{
+        source: "Location response header from resumable_start",
+        required_parameter: :upload_url,
+        note: "Use the returned upload session URL for all chunk and resume requests."
+      },
+      chunk_upload: chunk_upload_plan(params),
+      resume_probe: resume_probe_plan(params),
       status_request:
-        Client.build_request(:get, "/videos", %{
-          access_token: get(params, :access_token, nil),
-          query: %{part: "snippet,status,liveStreamingDetails", id: get(params, :video_id, nil)}
-        })
+        guarded_request(params, [:video_id], :video_status, fn %{video_id: video_id} ->
+          Client.build_request(:get, "/videos", %{
+            access_token: get(params, :access_token, nil),
+            query: %{part: "snippet,status,liveStreamingDetails", id: video_id}
+          })
+        end)
     }
   end
 
@@ -195,6 +215,8 @@ defmodule Lux.Integrations.YouTube.LiveStreaming do
         recordFromStart: get(params, :record_from_start, true)
       }
     }
+
+    body = prune_empty_values(body)
 
     %{
       insert:
@@ -229,45 +251,72 @@ defmodule Lux.Integrations.YouTube.LiveStreaming do
           json: body
         }),
       status:
-        Client.build_request(:get, "/liveStreams", %{
-          access_token: get(params, :access_token, nil),
-          query: %{part: "snippet,cdn,status", id: get(params, :stream_id, nil)}
-        })
+        guarded_request(params, [:stream_id], :stream_status, fn %{stream_id: stream_id} ->
+          Client.build_request(:get, "/liveStreams", %{
+            access_token: get(params, :access_token, nil),
+            query: %{part: "snippet,cdn,status", id: stream_id}
+          })
+        end)
     }
   end
 
   defp bind_plan(params) do
-    Client.build_request(:post, "/liveBroadcasts/bind", %{
-      access_token: get(params, :access_token, nil),
-      query: %{
-        id: get(params, :broadcast_id, nil),
-        stream_id: get(params, :stream_id, nil),
-        part: "id,contentDetails"
-      }
-    })
+    guarded_request(params, [:broadcast_id, :stream_id], :bind_broadcast, fn values ->
+      %{broadcast_id: broadcast_id, stream_id: stream_id} = values
+
+      Client.build_request(:post, "/liveBroadcasts/bind", %{
+        access_token: get(params, :access_token, nil),
+        query: %{
+          id: broadcast_id,
+          stream_id: stream_id,
+          part: "id,contentDetails"
+        }
+      })
+    end)
   end
 
   defp live_chat_plan(params) do
-    chat_id = get(params, :live_chat_id, nil)
-
     %{
       list:
-        Client.build_request(:get, "/liveChat/messages", %{
-          access_token: get(params, :access_token, nil),
-          query: %{live_chat_id: chat_id, part: "snippet,authorDetails", max_results: 200}
-        }),
+        guarded_request(
+          params,
+          [:live_chat_id],
+          :list_live_chat_messages,
+          fn %{live_chat_id: chat_id} ->
+            Client.build_request(:get, "/liveChat/messages", %{
+              access_token: get(params, :access_token, nil),
+              query: %{
+                live_chat_id: chat_id,
+                part: "snippet,authorDetails",
+                max_results: get(params, :live_chat_max_results, 200),
+                page_token: get(params, :live_chat_page_token, nil)
+              }
+            })
+          end
+        ),
       send:
-        Client.build_request(:post, "/liveChat/messages", %{
-          access_token: get(params, :access_token, nil),
-          query: %{part: "snippet"},
-          json: %{
-            snippet: %{
-              liveChatId: chat_id,
-              type: "textMessageEvent",
-              textMessageDetails: %{messageText: get(params, :chat_message, "")}
-            }
-          }
-        }),
+        guarded_request(
+          params,
+          [:live_chat_id],
+          :send_live_chat_message,
+          fn %{live_chat_id: chat_id} ->
+            Client.build_request(:post, "/liveChat/messages", %{
+              access_token: get(params, :access_token, nil),
+              query: %{part: "snippet"},
+              json: %{
+                snippet: %{
+                  liveChatId: chat_id,
+                  type: "textMessageEvent",
+                  textMessageDetails: %{messageText: get(params, :chat_message, "")}
+                }
+              }
+            })
+          end
+        ),
+      pagination: %{
+        next_page_token: :from_youtube_response,
+        polling_interval_millis: :from_youtube_response
+      },
       moderation: analyze_chat_messages(get(params, :chat_messages, []), params)
     }
   end
@@ -275,10 +324,12 @@ defmodule Lux.Integrations.YouTube.LiveStreaming do
   defp health_monitor_plan(params) do
     %{
       request:
-        Client.build_request(:get, "/liveStreams", %{
-          access_token: get(params, :access_token, nil),
-          query: %{part: "status", id: get(params, :stream_id, nil)}
-        }),
+        guarded_request(params, [:stream_id], :stream_health, fn %{stream_id: stream_id} ->
+          Client.build_request(:get, "/liveStreams", %{
+            access_token: get(params, :access_token, nil),
+            query: %{part: "status", id: stream_id}
+          })
+        end),
       snapshot: health_snapshot(get(params, :health, %{}))
     }
   end
@@ -318,6 +369,60 @@ defmodule Lux.Integrations.YouTube.LiveStreaming do
     if all_present?(params, keys), do: Client.token_request(type, params), else: nil
   end
 
+  defp chunk_upload_plan(params) do
+    with {:ok, values} <- required_values(params, [:upload_url, :content_length]),
+         {:ok, content_length} <- positive_integer(values.content_length, :content_length) do
+      range_start = integer(get(params, :chunk_start, 0))
+
+      Client.resumable_chunk_request(%{
+        access_token: get(params, :access_token, nil),
+        upload_url: values.upload_url,
+        content_type: get(params, :content_type, "video/mp4"),
+        content_length: content_length,
+        range_start: range_start,
+        range_end: get(params, :chunk_end, range_start + content_length - 1),
+        total_length: get(params, :total_length, content_length)
+      })
+    else
+      {:error, error, missing} when is_list(missing) ->
+        guarded_request(:upload_video_chunk, error, missing)
+
+      {:error, error, key} -> guarded_request(:upload_video_chunk, error, [key])
+    end
+  end
+
+  defp resume_probe_plan(params) do
+    with {:ok, values} <- required_values(params, [:upload_url, :total_length]),
+         {:ok, total_length} <- positive_integer(values.total_length, :total_length) do
+      Client.resumable_resume_request(%{
+        access_token: get(params, :access_token, nil),
+        upload_url: values.upload_url,
+        total_length: total_length
+      })
+    else
+      {:error, error, missing} when is_list(missing) ->
+        guarded_request(:resume_upload_session, error, missing)
+
+      {:error, error, key} -> guarded_request(:resume_upload_session, error, [key])
+    end
+  end
+
+  defp guarded_request(params, keys, operation, fun) do
+    case required_values(params, keys) do
+      {:ok, values} -> fun.(values)
+      {:error, error, missing} -> guarded_request(operation, error, missing)
+    end
+  end
+
+  defp guarded_request(operation, error, missing) do
+    %{
+      operation: operation,
+      executable: false,
+      error: error,
+      required_parameters: missing
+    }
+  end
+
   defp all_present?(params, keys) do
     Enum.all?(keys, fn key ->
       value = get(params, key, nil)
@@ -346,6 +451,21 @@ defmodule Lux.Integrations.YouTube.LiveStreaming do
     end
   end
 
+  defp required_values(params, keys) do
+    missing = Enum.filter(keys, &missing_param?(params, &1))
+
+    case missing do
+      [] -> {:ok, Map.new(keys, fn key -> {key, get(params, key, nil)} end)}
+      [key] -> {:error, "Missing required YouTube live parameter #{key}", [key]}
+      keys -> {:error, "Missing required YouTube live parameters #{Enum.join(keys, ", ")}", keys}
+    end
+  end
+
+  defp missing_param?(params, key) do
+    value = get(params, key, nil)
+    is_nil(value) or value == ""
+  end
+
   defp params_list(params, key) do
     case get(params, key, []) do
       value when is_list(value) -> value
@@ -372,6 +492,34 @@ defmodule Lux.Integrations.YouTube.LiveStreaming do
 
   defp maybe_issue(issues, issue, true), do: [issue | issues]
   defp maybe_issue(issues, _issue, false), do: issues
+
+  defp prune_empty_values(value) when is_map(value) do
+    value
+    |> Enum.reject(fn {_key, value} -> is_nil(value) or value == "" end)
+    |> Map.new(fn {key, value} -> {key, prune_empty_values(value)} end)
+  end
+
+  defp prune_empty_values(value) when is_list(value), do: Enum.map(value, &prune_empty_values/1)
+  defp prune_empty_values(value), do: value
+
+  defp positive_integer(value, key) do
+    case integer(value) do
+      number when number > 0 -> {:ok, number}
+      _ -> {:error, "Missing required YouTube live parameter #{key}", key}
+    end
+  end
+
+  defp integer(value) when is_integer(value), do: value
+  defp integer(value) when is_float(value), do: trunc(value)
+
+  defp integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {number, rest} -> if String.trim(rest) == "", do: number, else: 0
+      :error -> 0
+    end
+  end
+
+  defp integer(_value), do: 0
 
   defp numeric(value) when is_integer(value), do: value
   defp numeric(value) when is_float(value), do: value

--- a/lux/lib/lux/prisms/youtube/live/manage_broadcast.ex
+++ b/lux/lib/lux/prisms/youtube/live/manage_broadcast.ex
@@ -1,0 +1,60 @@
+defmodule Lux.Prisms.YouTube.Live.ManageBroadcast do
+  @moduledoc """
+  Builds a YouTube Core and Live Streaming workflow plan for Lux agents.
+
+  The prism intentionally defaults to dry-run planning. It returns the YouTube
+  Data API request envelopes an adapter would execute after OAuth credentials
+  and channel review are available.
+  """
+
+  use Lux.Prism,
+    name: "Manage YouTube Live Broadcast",
+    description: "Plans YouTube Data API v3 upload, live broadcast, live chat, health, and transition workflows",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        title: %{type: :string, description: "Broadcast title"},
+        scheduled_start_time: %{type: :string, description: "RFC3339 scheduled start time"},
+        description: %{type: :string, description: "Broadcast description"},
+        privacy_status: %{type: :string, enum: ["private", "unlisted", "public"]},
+        stream_id: %{type: :string, description: "Existing YouTube live stream ID"},
+        broadcast_id: %{type: :string, description: "Existing YouTube live broadcast ID"},
+        live_chat_id: %{type: :string, description: "Live chat ID for chat monitoring"},
+        target_life_cycle_status: %{type: :string, enum: ["testing", "live", "complete"]},
+        chat_message: %{type: :string, description: "Optional chat message draft"},
+        dry_run: %{type: :boolean, description: "Return a plan without executing live YouTube calls"}
+      },
+      required: ["title", "scheduled_start_time"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        planned: %{type: :boolean},
+        mode: %{type: :string},
+        workflow: %{type: :object},
+        execution_boundary: %{type: :object}
+      },
+      required: ["planned", "mode", "workflow"]
+    }
+
+  alias Lux.Integrations.YouTube.LiveStreaming
+
+  @doc """
+  Returns a deterministic YouTube live workflow plan.
+  """
+  def handler(params, _agent) do
+    case LiveStreaming.plan_broadcast_workflow(params) do
+      {:ok, workflow} ->
+        {:ok,
+         %{
+           planned: true,
+           mode: "dry_run",
+           workflow: workflow,
+           execution_boundary: workflow.execution_boundary
+         }}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+end

--- a/lux/mix.exs
+++ b/lux/mix.exs
@@ -142,6 +142,7 @@ defmodule Lux.MixProject do
         "guides/multi_agent_collaboration.livemd",
         "guides/trading_system.livemd",
         "guides/testing.md",
+        "guides/youtube_core_live_streaming.md",
         "guides/cursor_development.md",
         "guides/contributing.md",
         "guides/troubleshooting.md",

--- a/lux/test/unit/lux/integrations/youtube/client_test.exs
+++ b/lux/test/unit/lux/integrations/youtube/client_test.exs
@@ -1,0 +1,91 @@
+defmodule Lux.Integrations.YouTube.ClientTest do
+  use UnitAPICase, async: true
+
+  alias Lux.Integrations.YouTube.Client
+
+  describe "authorization_url/1" do
+    test "builds an offline OAuth consent URL with YouTube scopes" do
+      url =
+        Client.authorization_url(%{
+          client_id: "client-id",
+          redirect_uri: "https://example.test/oauth",
+          state: "state-1"
+        })
+
+      assert String.starts_with?(url, "https://accounts.google.com/o/oauth2/v2/auth?")
+      assert url =~ "client_id=client-id"
+      assert url =~ "access_type=offline"
+      assert url =~ "prompt=consent"
+      assert url =~ "state=state-1"
+      assert url =~ URI.encode_www_form("https://www.googleapis.com/auth/youtube.upload")
+    end
+  end
+
+  describe "integration defaults" do
+    test "exposes default headers and scopes through the integration module" do
+      assert Lux.Integrations.YouTube.headers() == [{"Content-Type", "application/json"}]
+      assert "https://www.googleapis.com/auth/youtube.force-ssl" in Lux.Integrations.YouTube.scopes()
+    end
+  end
+
+  describe "token_request/2" do
+    test "builds authorization-code and refresh-token requests" do
+      exchange =
+        Client.token_request(:authorization_code, %{
+          client_id: "client-id",
+          client_secret: "secret",
+          code: "code",
+          redirect_uri: "https://example.test/oauth"
+        })
+
+      assert exchange.method == :post
+      assert exchange.form.grant_type == "authorization_code"
+      assert exchange.form.code == "code"
+
+      refresh =
+        Client.token_request(:refresh_token, %{
+          client_id: "client-id",
+          client_secret: "secret",
+          refresh_token: "refresh"
+        })
+
+      assert refresh.form.grant_type == "refresh_token"
+      assert refresh.form.refresh_token == "refresh"
+    end
+  end
+
+  describe "build_request/3" do
+    test "normalizes query keys and adds bearer authorization" do
+      request =
+        Client.build_request(:get, "/liveBroadcasts", %{
+          access_token: "token",
+          query: %{broadcast_status: "all", max_results: 50, part: ["snippet", "status"]}
+        })
+
+      assert request.url == "https://www.googleapis.com/youtube/v3/liveBroadcasts"
+      assert request.query == %{"broadcastStatus" => "all", "maxResults" => 50, "part" => "snippet,status"}
+      assert {"Authorization", "Bearer token"} in request.headers
+    end
+  end
+
+  describe "resumable_upload_request/1" do
+    test "builds a resumable videos.insert request" do
+      request =
+        Client.resumable_upload_request(%{
+          access_token: "token",
+          title: "Launch stream",
+          description: "Archive",
+          tags: ["lux", "live"],
+          privacy_status: "unlisted",
+          content_length: 123_456
+        })
+
+      assert request.method == :post
+      assert request.url == "https://www.googleapis.com/upload/youtube/v3/videos"
+      assert request.query == %{"uploadType" => "resumable", "part" => "snippet,status"}
+      assert request.json.snippet.title == "Launch stream"
+      assert request.json.status.privacyStatus == "unlisted"
+      assert {"X-Upload-Content-Length", "123456"} in request.headers
+    end
+  end
+end

--- a/lux/test/unit/lux/integrations/youtube/client_test.exs
+++ b/lux/test/unit/lux/integrations/youtube/client_test.exs
@@ -88,4 +88,37 @@ defmodule Lux.Integrations.YouTube.ClientTest do
       assert {"X-Upload-Content-Length", "123456"} in request.headers
     end
   end
+
+  describe "resumable upload session helpers" do
+    test "builds chunk upload and resume probe requests against the Location URL" do
+      chunk =
+        Client.resumable_chunk_request(%{
+          access_token: "token",
+          upload_url: "https://upload.youtube.test/session",
+          content_type: "video/mp4",
+          content_length: "256",
+          range_start: 0,
+          total_length: "1024"
+        })
+
+      assert chunk.method == :put
+      assert chunk.url == "https://upload.youtube.test/session"
+      assert {"Authorization", "Bearer token"} in chunk.headers
+      assert {"Content-Length", "256"} in chunk.headers
+      assert {"Content-Range", "bytes 0-255/1024"} in chunk.headers
+      assert chunk.body == :video_binary
+
+      resume =
+        Client.resumable_resume_request(%{
+          upload_url: "https://upload.youtube.test/session",
+          total_length: "1024"
+        })
+
+      assert resume.method == :put
+      assert resume.url == "https://upload.youtube.test/session"
+      assert {"Content-Length", "0"} in resume.headers
+      assert {"Content-Range", "bytes */1024"} in resume.headers
+      assert resume.body == ""
+    end
+  end
 end

--- a/lux/test/unit/lux/integrations/youtube/live_streaming_test.exs
+++ b/lux/test/unit/lux/integrations/youtube/live_streaming_test.exs
@@ -13,6 +13,11 @@ defmodule Lux.Integrations.YouTube.LiveStreamingTest do
                  "broadcast_id" => "broadcast-1",
                  "stream_id" => "stream-1",
                  "live_chat_id" => "chat-1",
+                 "live_chat_page_token" => "page-2",
+                 "video_id" => "video-1",
+                 "upload_url" => "https://upload.youtube.test/session",
+                 "content_length" => 256,
+                 "total_length" => 1024,
                  "chat_messages" => [
                    %{"id" => "m1", "author" => "viewer", "text" => "great stream"},
                    %{"id" => "m2", "author" => "spammer", "text" => "click https://bad.test"}
@@ -24,6 +29,13 @@ defmodule Lux.Integrations.YouTube.LiveStreamingTest do
       assert workflow.broadcast.insert.url =~ "/liveBroadcasts"
       assert workflow.stream.insert.url =~ "/liveStreams"
       assert workflow.bind.query == %{"id" => "broadcast-1", "streamId" => "stream-1", "part" => "id,contentDetails"}
+      assert workflow.upload.status_request.query["id"] == "video-1"
+      assert workflow.upload.upload_session.required_parameter == :upload_url
+      assert {"Content-Range", "bytes 0-255/1024"} in workflow.upload.chunk_upload.headers
+      assert {"Content-Range", "bytes */1024"} in workflow.upload.resume_probe.headers
+      assert workflow.live_chat.list.query["pageToken"] == "page-2"
+      assert workflow.live_chat.pagination.next_page_token == :from_youtube_response
+      assert workflow.live_chat.pagination.polling_interval_millis == :from_youtube_response
       assert workflow.live_chat.moderation.requires_review == true
       assert workflow.execution_boundary.live_side_effects == false
     end
@@ -33,6 +45,38 @@ defmodule Lux.Integrations.YouTube.LiveStreamingTest do
                LiveStreaming.plan_broadcast_workflow(%{
                  scheduled_start_time: "2026-06-06T12:00:00Z"
                })
+    end
+
+    test "guards dependent requests when YouTube resource ids are not available yet" do
+      assert {:ok, workflow} =
+               LiveStreaming.plan_broadcast_workflow(%{
+                 title: "Lux market briefing",
+                 scheduled_start_time: "2026-06-06T12:00:00Z"
+               })
+
+      assert workflow.bind.executable == false
+      assert workflow.bind.required_parameters == [:broadcast_id, :stream_id]
+      assert workflow.stream.status.executable == false
+      assert workflow.stream.status.required_parameters == [:stream_id]
+      assert workflow.health_monitor.request.executable == false
+      assert workflow.health_monitor.request.required_parameters == [:stream_id]
+      assert workflow.transition.request.executable == false
+      assert workflow.transition.request.required_parameters == [:broadcast_id]
+      assert workflow.live_chat.list.executable == false
+      assert workflow.live_chat.send.executable == false
+      assert workflow.upload.status_request.required_parameters == [:video_id]
+      assert workflow.upload.chunk_upload.required_parameters == [:upload_url, :content_length]
+      assert workflow.upload.resume_probe.required_parameters == [:upload_url, :total_length]
+    end
+
+    test "omits optional nil fields from broadcast insert json" do
+      assert {:ok, workflow} =
+               LiveStreaming.plan_broadcast_workflow(%{
+                 title: "Lux market briefing",
+                 scheduled_start_time: "2026-06-06T12:00:00Z"
+               })
+
+      refute Map.has_key?(workflow.broadcast.insert.json.snippet, :scheduledEndTime)
     end
   end
 
@@ -77,6 +121,19 @@ defmodule Lux.Integrations.YouTube.LiveStreamingTest do
 
       assert rejected.allowed == false
       assert rejected.guardrails == ["completed broadcasts cannot be transitioned again"]
+    end
+
+    test "does not build transition requests without a broadcast id" do
+      guarded =
+        LiveStreaming.transition_plan(%{
+          current_life_cycle_status: "testing",
+          target_life_cycle_status: "live"
+        })
+
+      assert guarded.allowed == false
+      assert guarded.request.executable == false
+      assert guarded.request.required_parameters == [:broadcast_id]
+      assert "Missing required YouTube live parameter broadcast_id" in guarded.guardrails
     end
   end
 end

--- a/lux/test/unit/lux/integrations/youtube/live_streaming_test.exs
+++ b/lux/test/unit/lux/integrations/youtube/live_streaming_test.exs
@@ -1,0 +1,82 @@
+defmodule Lux.Integrations.YouTube.LiveStreamingTest do
+  use UnitAPICase, async: true
+
+  alias Lux.Integrations.YouTube.LiveStreaming
+
+  describe "plan_broadcast_workflow/1" do
+    test "returns a credential-free YouTube live workflow plan" do
+      assert {:ok, workflow} =
+               LiveStreaming.plan_broadcast_workflow(%{
+                 "title" => "Lux market briefing",
+                 "scheduled_start_time" => "2026-06-06T12:00:00Z",
+                 "privacy_status" => "unlisted",
+                 "broadcast_id" => "broadcast-1",
+                 "stream_id" => "stream-1",
+                 "live_chat_id" => "chat-1",
+                 "chat_messages" => [
+                   %{"id" => "m1", "author" => "viewer", "text" => "great stream"},
+                   %{"id" => "m2", "author" => "spammer", "text" => "click https://bad.test"}
+                 ]
+               })
+
+      assert workflow.mode == :dry_run
+      assert workflow.broadcast.insert.method == :post
+      assert workflow.broadcast.insert.url =~ "/liveBroadcasts"
+      assert workflow.stream.insert.url =~ "/liveStreams"
+      assert workflow.bind.query == %{"id" => "broadcast-1", "streamId" => "stream-1", "part" => "id,contentDetails"}
+      assert workflow.live_chat.moderation.requires_review == true
+      assert workflow.execution_boundary.live_side_effects == false
+    end
+
+    test "validates required scheduling fields" do
+      assert {:error, "Missing required YouTube live parameter title"} =
+               LiveStreaming.plan_broadcast_workflow(%{
+                 scheduled_start_time: "2026-06-06T12:00:00Z"
+               })
+    end
+  end
+
+  describe "health_snapshot/1" do
+    test "flags low bitrate, dropped frames, and latency" do
+      snapshot =
+        LiveStreaming.health_snapshot(%{
+          status: "good",
+          bitrate_kbps: 1_200,
+          min_bitrate_kbps: 2_500,
+          dropped_frames: 45,
+          max_dropped_frames: 30,
+          latency_ms: 12_000,
+          max_latency_ms: 10_000
+        })
+
+      assert snapshot.status == :attention_required
+      assert "low_bitrate" in snapshot.issues
+      assert "dropped_frames" in snapshot.issues
+      assert "high_latency" in snapshot.issues
+    end
+  end
+
+  describe "transition_plan/1" do
+    test "allows testing to live transition and rejects invalid transitions" do
+      allowed =
+        LiveStreaming.transition_plan(%{
+          broadcast_id: "broadcast-1",
+          current_life_cycle_status: "testing",
+          target_life_cycle_status: "live"
+        })
+
+      assert allowed.allowed == true
+      assert allowed.request.query["broadcastStatus"] == "live"
+
+      rejected =
+        LiveStreaming.transition_plan(%{
+          broadcast_id: "broadcast-1",
+          current_life_cycle_status: "complete",
+          target_life_cycle_status: "live"
+        })
+
+      assert rejected.allowed == false
+      assert rejected.guardrails == ["completed broadcasts cannot be transitioned again"]
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/youtube/live/manage_broadcast_test.exs
+++ b/lux/test/unit/lux/prisms/youtube/live/manage_broadcast_test.exs
@@ -1,0 +1,44 @@
+defmodule Lux.Prisms.YouTube.Live.ManageBroadcastTest do
+  use UnitAPICase, async: true
+
+  alias Lux.Prisms.YouTube.Live.ManageBroadcast
+
+  @agent %{name: "YouTubeOps"}
+
+  describe "handler/2" do
+    test "returns a dry-run workflow plan" do
+      assert {:ok, result} =
+               ManageBroadcast.handler(
+                 %{
+                   title: "Lux live",
+                   scheduled_start_time: "2026-06-06T12:00:00Z",
+                   broadcast_id: "broadcast-1",
+                   stream_id: "stream-1",
+                   target_life_cycle_status: "testing"
+                 },
+                 @agent
+               )
+
+      assert result.planned == true
+      assert result.mode == "dry_run"
+      assert result.workflow.transition.allowed == true
+      assert result.execution_boundary.live_side_effects == false
+    end
+
+    test "returns validation errors from the planner" do
+      assert {:error, "Missing required YouTube live parameter scheduled_start_time"} =
+               ManageBroadcast.handler(%{title: "Lux live"}, @agent)
+    end
+  end
+
+  describe "schema validation" do
+    test "exposes required input and output fields" do
+      prism = ManageBroadcast.view()
+
+      assert prism.input_schema.required == ["title", "scheduled_start_time"]
+      assert Map.has_key?(prism.input_schema.properties, :broadcast_id)
+      assert Map.has_key?(prism.input_schema.properties, :stream_id)
+      assert Map.has_key?(prism.output_schema.properties, :workflow)
+    end
+  end
+end


### PR DESCRIPTION
/claim #68

## Summary
- Adds a YouTube Data API v3 integration boundary with OAuth authorization URL, authorization-code exchange, refresh-token exchange, bearer request construction, response normalization, and resumable upload request envelopes.
- Adds a deterministic YouTube live-streaming workflow planner covering channel validation, upload startup, live broadcast creation, live stream creation/status, broadcast binding, live chat polling/sending envelopes, stream health snapshots, quality/failover checks, and guarded broadcast transitions.
- Adds `Lux.Prisms.YouTube.Live.ManageBroadcast` so agents can request a dry-run live workflow plan without mutating a YouTube channel.
- Adds unit coverage for OAuth/request construction, live workflow planning, stream health, lifecycle transition guardrails, and prism schema/handler behavior.
- Adds `guides/youtube_core_live_streaming.md` and includes it in ExDoc extras.

## Acceptance coverage
- Complete YouTube Data API v3 integration: request envelopes for channels, videos.insert resumable upload, liveBroadcasts, liveStreams, liveChat/messages, and OAuth token lifecycle.
- Live streaming setup and management: broadcast insert/list, stream insert/status, bind, lifecycle transition planning, quality/failover checks.
- Real-time chat monitoring and interaction: live chat list/send request envelopes plus deterministic moderation classification for imported chat messages.
- Stream health monitoring: local health snapshots with bitrate, dropped-frame, latency, and YouTube status issues.
- Documentation/examples: new guide with dry-run workflow example and execution boundary.

## Validation
- `git diff --cached --check` passed before commit.
- Changed YouTube files scanned for prompt/instruction disclosure and credential patterns; no real secrets found.
- Not run locally: `mix test` / `mix test.unit` because this Windows host does not have `mix` or `elixir` installed.

This intentionally avoids live YouTube side effects. The implementation produces reviewable request envelopes and guardrails; a credentialed adapter can execute selected envelopes after OAuth credentials and channel review are available.