### PR TITLE
feat: Implement Curve Finance Integration (#81)

### DIFF
--- a/lux/lib/lux/integrations/curve/pool.ex
+++ b/lux/lib/lux/integrations/curve/pool.ex
@@ -1,0 +1,40 @@
+defmodule Lux.Integrations.Curve.Pool do
+  @moduledoc """
+  Ethers contract definition for a Curve Finance StableSwap Pool.
+  """
+
+  use Ethers.Contract, abi: [
+    %{
+      "inputs" => [
+        %{"internalType" => "int128", "name" => "i", "type" => "int128"},
+        %{"internalType" => "int128", "name" => "j", "type" => "int128"},
+        %{"internalType" => "uint256", "name" => "dx", "type" => "uint256"},
+        %{"internalType" => "uint256", "name" => "min_dy", "type" => "uint256"}
+      ],
+      "name" => "exchange",
+      "outputs" => [%{"internalType" => "uint256", "name" => "", "type" => "uint256"}],
+      "stateMutability" => "nonpayable",
+      "type" => "function"
+    },
+    %{
+      "inputs" => [
+        %{"internalType" => "int128", "name" => "i", "type" => "int128"},
+        %{"internalType" => "int128", "name" => "j", "type" => "int128"},
+        %{"internalType" => "uint256", "name" => "dx", "type" => "uint256"}
+      ],
+      "name" => "get_dy",
+      "outputs" => [%{"internalType" => "uint256", "name" => "", "type" => "uint256"}],
+      "stateMutability" => "view",
+      "type" => "function"
+    },
+    %{
+      "inputs" => [
+        %{"internalType" => "uint256", "name" => "i", "type" => "uint256"}
+      ],
+      "name" => "balances",
+      "outputs" => [%{"internalType" => "uint256", "name" => "", "type" => "uint256"}],
+      "stateMutability" => "view",
+      "type" => "function"
+    }
+  ]
+end

--- a/lux/lib/lux/lenses/curve/get_pool_balances.ex
+++ b/lux/lib/lux/lenses/curve/get_pool_balances.ex
@@ -1,0 +1,37 @@
+defmodule Lux.Lenses.Curve.GetPoolBalances do
+  @moduledoc """
+  A lens for retrieving token balances from a Curve Finance Pool.
+  """
+
+  use Lux.Lens,
+    name: "Curve Pool Balances",
+    description: "Fetches the token balance for a specific index in a Curve pool",
+    schema: %{
+      type: :object,
+      properties: %{
+        pool_address: %{
+          type: :string,
+          description: "Address of the Curve pool contract",
+          pattern: "^0x[a-fA-F0-9]{40}$"
+        },
+        index: %{
+          type: :integer,
+          description: "Index of the token in the pool (e.g. 0, 1, 2)"
+        }
+      },
+      required: ["pool_address", "index"]
+    }
+
+  alias Lux.Integrations.Curve.Pool
+
+  @impl true
+  def handler(params, _agent) do
+    case Pool.balances(params.index, to: params.pool_address) do
+      {:ok, balance} ->
+        {:ok, %{balance: to_string(balance)}}
+        
+      {:error, reason} ->
+        {:error, "Failed to fetch pool balance: #{inspect(reason)}"}
+    end
+  end
+end

--- a/lux/lib/lux/lenses/curve/get_swap_quote.ex
+++ b/lux/lib/lux/lenses/curve/get_swap_quote.ex
@@ -1,0 +1,47 @@
+defmodule Lux.Lenses.Curve.GetSwapQuote do
+  @moduledoc """
+  A lens for retrieving Curve Finance swap quotes.
+  """
+
+  use Lux.Lens,
+    name: "Curve Swap Quote",
+    description: "Fetches expected output amount for a swap in a Curve pool",
+    schema: %{
+      type: :object,
+      properties: %{
+        pool_address: %{
+          type: :string,
+          description: "Address of the Curve pool contract",
+          pattern: "^0x[a-fA-F0-9]{40}$"
+        },
+        i: %{
+          type: :integer,
+          description: "Index value for the coin to send"
+        },
+        j: %{
+          type: :integer,
+          description: "Index value of the coin to receive"
+        },
+        dx: %{
+          type: :string,
+          description: "Amount of i being exchanged"
+        }
+      },
+      required: ["pool_address", "i", "j", "dx"]
+    }
+
+  alias Lux.Integrations.Curve.Pool
+
+  @impl true
+  def handler(params, _agent) do
+    dx = String.to_integer(params.dx)
+    
+    case Pool.get_dy(params.i, params.j, dx, to: params.pool_address) do
+      {:ok, amount_out} ->
+        {:ok, %{expected_output: to_string(amount_out)}}
+        
+      {:error, reason} ->
+        {:error, "Failed to fetch swap quote: #{inspect(reason)}"}
+    end
+  end
+end

--- a/lux/lib/lux/prisms/curve/execute_swap.ex
+++ b/lux/lib/lux/prisms/curve/execute_swap.ex
@@ -1,0 +1,72 @@
+defmodule Lux.Prisms.Curve.ExecuteSwap do
+  @moduledoc """
+  A prism for executing token swaps on a Curve Finance Pool.
+  """
+
+  use Lux.Prism,
+    name: "Curve Execute Swap",
+    description: "Executes a token swap on a Curve StableSwap pool",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        pool_address: %{
+          type: :string,
+          description: "Address of the Curve pool contract",
+          pattern: "^0x[a-fA-F0-9]{40}$"
+        },
+        i: %{
+          type: :integer,
+          description: "Index value for the coin to send"
+        },
+        j: %{
+          type: :integer,
+          description: "Index value of the coin to receive"
+        },
+        dx: %{
+          type: :string,
+          description: "Amount of i being exchanged"
+        },
+        min_dy: %{
+          type: :string,
+          description: "Minimum amount of j to receive"
+        }
+      },
+      required: ["pool_address", "i", "j", "dx", "min_dy"]
+    },
+    output_schema: %{
+      type: :object,
+      properties: %{
+        transaction_hash: %{
+          type: :string,
+          description: "Transaction hash"
+        }
+      },
+      required: ["transaction_hash"]
+    }
+
+  alias Lux.Integrations.Curve.Pool
+  require Logger
+
+  @impl true
+  def handler(params, _agent) do
+    dx = String.to_integer(params.dx)
+    min_dy = String.to_integer(params.min_dy)
+
+    # Note: Requires Ethers config setup with a valid wallet and RPC
+    case Pool.exchange(
+      params.i,
+      params.j,
+      dx,
+      min_dy,
+      to: params.pool_address
+    ) |> Ethers.send() do
+      {:ok, tx_hash} ->
+        Logger.info("Successfully executed Curve swap: #{tx_hash}")
+        {:ok, %{transaction_hash: tx_hash}}
+        
+      {:error, reason} ->
+        Logger.error("Failed to execute Curve swap: #{inspect(reason)}")
+        {:error, "Transaction failed: #{inspect(reason)}"}
+    end
+  end
+end


### PR DESCRIPTION
Fixes #81

Implemented Curve Finance integration using `ethers` to interact with Curve StableSwap pool contracts.

### Changes:
- Added Ethers contract definitions for Curve Pool
- Added `GetPoolBalances` and `GetSwapQuote` Lenses
- Added `ExecuteSwap` Prism for token exchanges in a Curve pool

Please send the **$900** bounty payout to the following PayPal link: https://paypal.me/sureshc26