### PR TITLE
feat(integrations): add Uniswap V3 integration with fee-tier selection and price-range helpers

### DIFF
--- a/lux/lib/lux/integrations/uniswap_v3.ex
+++ b/lux/lib/lux/integrations/uniswap_v3.ex
@@ -1,0 +1,118 @@
+defmodule Lux.Integrations.UniswapV3 do
+  @moduledoc """
+  Lux integration for Uniswap V3 concentrated liquidity.
+
+  Provides contract addresses, fee-tier selection, price-range helpers,
+  and configuration accessors for RPC / subgraph connectivity.
+
+  ## Configuration
+
+      config :lux, Lux.Integrations.UniswapV3,
+        rpc_url:       System.get_env("ETH_RPC_URL"),
+        subgraph_url:  System.get_env("UNISWAP_SUBGRAPH_URL"),
+        chain_id:      System.get_env("CHAIN_ID") || "1"
+
+  ## Mainnet contract addresses
+
+  | Contract                      | Address                                    |
+  |-------------------------------|--------------------------------------------|
+  | Factory                       | 0x1F98431c8aD98523631AE4a59f267346ea31F984 |
+  | NonfungiblePositionManager    | 0xC36442b4a4522E871399CD717aBDD847Ab11FE88 |
+  | SwapRouter                    | 0xE592427A0AEce92De3Edee1F18E0157C05861564 |
+  | QuoterV2                      | 0x61fFE014bA17989E743c5F6cB21bF9697530B21e |
+
+  ## Fee tiers
+
+  | Tier     | bps  | Suited for          |
+  |----------|------|---------------------|
+  | :lowest  |  100 | Stablecoin pairs    |
+  | :low     |  500 | Stable-major pairs  |
+  | :medium  | 3000 | Major-major pairs   |
+  | :high    |10000 | Exotic / long-tail  |
+  """
+
+  @factory          "0x1F98431c8aD98523631AE4a59f267346ea31F984"
+  @position_manager "0xC36442b4a4522E871399CD717aBDD847Ab11FE88"
+  @swap_router      "0xE592427A0AEce92De3Edee1F18E0157C05861564"
+  @quoter_v2        "0x61fFE014bA17989E743c5F6cB21bF9697530B21e"
+
+  @fee_tiers %{lowest: 100, low: 500, medium: 3_000, high: 10_000}
+
+  def factory,          do: @factory
+  def position_manager, do: @position_manager
+  def swap_router,      do: @swap_router
+  def quoter_v2,        do: @quoter_v2
+  def fee_tiers,        do: @fee_tiers
+
+  @doc "Ethereum JSON-RPC endpoint URL."
+  def rpc_url do
+    Application.get_env(:lux, __MODULE__, [])[:rpc_url] ||
+      System.get_env("ETH_RPC_URL") ||
+      raise ArgumentError, "ETH_RPC_URL not configured for #{__MODULE__}"
+  end
+
+  @doc "Uniswap V3 subgraph URL."
+  def subgraph_url do
+    Application.get_env(:lux, __MODULE__, [])[:subgraph_url] ||
+      System.get_env("UNISWAP_SUBGRAPH_URL") ||
+      "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3"
+  end
+
+  @doc "Chain ID string (default: \"1\" = Ethereum mainnet)."
+  def chain_id do
+    Application.get_env(:lux, __MODULE__, [])[:chain_id] ||
+      System.get_env("CHAIN_ID") ||
+      "1"
+  end
+
+  @doc "Base JSON headers for RPC calls."
+  def headers do
+    [{"Accept", "application/json"}, {"Content-Type", "application/json"}]
+  end
+
+  @doc "Headers for subgraph GraphQL calls (adds Bearer token when GRAPH_API_KEY is set)."
+  def subgraph_headers do
+    base = [{"Accept", "application/json"}, {"Content-Type", "application/json"}]
+    case System.get_env("GRAPH_API_KEY") do
+      nil -> base
+      key -> [{"Authorization", "Bearer #{key}"} | base]
+    end
+  end
+
+  @doc """
+  Picks the optimal fee tier for a token pair.
+
+  Heuristic:
+  - stable/stable  → :lowest (0.01%)
+  - stable/major   → :low    (0.05%)
+  - major/major    → :medium (0.30%)
+  - everything else → :high  (1.00%)
+  """
+  @spec select_fee_tier(String.t(), String.t()) :: :lowest | :low | :medium | :high
+  def select_fee_tier(token0, token1) do
+    stables = MapSet.new(~w[USDC USDT DAI FRAX LUSD crvUSD])
+    majors  = MapSet.new(~w[WETH ETH WBTC BTC])
+    t0 = String.upcase(token0)
+    t1 = String.upcase(token1)
+    cond do
+      MapSet.member?(stables, t0) and MapSet.member?(stables, t1) -> :lowest
+      MapSet.member?(stables, t0) or  MapSet.member?(stables, t1) -> :low
+      MapSet.member?(majors,  t0) and MapSet.member?(majors,  t1) -> :medium
+      true -> :high
+    end
+  end
+
+  @doc """
+  Returns a symmetric price range `{lower, upper}` centred on `current_price`.
+
+  `range_factor` defaults to 0.10 (±10%).  Increase for wider, more passive
+  ranges; decrease for tighter, higher-fee-capture ranges.
+  """
+  @spec compute_price_range(number(), float()) :: {float(), float()}
+  def compute_price_range(current_price, range_factor \\ 0.10)
+      when is_number(current_price) and is_float(range_factor) do
+    lower = current_price * (1.0 - range_factor)
+    upper = current_price * (1.0 + range_factor)
+    {lower, upper}
+  end
+end

--- a/lux/lib/lux/lenses/uniswap_v3/get_pool_data.ex
+++ b/lux/lib/lux/lenses/uniswap_v3/get_pool_data.ex
@@ -1,0 +1,40 @@
+defmodule Lux.Lenses.UniswapV3.GetPoolData do
+  @moduledoc "Lens for Uniswap V3 pool data via the subgraph."
+
+  alias Lux.Integrations.UniswapV3
+  @subgraph_url UniswapV3.subgraph_url()
+  @headers      UniswapV3.subgraph_headers()
+
+  @spec focus(%{pool_address: String.t()}) :: {:ok, map()} | {:error, term()}
+  def focus(%{pool_address: addr}) do
+    q = Jason.encode!(%{query: "{ pool(id: \\"#{String.downcase(addr)}\\") { id token0 { id symbol decimals } token1 { id symbol decimals } feeTier liquidity sqrtPrice tick token0Price token1Price volumeUSD totalValueLockedUSD feesUSD txCount } }"})
+    case Req.post(@subgraph_url, body: q, headers: @headers) do
+      {:ok, %{status: 200, body: %{"data" => %{"pool" => nil}}}} -> {:error, "Pool not found"}
+      {:ok, %{status: 200, body: %{"data" => %{"pool" => pool}}}} -> {:ok, parse_pool(pool)}
+      {:ok, %{status: 200, body: %{"errors" => e}}} -> {:error, e}
+      {:ok, %{status: s}} -> {:error, "HTTP #{s}"}
+      err -> err
+    end
+  end
+
+  defp parse_pool(p) do
+    %{address: p["id"], token0: p["token0"], token1: p["token1"],
+      fee_tier: to_int(p["feeTier"]), liquidity: p["liquidity"],
+      sqrt_price: p["sqrtPrice"], current_tick: to_int(p["tick"]),
+      token0_price: to_float(p["token0Price"]), token1_price: to_float(p["token1Price"]),
+      volume_usd: to_float(p["volumeUSD"]), tvl_usd: to_float(p["totalValueLockedUSD"]),
+      fees_usd: to_float(p["feesUSD"]), tx_count: to_int(p["txCount"])}
+  end
+
+  defp to_int(nil), do: nil
+  defp to_int(s) when is_binary(s), do: String.to_integer(s)
+  defp to_int(n) when is_integer(n), do: n
+  defp to_float(nil), do: nil
+  defp to_float(s) when is_binary(s) do
+    case Float.parse(s) do
+      {f, _} -> f
+      :error -> nil
+    end
+  end
+  defp to_float(n) when is_number(n), do: n / 1
+end


### PR DESCRIPTION
## Summary
Partial implementation of #78 - Uniswap V3 Integration and Liquidity Management (00)

## Changes

### lux/lib/lux/integrations/uniswap_v3.ex
- Contract addresses (Factory, PositionManager, SwapRouter, QuoterV2)
- All four fee tiers with semantic names (:lowest/:low/:medium/:high)
- rpc_url/0, subgraph_url/0, chain_id/0 config accessors
- headers/0 and subgraph_headers/0 (adds Bearer token when GRAPH_API_KEY set)
- select_fee_tier/2: heuristic fee tier selection based on token stability
- compute_price_range/2: symmetric ±N% range around current price

### lux/lib/lux/lenses/uniswap_v3/get_pool_data.ex
- GetPoolData lens querying Uniswap V3 subgraph
- Returns parsed pool: tokens, fee tier, price, liquidity, TVL, volume, fees
- Handles pool-not-found, subgraph errors, HTTP errors

## Pattern
Follows existing Allora/Discord/Telegram integration pattern exactly.