### PR TITLE
feat: Add Coinbase Exchange Integration (Advanced Trade, WebSockets)

### DIFF
--- a/lux/lib/lux/integrations/coinbase.ex
+++ b/lux/lib/lux/integrations/coinbase.ex
@@ -1,0 +1,35 @@
+defmodule Lux.Integrations.Coinbase do
+  @moduledoc """
+  Core settings and authentication utilities for the Coinbase Advanced Trade API integration.
+  """
+
+  @doc """
+  Generates headers for Coinbase API calls including HMAC signatures for authenticated endpoints.
+  """
+  def headers(method, path, body \\ "") do
+    api_key = Application.get_env(:lux, :api_keys)[:coinbase_api_key]
+    api_secret = Application.get_env(:lux, :api_keys)[:coinbase_api_secret]
+
+    base_headers = [{"Content-Type", "application/json"}]
+
+    if api_key && api_secret do
+      timestamp = System.os_time(:second) |> Integer.to_string()
+
+      message = timestamp <> String.upcase(to_string(method)) <> path <> body
+
+      # For standard HMAC based auth (some endpoints / legacy keys)
+      signature =
+        :crypto.mac(:hmac, :sha256, api_secret, message)
+        |> Base.encode16(case: :lower)
+
+      [
+        {"CB-ACCESS-KEY", api_key},
+        {"CB-ACCESS-SIGN", signature},
+        {"CB-ACCESS-TIMESTAMP", timestamp}
+        | base_headers
+      ]
+    else
+      base_headers
+    end
+  end
+end

--- a/lux/lib/lux/integrations/coinbase/client.ex
+++ b/lux/lib/lux/integrations/coinbase/client.ex
@@ -1,0 +1,68 @@
+defmodule Lux.Integrations.Coinbase.Client do
+  @moduledoc """
+  HTTP Client for the Coinbase Advanced Trade REST API.
+  """
+
+  alias Lux.Integrations.Coinbase
+
+  @base_url "https://api.coinbase.com"
+
+  @type request_opts :: %{
+          optional(:signed) => boolean(),
+          optional(:json) => map(),
+          optional(:params) => map()
+        }
+
+  @doc """
+  Makes a request to the Coinbase API.
+
+  ## Parameters
+    * `method` - HTTP method (:get, :post, :put, :delete)
+    * `path` - API endpoint path (e.g. "/api/v3/brokerage/accounts")
+    * `opts` - Request options map
+  """
+  @spec request(atom(), String.t(), request_opts()) :: {:ok, map() | list()} | {:error, term()}
+  def request(method, path, opts \\ %{}) do
+    signed? = Map.get(opts, :signed, false)
+    params = Map.get(opts, :params, %{})
+    json_body = Map.get(opts, :json)
+
+    query_string = if params == %{}, do: "", else: "?" <> URI.encode_query(params)
+    full_path = path <> query_string
+
+    body_str = if json_body, do: Jason.encode!(json_body), else: ""
+
+    headers =
+      if signed? do
+        Coinbase.headers(method, full_path, body_str)
+      else
+        [{"Content-Type", "application/json"}]
+      end
+
+    req_opts =
+      [
+        method: method,
+        url: @base_url <> path,
+        headers: headers,
+        params: params,
+        json: json_body
+      ]
+      |> Keyword.merge(Application.get_env(:lux, __MODULE__, []))
+
+    req = Req.new(req_opts)
+
+    case Req.request(req) do
+      {:ok, %{status: status} = response} when status in 200..299 ->
+        {:ok, response.body}
+
+      {:ok, %{status: status, body: %{"error" => error, "message" => message}}} ->
+        {:error, {status, error, message}}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, {status, body}}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+end

--- a/lux/lib/lux/integrations/coinbase/web_socket.ex
+++ b/lux/lib/lux/integrations/coinbase/web_socket.ex
@@ -1,0 +1,119 @@
+defmodule Lux.Integrations.Coinbase.WebSocket do
+  @moduledoc """
+  WebSocket client for Coinbase Advanced Trade data streams.
+  """
+
+  use WebSockex
+  require Logger
+
+  @ws_url "wss://advanced-trade-ws.coinbase.com"
+
+  @doc """
+  Starts a WebSocket connection to Coinbase Advanced Trade.
+
+  ## Options
+    * `:channels` - List of channels to subscribe to (e.g. ["level2", "ticker"])
+    * `:product_ids` - List of product IDs (e.g. ["BTC-USD", "ETH-USD"])
+    * `:handler` - The PID or a function `fn msg -> ... end` to handle incoming parsed JSON messages.
+  """
+  def start_link(opts) do
+    handler = Keyword.get(opts, :handler, self())
+    channels = Keyword.get(opts, :channels, [])
+    product_ids = Keyword.get(opts, :product_ids, [])
+
+    state = %{
+      handler: handler,
+      channels: channels,
+      product_ids: product_ids
+    }
+
+    case WebSockex.start_link(@ws_url, __MODULE__, state) do
+      {:ok, pid} ->
+        if not Enum.empty?(channels) and not Enum.empty?(product_ids) do
+          subscribe(pid, channels, product_ids)
+        end
+
+        {:ok, pid}
+
+      error ->
+        error
+    end
+  end
+
+  @doc """
+  Subscribes to channels for specific products.
+  """
+  def subscribe(pid, channels, product_ids) when is_list(channels) and is_list(product_ids) do
+    msg = %{
+      "type" => "subscribe",
+      # In advanced trade, usually one channel per message
+      "channel" => hd(channels),
+      "product_ids" => product_ids
+    }
+
+    # Advanced trade requires signature for authenticated channels like "user"
+    # For public channels like "ticker", "level2", "market_trades", signature is optional but recommended
+
+    api_key = Application.get_env(:lux, :api_keys)[:coinbase_api_key]
+    api_secret = Application.get_env(:lux, :api_keys)[:coinbase_api_secret]
+
+    msg =
+      if api_key && api_secret do
+        timestamp = System.os_time(:second) |> Integer.to_string()
+        message = timestamp <> msg["channel"] <> Enum.join(product_ids, ",")
+
+        signature =
+          :crypto.mac(:hmac, :sha256, api_secret, message) |> Base.encode16(case: :lower)
+
+        Map.merge(msg, %{
+          "api_key" => api_key,
+          "timestamp" => timestamp,
+          "signature" => signature
+        })
+      else
+        msg
+      end
+
+    WebSockex.send_frame(pid, {:text, Jason.encode!(msg)})
+  end
+
+  @doc """
+  Unsubscribes from channels.
+  """
+  def unsubscribe(pid, channels, product_ids) when is_list(channels) and is_list(product_ids) do
+    msg = %{
+      "type" => "unsubscribe",
+      "channel" => hd(channels),
+      "product_ids" => product_ids
+    }
+
+    WebSockex.send_frame(pid, {:text, Jason.encode!(msg)})
+  end
+
+  @impl true
+  def handle_frame({:text, msg}, state) do
+    case Jason.decode(msg) do
+      {:ok, decoded} ->
+        notify_handler(state.handler, decoded)
+
+      {:error, _} ->
+        Logger.warning("Failed to decode Coinbase WS message: #{msg}")
+    end
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_disconnect(disconnect_map, state) do
+    Logger.warning("Coinbase WS disconnected: #{inspect(disconnect_map)}")
+    {:reconnect, state}
+  end
+
+  defp notify_handler(pid, msg) when is_pid(pid) do
+    send(pid, {:coinbase_ws_msg, msg})
+  end
+
+  defp notify_handler(fun, msg) when is_function(fun, 1) do
+    fun.(msg)
+  end
+end

--- a/lux/lib/lux/lenses/coinbase/get_account_state.ex
+++ b/lux/lib/lux/lenses/coinbase/get_account_state.ex
@@ -1,0 +1,52 @@
+defmodule Lux.Lenses.Coinbase.GetAccountState do
+  @moduledoc """
+  A lens for retrieving account balances from Coinbase Advanced Trade.
+  """
+
+  use Lux.Lens,
+    name: "Coinbase Account State",
+    description: "Fetches account balances from Coinbase",
+    params: %{
+      limit: %{
+        type: :integer,
+        description: "Number of accounts to return",
+        default: 100
+      }
+    }
+
+  alias Lux.Integrations.Coinbase.Client
+
+  @impl true
+  def focus(params, _assigns) do
+    path = "/api/v3/brokerage/accounts"
+
+    query_params = %{
+      "limit" => Map.get(params, :limit, 100)
+    }
+
+    case Client.request(:get, path, signed: true, params: query_params) do
+      {:ok, response} ->
+        {:ok, normalize_balances(response)}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp normalize_balances(%{"accounts" => accounts} = response) do
+    balances =
+      accounts
+      |> Enum.map(fn a ->
+        %{
+          "asset" => a["currency"],
+          "free" => a["available_balance"]["value"],
+          "locked" => a["hold"]["value"],
+          "uuid" => a["uuid"]
+        }
+      end)
+
+    Map.put(response, "normalized_balances", balances)
+  end
+
+  defp normalize_balances(response), do: response
+end

--- a/lux/lib/lux/prisms/coinbase/cancel_order.ex
+++ b/lux/lib/lux/prisms/coinbase/cancel_order.ex
@@ -1,0 +1,39 @@
+defmodule Lux.Prisms.Coinbase.CancelOrder do
+  @moduledoc """
+  A prism for cancelling orders on Coinbase Advanced Trade.
+  """
+
+  use Lux.Prism,
+    name: "Coinbase Cancel Order",
+    description: "Cancels active trading orders on Coinbase Advanced Trade",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        order_ids: %{
+          type: :array,
+          items: %{type: :string},
+          description: "List of Order IDs to cancel"
+        }
+      },
+      required: ["order_ids"]
+    }
+
+  alias Lux.Integrations.Coinbase.Client
+
+  @impl true
+  def handler(params, _ctx) do
+    path = "/api/v3/brokerage/orders/batch_cancel"
+
+    api_params = %{
+      "order_ids" => params.order_ids
+    }
+
+    case Client.request(:post, path, signed: true, json: api_params) do
+      {:ok, response} ->
+        {:ok, response}
+
+      {:error, error} ->
+        {:error, inspect(error)}
+    end
+  end
+end

--- a/lux/lib/lux/prisms/coinbase/place_order.ex
+++ b/lux/lib/lux/prisms/coinbase/place_order.ex
@@ -1,0 +1,70 @@
+defmodule Lux.Prisms.Coinbase.PlaceOrder do
+  @moduledoc """
+  A prism for placing orders on Coinbase Advanced Trade.
+  """
+
+  use Lux.Prism,
+    name: "Coinbase Place Order",
+    description: "Places a trading order on Coinbase Advanced Trade",
+    input_schema: %{
+      type: :object,
+      properties: %{
+        product_id: %{type: :string, description: "Trading pair (e.g., BTC-USD)"},
+        side: %{type: :string, description: "BUY or SELL"},
+        type: %{type: :string, description: "Order type (LIMIT, MARKET)"},
+        quantity: %{type: :string, description: "Quantity to order"},
+        price: %{type: :string, description: "Price for LIMIT orders (optional)"}
+      },
+      required: ["product_id", "side", "type", "quantity"]
+    }
+
+  alias Lux.Integrations.Coinbase.Client
+
+  @impl true
+  def handler(params, _ctx) do
+    path = "/api/v3/brokerage/orders"
+    client_order_id = System.unique_integer([:positive]) |> to_string()
+
+    order_config =
+      case String.upcase(params.type) do
+        "LIMIT" ->
+          %{
+            "limit_limit_gtc" => %{
+              "base_size" => params.quantity,
+              "limit_price" => params.price,
+              "post_only" => false
+            }
+          }
+
+        "MARKET" ->
+          if String.upcase(params.side) == "BUY" do
+            %{
+              "market_market_ioc" => %{
+                "quote_size" => params.quantity
+              }
+            }
+          else
+            %{
+              "market_market_ioc" => %{
+                "base_size" => params.quantity
+              }
+            }
+          end
+      end
+
+    api_params = %{
+      "client_order_id" => client_order_id,
+      "product_id" => String.upcase(params.product_id),
+      "side" => String.upcase(params.side),
+      "order_configuration" => order_config
+    }
+
+    case Client.request(:post, path, signed: true, json: api_params) do
+      {:ok, response} ->
+        {:ok, response}
+
+      {:error, error} ->
+        {:error, inspect(error)}
+    end
+  end
+end

--- a/lux/test/unit/lux/prisms/coinbase/place_order_test.exs
+++ b/lux/test/unit/lux/prisms/coinbase/place_order_test.exs
@@ -1,0 +1,35 @@
+defmodule Lux.Prisms.Coinbase.PlaceOrderTest do
+  use ExUnit.Case, async: false
+
+  import Mock
+  alias Lux.Prisms.Coinbase.PlaceOrder
+  alias Lux.Integrations.Coinbase.Client
+
+  @moduletag :unit
+
+  describe "handler/2" do
+    test "successfully places a limit order" do
+      params = %{
+        product_id: "BTC-USD",
+        side: "BUY",
+        type: "LIMIT",
+        quantity: "1.5",
+        price: "65000.0"
+      }
+
+      with_mock Client,
+        request: fn :post, "/api/v3/brokerage/orders", opts ->
+          assert opts[:signed] == true
+          assert opts[:json]["product_id"] == "BTC-USD"
+          assert opts[:json]["side"] == "BUY"
+          assert opts[:json]["order_configuration"]["limit_limit_gtc"]["limit_price"] == "65000.0"
+
+          {:ok, %{"success" => true, "order_id" => "111-222"}}
+        end do
+        assert {:ok, result} = PlaceOrder.handler(params, %{})
+        assert result["success"] == true
+        assert result["order_id"] == "111-222"
+      end
+    end
+  end
+end


### PR DESCRIPTION
hey, put together the coinbase integration for #83. wired up the new advanced trade api since the old pro one is dead. built out the hmac auth for the private routes and got the websockets hooked up for the public market streams. should be good to go, let me know if u need any tweaks.