### PR TITLE
feat: Implement Discord server, member, and role capabilities (#55)

### DIFF
--- a/lux/lib/lux/integrations/discord.ex
+++ b/lux/lib/lux/integrations/discord.ex
@@ -35,7 +35,15 @@ defmodule Lux.Integrations.Discord do
   @spec add_auth_header(Lux.Lens.t()) :: Lux.Lens.t()
   def add_auth_header(%Lux.Lens{} = lens) do
     token = Application.get_env(:lux, :api_keys)[:discord]
-    %{lens | headers: lens.headers ++ [{"Authorization", "Bot #{token}"}]}
+
+    url =
+      Enum.reduce(lens.params, lens.url, fn {key, val}, acc ->
+        acc
+        |> String.replace(":#{key}", to_string(val))
+        |> String.replace(":#{to_string(key)}", to_string(val))
+      end)
+
+    %{lens | url: url, headers: lens.headers ++ [{"Authorization", "Bot #{token}"}]}
   end
 
   @spec add_auth_header(Plug.Conn.t()) :: Plug.Conn.t()

--- a/lux/lib/lux/lenses/discord/guilds/list_guilds.ex
+++ b/lux/lib/lux/lenses/discord/guilds/list_guilds.ex
@@ -1,0 +1,67 @@
+defmodule Lux.Lenses.Discord.Guilds.ListGuilds do
+  @moduledoc """
+  A lens for listing Discord guilds of which the bot user is a member.
+
+  Supports pagination parameters:
+  - limit: max number of guilds to return (1-200, default: 200)
+  - before: guild ID to list guilds before
+  - after: guild ID to list guilds after
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "List Discord Guilds",
+    description: "Lists the guilds the bot user is a member of",
+    url: "https://discord.com/api/v10/users/@me/guilds",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        before: %{
+          type: :string,
+          description: "List guilds before this guild ID",
+          pattern: "^[0-9]{17,20}$"
+        },
+        after: %{
+          type: :string,
+          description: "List guilds after this guild ID",
+          pattern: "^[0-9]{17,20}$"
+        },
+        limit: %{
+          type: :integer,
+          description: "Max number of guilds to return (1-200)",
+          minimum: 1,
+          maximum: 200
+        }
+      }
+    }
+
+  @doc """
+  Transforms the list of guilds response into a cleaner representation.
+  """
+  @impl true
+  def after_focus(guilds) when is_list(guilds) do
+    parsed_guilds =
+      Enum.map(guilds, fn guild ->
+        %{
+          id: guild["id"],
+          name: guild["name"],
+          icon: guild["icon"],
+          owner: guild["owner"],
+          permissions: guild["permissions"],
+          features: guild["features"]
+        }
+      end)
+
+    {:ok, parsed_guilds}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+
+  def after_focus(other), do: {:error, other}
+end

--- a/lux/lib/lux/lenses/discord/guilds/read_guild.ex
+++ b/lux/lib/lux/lenses/discord/guilds/read_guild.ex
@@ -1,0 +1,55 @@
+defmodule Lux.Lenses.Discord.Guilds.ReadGuild do
+  @moduledoc """
+  A lens for reading Discord guild information.
+
+  Requires guild_id. Supports optional with_counts parameter.
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "Read Discord Guild",
+    description: "Reads detail of a specific Discord guild",
+    url: "https://discord.com/api/v10/guilds/:guild_id",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to read",
+          pattern: "^[0-9]{17,20}$"
+        },
+        with_counts: %{
+          type: :boolean,
+          description: "Whether to include approximate member and presence counts"
+        }
+      },
+      required: ["guild_id"]
+    }
+
+  @doc """
+  Transforms the guild details response into a cleaner format.
+  """
+  @impl true
+  def after_focus(%{"id" => id, "name" => name} = guild) do
+    {:ok,
+     %{
+       id: id,
+       name: name,
+       icon: guild["icon"],
+       description: guild["description"],
+       owner_id: guild["owner_id"],
+       approximate_member_count: guild["approximate_member_count"],
+       approximate_presence_count: guild["approximate_presence_count"]
+     }}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+
+  def after_focus(other), do: {:error, other}
+end

--- a/lux/lib/lux/lenses/discord/members/list_members.ex
+++ b/lux/lib/lux/lenses/discord/members/list_members.ex
@@ -1,0 +1,70 @@
+defmodule Lux.Lenses.Discord.Members.ListMembers do
+  @moduledoc """
+  A lens for listing members of a Discord guild.
+
+  Requires guild_id. Supports limit and after query parameters for pagination.
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "List Discord Guild Members",
+    description: "Lists members of a specific Discord guild",
+    url: "https://discord.com/api/v10/guilds/:guild_id/members",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to list members for",
+          pattern: "^[0-9]{17,20}$"
+        },
+        limit: %{
+          type: :integer,
+          description: "Max number of members to return (1-1000)",
+          minimum: 1,
+          maximum: 1000
+        },
+        after: %{
+          type: :string,
+          description: "The highest user ID in the previous page",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id"]
+    }
+
+  @doc """
+  Transforms the list of members response into a cleaner format.
+  """
+  @impl true
+  def after_focus(members) when is_list(members) do
+    parsed_members =
+      Enum.map(members, fn member ->
+        %{
+          user: %{
+            id: member["user"]["id"],
+            username: member["user"]["username"],
+            discriminator: member["user"]["discriminator"],
+            avatar: member["user"]["avatar"]
+          },
+          nick: member["nick"],
+          roles: member["roles"],
+          joined_at: member["joined_at"],
+          deaf: member["deaf"],
+          mute: member["mute"]
+        }
+      end)
+
+    {:ok, parsed_members}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+
+  def after_focus(other), do: {:error, other}
+end

--- a/lux/lib/lux/lenses/discord/members/read_member.ex
+++ b/lux/lib/lux/lenses/discord/members/read_member.ex
@@ -1,0 +1,62 @@
+defmodule Lux.Lenses.Discord.Members.ReadMember do
+  @moduledoc """
+  A lens for reading information about a specific member in a Discord guild.
+
+  Requires guild_id and user_id.
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "Read Discord Guild Member",
+    description: "Reads information about a specific Discord guild member",
+    url: "https://discord.com/api/v10/guilds/:guild_id/members/:user_id",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild",
+          pattern: "^[0-9]{17,20}$"
+        },
+        user_id: %{
+          type: :string,
+          description: "The ID of the user",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id", "user_id"]
+    }
+
+  @doc """
+  Transforms the guild member details response into a cleaner format.
+  """
+  @impl true
+  def after_focus(%{"user" => %{"id" => id, "username" => username}} = member) do
+    {:ok,
+     %{
+       user: %{
+         id: id,
+         username: username,
+         discriminator: member["user"]["discriminator"],
+         avatar: member["user"]["avatar"]
+       },
+       nick: member["nick"],
+       roles: member["roles"],
+       joined_at: member["joined_at"],
+       premium_since: member["premium_since"],
+       deaf: member["deaf"],
+       mute: member["mute"],
+       pending: member["pending"]
+     }}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+
+  def after_focus(other), do: {:error, other}
+end

--- a/lux/lib/lux/lenses/discord/roles/list_roles.ex
+++ b/lux/lib/lux/lenses/discord/roles/list_roles.ex
@@ -1,0 +1,56 @@
+defmodule Lux.Lenses.Discord.Roles.ListRoles do
+  @moduledoc """
+  A lens for listing roles of a Discord guild.
+
+  Requires guild_id.
+  """
+
+  alias Lux.Integrations.Discord
+
+  use Lux.Lens,
+    name: "List Discord Guild Roles",
+    description: "Lists all roles in a specific Discord guild",
+    url: "https://discord.com/api/v10/guilds/:guild_id/roles",
+    method: :get,
+    headers: Discord.headers(),
+    auth: Discord.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild to list roles for",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id"]
+    }
+
+  @doc """
+  Transforms the list of roles response into a cleaner format.
+  """
+  @impl true
+  def after_focus(roles) when is_list(roles) do
+    parsed_roles =
+      Enum.map(roles, fn role ->
+        %{
+          id: role["id"],
+          name: role["name"],
+          color: role["color"],
+          hoist: role["hoist"],
+          position: role["position"],
+          permissions: role["permissions"],
+          managed: role["managed"],
+          mentionable: role["mentionable"]
+        }
+      end)
+
+    {:ok, parsed_roles}
+  end
+
+  def after_focus(%{"message" => message}) do
+    {:error, %{"message" => message}}
+  end
+
+  def after_focus(other), do: {:error, other}
+end

--- a/lux/lib/lux/prisms/discord/roles/add_role.ex
+++ b/lux/lib/lux/prisms/discord/roles/add_role.ex
@@ -1,0 +1,90 @@
+defmodule Lux.Prisms.Discord.Roles.AddRole do
+  @moduledoc """
+  A prism for adding a role to a member in a Discord guild.
+
+  This prism provides an interface for adding a role with:
+  - Required parameters (guild_id, user_id, role_id)
+  - Success/failure response structure
+  """
+
+  use Lux.Prism,
+    name: "Add Discord Role to Member",
+    description: "Adds a specific role to a member in a Discord guild",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild",
+          pattern: "^[0-9]{17,20}$"
+        },
+        user_id: %{
+          type: :string,
+          description: "The ID of the member",
+          pattern: "^[0-9]{17,20}$"
+        },
+        role_id: %{
+          type: :string,
+          description: "The ID of the role to add",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id", "user_id", "role_id"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        added: %{
+          type: :boolean,
+          description: "Whether the role was successfully added"
+        },
+        guild_id: %{type: :string},
+        user_id: %{type: :string},
+        role_id: %{type: :string}
+      },
+      required: ["added"]
+    }
+
+  alias Lux.Integrations.Discord.Client
+  require Logger
+
+  @doc """
+  Handles the request to add a role to a member.
+  """
+  def handler(params, agent) do
+    with {:ok, guild_id} <- validate_param(params, :guild_id),
+         {:ok, user_id} <- validate_param(params, :user_id),
+         {:ok, role_id} <- validate_param(params, :role_id) do
+      agent_name = agent[:name] || "Unknown Agent"
+      Logger.info("Agent #{agent_name} adding role #{role_id} to member #{user_id} in guild #{guild_id}")
+
+      req_opts = Map.take(params, [:plug])
+
+      case Client.request(
+             :put,
+             "/guilds/#{guild_id}/members/#{user_id}/roles/#{role_id}",
+             req_opts
+           ) do
+        {:ok, _body} ->
+          Logger.info("Successfully added role #{role_id} to member #{user_id} in guild #{guild_id}")
+          {:ok, %{added: true, guild_id: guild_id, user_id: user_id, role_id: role_id}}
+
+        {:error, {status, %{"message" => message}}} ->
+          error = {status, message}
+          Logger.error("Failed to add role: #{inspect(error)}")
+          {:error, error}
+
+        {:error, error} ->
+          Logger.error("Failed to add role: #{inspect(error)}")
+          {:error, error}
+      end
+    end
+  end
+
+  defp validate_param(params, key) do
+    case Map.fetch(params, key) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "Missing or invalid #{key}"}
+    end
+  end
+end

--- a/lux/lib/lux/prisms/discord/roles/remove_role.ex
+++ b/lux/lib/lux/prisms/discord/roles/remove_role.ex
@@ -1,0 +1,90 @@
+defmodule Lux.Prisms.Discord.Roles.RemoveRole do
+  @moduledoc """
+  A prism for removing a role from a member in a Discord guild.
+
+  This prism provides an interface for removing a role with:
+  - Required parameters (guild_id, user_id, role_id)
+  - Success/failure response structure
+  """
+
+  use Lux.Prism,
+    name: "Remove Discord Role from Member",
+    description: "Removes a specific role from a member in a Discord guild",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        guild_id: %{
+          type: :string,
+          description: "The ID of the guild",
+          pattern: "^[0-9]{17,20}$"
+        },
+        user_id: %{
+          type: :string,
+          description: "The ID of the member",
+          pattern: "^[0-9]{17,20}$"
+        },
+        role_id: %{
+          type: :string,
+          description: "The ID of the role to remove",
+          pattern: "^[0-9]{17,20}$"
+        }
+      },
+      required: ["guild_id", "user_id", "role_id"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        removed: %{
+          type: :boolean,
+          description: "Whether the role was successfully removed"
+        },
+        guild_id: %{type: :string},
+        user_id: %{type: :string},
+        role_id: %{type: :string}
+      },
+      required: ["removed"]
+    }
+
+  alias Lux.Integrations.Discord.Client
+  require Logger
+
+  @doc """
+  Handles the request to remove a role from a member.
+  """
+  def handler(params, agent) do
+    with {:ok, guild_id} <- validate_param(params, :guild_id),
+         {:ok, user_id} <- validate_param(params, :user_id),
+         {:ok, role_id} <- validate_param(params, :role_id) do
+      agent_name = agent[:name] || "Unknown Agent"
+      Logger.info("Agent #{agent_name} removing role #{role_id} from member #{user_id} in guild #{guild_id}")
+
+      req_opts = Map.take(params, [:plug])
+
+      case Client.request(
+             :delete,
+             "/guilds/#{guild_id}/members/#{user_id}/roles/#{role_id}",
+             req_opts
+           ) do
+        {:ok, _body} ->
+          Logger.info("Successfully removed role #{role_id} from member #{user_id} in guild #{guild_id}")
+          {:ok, %{removed: true, guild_id: guild_id, user_id: user_id, role_id: role_id}}
+
+        {:error, {status, %{"message" => message}}} ->
+          error = {status, message}
+          Logger.error("Failed to remove role: #{inspect(error)}")
+          {:error, error}
+
+        {:error, error} ->
+          Logger.error("Failed to remove role: #{inspect(error)}")
+          {:error, error}
+      end
+    end
+  end
+
+  defp validate_param(params, key) do
+    case Map.fetch(params, key) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "Missing or invalid #{key}"}
+    end
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/channels/read_channel_test.exs
+++ b/lux/test/unit/lux/lenses/discord/channels/read_channel_test.exs
@@ -22,7 +22,7 @@ defmodule Lux.Lenses.Discord.Channels.ReadChannelTest do
     test "successfully reads a channel" do
       Req.Test.expect(Lux.Lens, fn conn ->
         assert conn.method == "GET"
-        assert conn.request_path == "/api/v10/channels/:channel_id"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}"
         assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
 
         conn
@@ -48,7 +48,7 @@ defmodule Lux.Lenses.Discord.Channels.ReadChannelTest do
     test "handles Discord API error" do
       Req.Test.expect(Lux.Lens, fn conn ->
         assert conn.method == "GET"
-        assert conn.request_path == "/api/v10/channels/:channel_id"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}"
         assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
 
         conn

--- a/lux/test/unit/lux/lenses/discord/guilds/list_guilds_test.exs
+++ b/lux/test/unit/lux/lenses/discord/guilds/list_guilds_test.exs
@@ -1,0 +1,59 @@
+defmodule Lux.Lenses.Discord.Guilds.ListGuildsTest do
+  @moduledoc """
+  Test suite for ListGuilds lens.
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Guilds.ListGuilds
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully lists guilds" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/users/@me/guilds"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!([
+            %{
+              "id" => "123456789012345678",
+              "name" => "Guild One",
+              "icon" => "iconhash",
+              "owner" => true,
+              "permissions" => "104320577",
+              "features" => ["COMMUNITY"]
+            }
+          ])
+        )
+      end)
+
+      assert {:ok, guilds} = ListGuilds.focus(%{}, %{})
+      assert length(guilds) == 1
+      [guild] = guilds
+      assert guild.id == "123456789012345678"
+      assert guild.name == "Guild One"
+      assert guild.owner == true
+    end
+
+    test "handles error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/users/@me/guilds"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(401, Jason.encode!(%{"message" => "401: Unauthorized"}))
+      end)
+
+      assert {:error, %{"message" => "401: Unauthorized"}} = ListGuilds.focus(%{}, %{})
+    end
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/guilds/read_guild_test.exs
+++ b/lux/test/unit/lux/lenses/discord/guilds/read_guild_test.exs
@@ -1,0 +1,58 @@
+defmodule Lux.Lenses.Discord.Guilds.ReadGuildTest do
+  @moduledoc """
+  Test suite for ReadGuild lens.
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Guilds.ReadGuild
+
+  @guild_id "123456789012345678"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully reads guild" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(%{
+            "id" => @guild_id,
+            "name" => "Guild One",
+            "icon" => "iconhash",
+            "description" => "A description",
+            "owner_id" => "111222333444",
+            "approximate_member_count" => 150,
+            "approximate_presence_count" => 30
+          })
+        )
+      end)
+
+      assert {:ok, guild} = ReadGuild.focus(%{guild_id: @guild_id}, %{})
+      assert guild.id == @guild_id
+      assert guild.name == "Guild One"
+      assert guild.approximate_member_count == 150
+    end
+
+    test "handles error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{"message" => "Unknown Guild"}))
+      end)
+
+      assert {:error, %{"message" => "Unknown Guild"}} = ReadGuild.focus(%{guild_id: @guild_id}, %{})
+    end
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/members/list_members_test.exs
+++ b/lux/test/unit/lux/lenses/discord/members/list_members_test.exs
@@ -1,0 +1,67 @@
+defmodule Lux.Lenses.Discord.Members.ListMembersTest do
+  @moduledoc """
+  Test suite for ListMembers lens.
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Members.ListMembers
+
+  @guild_id "123456789012345678"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully lists members" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/members"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!([
+            %{
+              "user" => %{
+                "id" => "111222333444",
+                "username" => "TestUser",
+                "discriminator" => "0000",
+                "avatar" => "avatarhash"
+              },
+              "nick" => "Nickname",
+              "roles" => ["role1"],
+              "joined_at" => "2026-06-01T00:00:00.000Z",
+              "deaf" => false,
+              "mute" => false
+            }
+          ])
+        )
+      end)
+
+      assert {:ok, members} = ListMembers.focus(%{guild_id: @guild_id}, %{})
+      assert length(members) == 1
+      [member] = members
+      assert member.user.id == "111222333444"
+      assert member.user.username == "TestUser"
+      assert member.nick == "Nickname"
+    end
+
+    test "handles error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/members"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{"message" => "Missing Permissions"}))
+      end)
+
+      assert {:error, %{"message" => "Missing Permissions"}} =
+               ListMembers.focus(%{guild_id: @guild_id}, %{})
+    end
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/members/read_member_test.exs
+++ b/lux/test/unit/lux/lenses/discord/members/read_member_test.exs
@@ -1,0 +1,66 @@
+defmodule Lux.Lenses.Discord.Members.ReadMemberTest do
+  @moduledoc """
+  Test suite for ReadMember lens.
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Members.ReadMember
+
+  @guild_id "123456789012345678"
+  @user_id "111222333444555666"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully reads member" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/members/#{@user_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(%{
+            "user" => %{
+              "id" => @user_id,
+              "username" => "TestUser",
+              "discriminator" => "0000",
+              "avatar" => "avatarhash"
+            },
+            "nick" => "Nickname",
+            "roles" => ["role1"],
+            "joined_at" => "2026-06-01T00:00:00.000Z",
+            "premium_since" => nil,
+            "deaf" => false,
+            "mute" => false,
+            "pending" => false
+          })
+        )
+      end)
+
+      assert {:ok, member} = ReadMember.focus(%{guild_id: @guild_id, user_id: @user_id}, %{})
+      assert member.user.id == @user_id
+      assert member.user.username == "TestUser"
+      assert member.nick == "Nickname"
+    end
+
+    test "handles error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/members/#{@user_id}"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{"message" => "Unknown Member"}))
+      end)
+
+      assert {:error, %{"message" => "Unknown Member"}} =
+               ReadMember.focus(%{guild_id: @guild_id, user_id: @user_id}, %{})
+    end
+  end
+end

--- a/lux/test/unit/lux/lenses/discord/messages/list_messages_test.exs
+++ b/lux/test/unit/lux/lenses/discord/messages/list_messages_test.exs
@@ -23,7 +23,7 @@ defmodule Lux.Lenses.Discord.Messages.ListMessagesTest do
     test "successfully lists messages with default parameters" do
       Req.Test.expect(Lux.Lens, fn conn ->
         assert conn.method == "GET"
-        assert conn.request_path == "/api/v10/channels/:channel_id/messages"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}/messages"
         assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
 
         # Verify only channel_id is present in the query string
@@ -69,7 +69,7 @@ defmodule Lux.Lenses.Discord.Messages.ListMessagesTest do
     test "successfully lists messages with pagination parameters" do
       Req.Test.expect(Lux.Lens, fn conn ->
         assert conn.method == "GET"
-        assert conn.request_path == "/api/v10/channels/:channel_id/messages"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}/messages"
 
         # Verify pagination parameters
         query = URI.decode_query(conn.query_string)
@@ -107,7 +107,7 @@ defmodule Lux.Lenses.Discord.Messages.ListMessagesTest do
     test "handles Discord API error" do
       Req.Test.expect(Lux.Lens, fn conn ->
         assert conn.method == "GET"
-        assert conn.request_path == "/api/v10/channels/:channel_id/messages"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}/messages"
         assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
 
         conn

--- a/lux/test/unit/lux/lenses/discord/messages/read_message_test.exs
+++ b/lux/test/unit/lux/lenses/discord/messages/read_message_test.exs
@@ -22,7 +22,7 @@ defmodule Lux.Lenses.Discord.Messages.ReadMessageTest do
     test "successfully reads a message" do
       Req.Test.expect(Lux.Lens, fn conn ->
         assert conn.method == "GET"
-        assert conn.request_path == "/api/v10/channels/:channel_id/messages/:message_id"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}/messages/#{@message_id}"
         assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
 
         conn
@@ -53,7 +53,7 @@ defmodule Lux.Lenses.Discord.Messages.ReadMessageTest do
     test "handles Discord API error" do
       Req.Test.expect(Lux.Lens, fn conn ->
         assert conn.method == "GET"
-        assert conn.request_path == "/api/v10/channels/:channel_id/messages/:message_id"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}/messages/#{@message_id}"
         assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
 
         conn
@@ -72,7 +72,7 @@ defmodule Lux.Lenses.Discord.Messages.ReadMessageTest do
     test "crashes on unexpected response format" do
       Req.Test.expect(Lux.Lens, fn conn ->
         assert conn.method == "GET"
-        assert conn.request_path == "/api/v10/channels/:channel_id/messages/:message_id"
+        assert conn.request_path == "/api/v10/channels/#{@channel_id}/messages/#{@message_id}"
         assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
 
         conn

--- a/lux/test/unit/lux/lenses/discord/roles/list_roles_test.exs
+++ b/lux/test/unit/lux/lenses/discord/roles/list_roles_test.exs
@@ -1,0 +1,64 @@
+defmodule Lux.Lenses.Discord.Roles.ListRolesTest do
+  @moduledoc """
+  Test suite for ListRoles lens.
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Discord.Roles.ListRoles
+
+  @guild_id "123456789012345678"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully lists roles" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/roles"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!([
+            %{
+              "id" => "111111",
+              "name" => "Admin",
+              "color" => 16711680,
+              "hoist" => true,
+              "position" => 1,
+              "permissions" => "8",
+              "managed" => false,
+              "mentionable" => true
+            }
+          ])
+        )
+      end)
+
+      assert {:ok, roles} = ListRoles.focus(%{guild_id: @guild_id}, %{})
+      assert length(roles) == 1
+      [role] = roles
+      assert role.id == "111111"
+      assert role.name == "Admin"
+      assert role.color == 16711680
+    end
+
+    test "handles error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/roles"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{"message" => "Missing Permissions"}))
+      end)
+
+      assert {:error, %{"message" => "Missing Permissions"}} =
+               ListRoles.focus(%{guild_id: @guild_id}, %{})
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/discord/roles/add_role_test.exs
+++ b/lux/test/unit/lux/prisms/discord/roles/add_role_test.exs
@@ -1,0 +1,63 @@
+defmodule Lux.Prisms.Discord.Roles.AddRoleTest do
+  @moduledoc """
+  Test suite for AddRole prism.
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Prisms.Discord.Roles.AddRole
+
+  @guild_id "123456789012345678"
+  @user_id "111222333444555666"
+  @role_id "999888777666"
+  @agent_ctx %{name: "TestAgent"}
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "handler/2" do
+    test "successfully adds a role" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "PUT"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/members/#{@user_id}/roles/#{@role_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.send_resp(204, "")
+      end)
+
+      assert {:ok, %{added: true, guild_id: @guild_id, user_id: @user_id, role_id: @role_id}} =
+               AddRole.handler(
+                 %{
+                   guild_id: @guild_id,
+                   user_id: @user_id,
+                   role_id: @role_id,
+                   plug: {Req.Test, DiscordClientMock}
+                 },
+                 @agent_ctx
+               )
+    end
+
+    test "handles error" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "PUT"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{"message" => "Missing Permissions"}))
+      end)
+
+      assert {:error, {403, "Missing Permissions"}} =
+               AddRole.handler(
+                 %{
+                   guild_id: @guild_id,
+                   user_id: @user_id,
+                   role_id: @role_id,
+                   plug: {Req.Test, DiscordClientMock}
+                 },
+                 @agent_ctx
+               )
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/discord/roles/remove_role_test.exs
+++ b/lux/test/unit/lux/prisms/discord/roles/remove_role_test.exs
@@ -1,0 +1,63 @@
+defmodule Lux.Prisms.Discord.Roles.RemoveRoleTest do
+  @moduledoc """
+  Test suite for RemoveRole prism.
+  """
+
+  use UnitAPICase, async: true
+  alias Lux.Prisms.Discord.Roles.RemoveRole
+
+  @guild_id "123456789012345678"
+  @user_id "111222333444555666"
+  @role_id "999888777666"
+  @agent_ctx %{name: "TestAgent"}
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "handler/2" do
+    test "successfully removes a role" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "DELETE"
+        assert conn.request_path == "/api/v10/guilds/#{@guild_id}/members/#{@user_id}/roles/#{@role_id}"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bot test-discord-token"]
+
+        conn
+        |> Plug.Conn.send_resp(204, "")
+      end)
+
+      assert {:ok, %{removed: true, guild_id: @guild_id, user_id: @user_id, role_id: @role_id}} =
+               RemoveRole.handler(
+                 %{
+                   guild_id: @guild_id,
+                   user_id: @user_id,
+                   role_id: @role_id,
+                   plug: {Req.Test, DiscordClientMock}
+                 },
+                 @agent_ctx
+               )
+    end
+
+    test "handles error" do
+      Req.Test.expect(DiscordClientMock, fn conn ->
+        assert conn.method == "DELETE"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(403, Jason.encode!(%{"message" => "Missing Permissions"}))
+      end)
+
+      assert {:error, {403, "Missing Permissions"}} =
+               RemoveRole.handler(
+                 %{
+                   guild_id: @guild_id,
+                   user_id: @user_id,
+                   role_id: @role_id,
+                   plug: {Req.Test, DiscordClientMock}
+                 },
+                 @agent_ctx
+               )
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR implements the missing Discord capabilities requested in Issue #55, focusing on Guild/Server management, Member interactions, and Role management.

In addition, it resolves a critical architectural bug in the existing Discord lenses (such as `ReadChannel`) where path variables in the URLs (e.g. `:channel_id`) were not replaced before making HTTP requests.

### Core Changes

1. **Path Variable Replacement Engine**:
   - Updated `add_auth_header/1` in `Lux.Integrations.Discord` to dynamically replace all colon-prefixed URL placeholders (like `:guild_id`, `:user_id`, etc.) using key-value entries in `lens.params`.
   - Updated existing tests for `ReadChannel`, `ReadMessage`, and `ListMessages` to assert against fully-resolved request paths instead of literal path templates.

2. **Guild/Server Management**:
   - `Lux.Lenses.Discord.Guilds.ListGuilds` (GET `/users/@me/guilds` with support for `before`, `after`, and `limit` query parameters).
   - `Lux.Lenses.Discord.Guilds.ReadGuild` (GET `/guilds/:guild_id` with support for `with_counts` query parameter).

3. **Member Interaction**:
   - `Lux.Lenses.Discord.Members.ListMembers` (GET `/guilds/:guild_id/members` with support for `limit` and `after` query parameters).
   - `Lux.Lenses.Discord.Members.ReadMember` (GET `/guilds/:guild_id/members/:user_id`).

4. **Role Management**:
   - `Lux.Lenses.Discord.Roles.ListRoles` (GET `/guilds/:guild_id/roles`).
   - `Lux.Prisms.Discord.Roles.AddRole` (PUT `/guilds/:guild_id/members/:user_id/roles/:role_id`).
   - `Lux.Prisms.Discord.Roles.RemoveRole` (DELETE `/guilds/:guild_id/members/:user_id/roles/:role_id`).

### Verification & Testing

- Mocked testing via `Req.Test` and standard `UnitAPICase` is fully implemented for all new Lenses and Prisms.
- The unit tests verify correct API routing, placeholder replacement, headers, query parameters, and successful/error response mappings.

Closes #55
