### PR TITLE
feat(discord): add Moderation and Event Handling prisms (#57)

### DIFF
--- a/lux/lib/lux/prisms/discord/events/create_event.ex
+++ b/lux/lib/lux/prisms/discord/events/create_event.ex
@@ -1,0 +1,39 @@
+defmodule Lux.Prisms.Discord.Events.CreateEvent do
+  @moduledoc "A prism for creating a scheduled event in a Discord guild."
+  use Lux.Prism,
+    name: "Create Discord Event",
+    description: "Creates a scheduled event in a Discord guild",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{type: :string, pattern: "^[0-9]{17,20}$"},
+        name: %{type: :string, minLength: 1, maxLength: 100},
+        description: %{type: :string, maxLength: 1000},
+        scheduled_start_time: %{type: :string, description: "ISO 8601 start time"},
+        scheduled_end_time: %{type: :string, description: "ISO 8601 end time"},
+        entity_type: %{type: :integer, enum: [2, 3, 8], description: "2: stage, 3: voice, 8: external"},
+        channel_id: %{type: :string, pattern: "^[0-9]{17,20}$"},
+        location: %{type: :string, maxLength: 100}
+      },
+      required: ["guild_id", "name", "scheduled_start_time", "entity_type"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        created: %{type: :boolean},
+        event_id: %{type: :string},
+        name: %{type: :string}
+      }
+    }
+  def handler(input, _ctx) do
+    body = %{name: input["name"], scheduled_start_time: input["scheduled_start_time"], entity_type: input["entity_type"]}
+    body = if input["description"], do: Map.put(body, :description, input["description"]), else: body
+    body = if input["scheduled_end_time"], do: Map.put(body, :scheduled_end_time, input["scheduled_end_time"]), else: body
+    body = if input["channel_id"], do: Map.put(body, :channel_id, input["channel_id"]), else: body
+    body = if input["location"], do: Map.put(body, :location, input["location"]), else: body
+    case Lux.Integrations.Discord.Client.request(:post, "/guilds/#{input["guild_id"]}/scheduled-events", json: body) do
+      {:ok, ev} -> {:ok, %{created: true, event_id: ev["id"], name: ev["name"]}}
+      {:error, reason} -> {:error, "Event creation failed: #{reason}"}
+    end
+  end
+end

--- a/lux/lib/lux/prisms/discord/events/delete_event.ex
+++ b/lux/lib/lux/prisms/discord/events/delete_event.ex
@@ -1,0 +1,27 @@
+defmodule Lux.Prisms.Discord.Events.DeleteEvent do
+  @moduledoc "A prism for deleting a scheduled event in a Discord guild."
+  use Lux.Prism,
+    name: "Delete Discord Event",
+    description: "Deletes a scheduled event in a Discord guild",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{type: :string, pattern: "^[0-9]{17,20}$"},
+        event_id: %{type: :string, pattern: "^[0-9]{17,20}$"}
+      },
+      required: ["guild_id", "event_id"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        deleted: %{type: :boolean},
+        event_id: %{type: :string}
+      }
+    }
+  def handler(input, _ctx) do
+    case Lux.Integrations.Discord.Client.request(:delete, "/guilds/#{input["guild_id"]}/scheduled-events/#{input["event_id"]}") do
+      {:ok, _} -> {:ok, %{deleted: true, event_id: input["event_id"]}}
+      {:error, reason} -> {:error, "Event deletion failed: #{reason}"}
+    end
+  end
+end

--- a/lux/lib/lux/prisms/discord/events/list_events.ex
+++ b/lux/lib/lux/prisms/discord/events/list_events.ex
@@ -1,0 +1,30 @@
+defmodule Lux.Prisms.Discord.Events.ListEvents do
+  @moduledoc "A prism for listing scheduled events in a Discord guild."
+  use Lux.Prism,
+    name: "List Discord Events",
+    description: "Lists scheduled events in a Discord guild",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{type: :string, pattern: "^[0-9]{17,20}$"},
+        with_user_count: %{type: :boolean}
+      },
+      required: ["guild_id"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        events: %{type: :array},
+        guild_id: %{type: :string},
+        count: %{type: :integer}
+      }
+    }
+  def handler(input, _ctx) do
+    query = if input["with_user_count"], do: "?with_user_count=true", else: ""
+    case Lux.Integrations.Discord.Client.request(:get, "/guilds/#{input["guild_id"]}/scheduled-events#{query}") do
+      {:ok, events} when is_list(events) -> {:ok, %{events: events, guild_id: input["guild_id"], count: length(events)}}
+      {:ok, events} -> {:ok, %{events: events || [], guild_id: input["guild_id"], count: 0}}
+      {:error, reason} -> {:error, "List events failed: #{reason}"}
+    end
+  end
+end

--- a/lux/lib/lux/prisms/discord/moderation/ban_member.ex
+++ b/lux/lib/lux/prisms/discord/moderation/ban_member.ex
@@ -1,0 +1,38 @@
+defmodule Lux.Prisms.Discord.Moderation.BanMember do
+  @moduledoc """
+  A prism for banning a member from a Discord guild.
+  Bans a user from the guild, optionally deleting their messages from the past N days.
+  """
+  use Lux.Prism,
+    name: "Ban Discord Member",
+    description: "Bans a member from a Discord guild",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{type: :string, description: "The ID of the guild", pattern: "^[0-9]{17,20}$"},
+        user_id: %{type: :string, description: "The ID of the user to ban", pattern: "^[0-9]{17,20}$"},
+        reason: %{type: :string, description: "Reason for the ban", maxLength: 512},
+        delete_message_days: %{type: :integer, description: "Delete messages from the past N days (0-7)", minimum: 0, maximum: 7}
+      },
+      required: ["guild_id", "user_id"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        banned: %{type: :boolean, description: "Whether the user was successfully banned"},
+        user_id: %{type: :string, description: "The ID of the banned user"},
+        guild_id: %{type: :string, description: "The ID of the guild"}
+      }
+    }
+  def handler(input, _ctx) do
+    guild_id = input["guild_id"]
+    user_id = input["user_id"]
+    body = %{}
+    body = if input["reason"], do: Map.put(body, :reason, input["reason"]), else: body
+    body = if input["delete_message_days"], do: Map.put(body, :delete_message_days, input["delete_message_days"]), else: body
+    case Lux.Integrations.Discord.Client.request(:put, "/guilds/#{guild_id}/bans/#{user_id}", json: body) do
+      {:ok, _} -> {:ok, %{banned: true, user_id: user_id, guild_id: guild_id}}
+      {:error, reason} -> {:error, "Ban failed: #{reason}"}
+    end
+  end
+end

--- a/lux/lib/lux/prisms/discord/moderation/get_member.ex
+++ b/lux/lib/lux/prisms/discord/moderation/get_member.ex
@@ -1,0 +1,29 @@
+defmodule Lux.Prisms.Discord.Moderation.GetMember do
+  @moduledoc "A prism for getting detailed information about a guild member."
+  use Lux.Prism,
+    name: "Get Discord Member Info",
+    description: "Gets detailed information about a Discord guild member",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{type: :string, pattern: "^[0-9]{17,20}$"},
+        user_id: %{type: :string, pattern: "^[0-9]{17,20}$"}
+      },
+      required: ["guild_id", "user_id"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        user_id: %{type: :string},
+        roles: %{type: :array},
+        joined_at: %{type: :string},
+        nickname: %{type: :string}
+      }
+    }
+  def handler(input, _ctx) do
+    case Lux.Integrations.Discord.Client.request(:get, "/guilds/#{input["guild_id"]}/members/#{input["user_id"]}") do
+      {:ok, m} -> {:ok, %{user_id: m["user"]["id"], username: m["user"]["username"], roles: m["roles"] || [], joined_at: m["joined_at"], nickname: m["nick"]}}
+      {:error, reason} -> {:error, "Get member failed: #{reason}"}
+    end
+  end
+end

--- a/lux/lib/lux/prisms/discord/moderation/list_bans.ex
+++ b/lux/lib/lux/prisms/discord/moderation/list_bans.ex
@@ -1,0 +1,30 @@
+defmodule Lux.Prisms.Discord.Moderation.ListBans do
+  @moduledoc "A prism for listing all bans in a Discord guild."
+  use Lux.Prism,
+    name: "List Discord Bans",
+    description: "Lists all banned users in a Discord guild",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{type: :string, pattern: "^[0-9]{17,20}$"},
+        limit: %{type: :integer, minimum: 1, maximum: 1000}
+      },
+      required: ["guild_id"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        bans: %{type: :array},
+        guild_id: %{type: :string},
+        count: %{type: :integer}
+      }
+    }
+  def handler(input, _ctx) do
+    query = if input["limit"], do: "?limit=#{input["limit"]}", else: ""
+    case Lux.Integrations.Discord.Client.request(:get, "/guilds/#{input["guild_id"]}/bans#{query}") do
+      {:ok, bans} when is_list(bans) -> {:ok, %{bans: bans, guild_id: input["guild_id"], count: length(bans)}}
+      {:ok, bans} -> {:ok, %{bans: bans || [], guild_id: input["guild_id"], count: 0}}
+      {:error, reason} -> {:error, "List bans failed: #{reason}"}
+    end
+  end
+end

--- a/lux/lib/lux/prisms/discord/moderation/timeout_member.ex
+++ b/lux/lib/lux/prisms/discord/moderation/timeout_member.ex
@@ -1,0 +1,33 @@
+defmodule Lux.Prisms.Discord.Moderation.TimeoutMember do
+  @moduledoc "A prism for timing out (muting) a member."
+  use Lux.Prism,
+    name: "Timeout Discord Member",
+    description: "Times out a member in a Discord guild",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{type: :string, pattern: "^[0-9]{17,20}$"},
+        user_id: %{type: :string, pattern: "^[0-9]{17,20}$"},
+        duration_minutes: %{type: :integer, description: "Timeout in minutes (max 40320)", minimum: 1, maximum: 40320},
+        reason: %{type: :string, maxLength: 512}
+      },
+      required: ["guild_id", "user_id", "duration_minutes"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        timed_out: %{type: :boolean},
+        user_id: %{type: :string},
+        expires_at: %{type: :string, description: "ISO 8601 expiry"}
+      }
+    }
+  def handler(input, _ctx) do
+    expires_at = DateTime.utc_now() |> DateTime.add(input["duration_minutes"] * 60, :second) |> DateTime.to_iso8601()
+    body = %{communication_disabled_until: expires_at}
+    body = if input["reason"], do: Map.put(body, :reason, input["reason"]), else: body
+    case Lux.Integrations.Discord.Client.request(:patch, "/guilds/#{input["guild_id"]}/members/#{input["user_id"]}", json: body) do
+      {:ok, _} -> {:ok, %{timed_out: true, user_id: input["user_id"], expires_at: expires_at}}
+      {:error, reason} -> {:error, "Timeout failed: #{reason}"}
+    end
+  end
+end

--- a/lux/lib/lux/prisms/discord/moderation/unban_member.ex
+++ b/lux/lib/lux/prisms/discord/moderation/unban_member.ex
@@ -1,0 +1,30 @@
+defmodule Lux.Prisms.Discord.Moderation.UnbanMember do
+  @moduledoc "A prism for unbanning a member from a Discord guild."
+  use Lux.Prism,
+    name: "Unban Discord Member",
+    description: "Removes a ban from a user in a Discord guild",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{type: :string, description: "The ID of the guild", pattern: "^[0-9]{17,20}$"},
+        user_id: %{type: :string, description: "The ID of the user to unban", pattern: "^[0-9]{17,20}$"}
+      },
+      required: ["guild_id", "user_id"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        unbanned: %{type: :boolean},
+        user_id: %{type: :string},
+        guild_id: %{type: :string}
+      }
+    }
+  def handler(input, _ctx) do
+    guild_id = input["guild_id"]
+    user_id = input["user_id"]
+    case Lux.Integrations.Discord.Client.request(:delete, "/guilds/#{guild_id}/bans/#{user_id}") do
+      {:ok, _} -> {:ok, %{unbanned: true, user_id: user_id, guild_id: guild_id}}
+      {:error, reason} -> {:error, "Unban failed: #{reason}"}
+    end
+  end
+end

--- a/test/unit/lux/prisms/discord/events/create_event_test.exs
+++ b/test/unit/lux/prisms/discord/events/create_event_test.exs
@@ -1,0 +1,12 @@
+defmodule Lux.Prisms.Discord.Events.CreateEventTest do
+  use ExUnit.Case, async: true
+  alias Lux.Prisms.Discord.Events.CreateEvent
+  describe "handler/2" do
+    test "creates event" do
+      result = CreateEvent.handler(%{"guild_id" => "123456789012345678", "name" => "Test Event", "scheduled_start_time" => "2026-07-01T18:00:00Z", "entity_type" => 2}, %{})
+      assert elem(result, 0) in [:ok, :error]
+    end
+    test "creates event with description", do:
+      assert elem(CreateEvent.handler(%{"guild_id" => "123456789012345678", "name" => "Test", "scheduled_start_time" => "2026-07-01T18:00:00Z", "entity_type" => 3, "description" => "desc"}, %{}), 0) in [:ok, :error]
+  end
+end

--- a/test/unit/lux/prisms/discord/events/delete_event_test.exs
+++ b/test/unit/lux/prisms/discord/events/delete_event_test.exs
@@ -1,0 +1,10 @@
+defmodule Lux.Prisms.Discord.Events.DeleteEventTest do
+  use ExUnit.Case, async: true
+  alias Lux.Prisms.Discord.Events.DeleteEvent
+  describe "handler/2" do
+    test "deletes event" do
+      result = DeleteEvent.handler(%{"guild_id" => "123456789012345678", "event_id" => "111111111111111111"}, %{})
+      assert elem(result, 0) in [:ok, :error]
+    end
+  end
+end

--- a/test/unit/lux/prisms/discord/events/list_events_test.exs
+++ b/test/unit/lux/prisms/discord/events/list_events_test.exs
@@ -1,0 +1,10 @@
+defmodule Lux.Prisms.Discord.Events.ListEventsTest do
+  use ExUnit.Case, async: true
+  alias Lux.Prisms.Discord.Events.ListEvents
+  describe "handler/2" do
+    test "lists events" do
+      result = ListEvents.handler(%{"guild_id" => "123456789012345678"}, %{})
+      assert elem(result, 0) in [:ok, :error]
+    end
+  end
+end

--- a/test/unit/lux/prisms/discord/moderation/ban_member_test.exs
+++ b/test/unit/lux/prisms/discord/moderation/ban_member_test.exs
@@ -1,0 +1,16 @@
+defmodule Lux.Prisms.Discord.Moderation.BanMemberTest do
+  use ExUnit.Case, async: true
+  alias Lux.Prisms.Discord.Moderation.BanMember
+  describe "handler/2" do
+    test "returns error with invalid guild_id" do
+      result = BanMember.handler(%{"guild_id" => "abc", "user_id" => "123"}, %{})
+      assert elem(result, 0) == :error
+    end
+    test "returns tuple with valid input" do
+      result = BanMember.handler(%{"guild_id" => "123456789012345678", "user_id" => "987654321098765432"}, %{})
+      assert elem(result, 0) in [:ok, :error]
+    end
+    test "accepts optional reason", do:
+      assert elem(BanMember.handler(%{"guild_id" => "123456789012345678", "user_id" => "987654321098765432", "reason" => "spam"}, %{}), 0) in [:ok, :error]
+  end
+end

--- a/test/unit/lux/prisms/discord/moderation/get_member_test.exs
+++ b/test/unit/lux/prisms/discord/moderation/get_member_test.exs
@@ -1,0 +1,10 @@
+defmodule Lux.Prisms.Discord.Moderation.GetMemberTest do
+  use ExUnit.Case, async: true
+  alias Lux.Prisms.Discord.Moderation.GetMember
+  describe "handler/2" do
+    test "returns member data" do
+      result = GetMember.handler(%{"guild_id" => "123456789012345678", "user_id" => "987654321098765432"}, %{})
+      assert elem(result, 0) in [:ok, :error]
+    end
+  end
+end

--- a/test/unit/lux/prisms/discord/moderation/list_bans_test.exs
+++ b/test/unit/lux/prisms/discord/moderation/list_bans_test.exs
@@ -1,0 +1,12 @@
+defmodule Lux.Prisms.Discord.Moderation.ListBansTest do
+  use ExUnit.Case, async: true
+  alias Lux.Prisms.Discord.Moderation.ListBans
+  describe "handler/2" do
+    test "returns bans list" do
+      result = ListBans.handler(%{"guild_id" => "123456789012345678"}, %{})
+      assert elem(result, 0) in [:ok, :error]
+    end
+    test "accepts limit parameter", do:
+      assert elem(ListBans.handler(%{"guild_id" => "123456789012345678", "limit" => 10}, %{}), 0) in [:ok, :error]
+  end
+end

--- a/test/unit/lux/prisms/discord/moderation/timeout_member_test.exs
+++ b/test/unit/lux/prisms/discord/moderation/timeout_member_test.exs
@@ -1,0 +1,12 @@
+defmodule Lux.Prisms.Discord.Moderation.TimeoutMemberTest do
+  use ExUnit.Case, async: true
+  alias Lux.Prisms.Discord.Moderation.TimeoutMember
+  describe "handler/2" do
+    test "returns tuple with valid inputs" do
+      result = TimeoutMember.handler(%{"guild_id" => "123456789012345678", "user_id" => "987654321098765432", "duration_minutes" => 60}, %{})
+      assert elem(result, 0) in [:ok, :error]
+    end
+    test "accepts optional reason", do:
+      assert elem(TimeoutMember.handler(%{"guild_id" => "123456789012345678", "user_id" => "987654321098765432", "duration_minutes" => 30, "reason" => "spam"}, %{}), 0) in [:ok, :error]
+  end
+end

--- a/test/unit/lux/prisms/discord/moderation/unban_member_test.exs
+++ b/test/unit/lux/prisms/discord/moderation/unban_member_test.exs
@@ -1,0 +1,10 @@
+defmodule Lux.Prisms.Discord.Moderation.UnbanMemberTest do
+  use ExUnit.Case, async: true
+  alias Lux.Prisms.Discord.Moderation.UnbanMember
+  describe "handler/2" do
+    test "returns tuple" do
+      result = UnbanMember.handler(%{"guild_id" => "123456789012345678", "user_id" => "987654321098765432"}, %{})
+      assert elem(result, 0) in [:ok, :error]
+    end
+  end
+end


### PR DESCRIPTION
## Discord Core Prisms - Moderation & Event Handling ($900)

### Moderation Prisms ($500)
- **BanMember** — Ban with optional message deletion and reason
- **UnbanMember** — Remove ban
- **TimeoutMember** — Timeout with configurable duration
- **ListBans** — View banned users
- **GetMember** — Get member details

### Event Handling Prisms ($400)
- **CreateEvent** — Create scheduled guild events
- **ListEvents** — List scheduled events
- **DeleteEvent** — Delete scheduled events

All prisms follow `use Lux.Prism` pattern with typed schemas, use existing `Discord.Client`, and return `{:ok, result} | {:error, reason}`.

Completes the remaining $900 scope for Issue #57 (Moderation + EventHandling).
MessageManagementPrism and ChannelManagement were already in the codebase.