### PR TITLE
feat(llm): add Ollama local model integration (#96)

### DIFF
--- a/lux/lib/lux/llm/ollama.ex
+++ b/lux/lib/lux/llm/ollama.ex
@@ -37,8 +37,6 @@ defmodule Lux.LLM.Ollama do
 
   @default_endpoint "http://localhost:11434"
   @default_model "llama3.3"
-  @max_retries 3
-  @retry_delay 1000
 
   defmodule Config do
     @moduledoc "Configuration for Ollama integration."
@@ -142,18 +140,17 @@ defmodule Lux.LLM.Ollama do
 
   defp build_tools_config([]), do: []
 
-  defp build_tools_config(tools) do
-    Enum.flat_map(tools, &tool_to_function/1)
-  end
+  defp build_tools_config(tools),
+    do: Enum.map(tools, &tool_to_function/1) |> Enum.reject(&is_nil/1)
 
-  defp tool_to_function({:python, _path}), do: []
+  defp tool_to_function({:python, _path}), do: nil
 
   defp tool_to_function(tool_module) when is_atom(tool_module) and not is_nil(tool_module) do
     cond do
       Lux.prism?(tool_module) -> tool_to_function(Lux.Prism.view(tool_module))
       Lux.beam?(tool_module) -> tool_to_function(Lux.Beam.view(tool_module))
       Lux.lens?(tool_module) -> tool_to_function(Lux.Lens.view(tool_module))
-      true -> []
+      true -> nil
     end
   end
 
@@ -223,30 +220,20 @@ defmodule Lux.LLM.Ollama do
 
     system_prompt = config.system || "You are a helpful AI assistant powered by Ollama."
 
-    messages = [
-      %{role: "system", content: system_prompt}
-      | build_messages(prompt, tools, config)
-    ]
+    messages = [%{role: "system", content: system_prompt}, %{role: "user", content: prompt}]
 
     tool_defs = build_tools_config(tools)
 
-    payload = %{
-      model: config.model,
-      messages: messages,
-      stream: false,
-      options: build_options(config)
-    }
-
-    # Add tools field if tool definitions exist (Ollama API contract)
-    payload = if Enum.empty?(tool_defs), do: payload, else: Map.put(payload, :tools, tool_defs)
-
-    if config.format do
-      payload = Map.put(payload, :format, config.format)
-    end
-
-    if config.keep_alive do
-      payload = Map.put(payload, :keep_alive, config.keep_alive)
-    end
+    payload =
+      %{
+        model: config.model,
+        messages: messages,
+        stream: config.stream,
+        options: build_options(config)
+      }
+      |> maybe_put(:tools, tool_defs, tool_defs != [])
+      |> maybe_put(:format, config.format, not is_nil(config.format))
+      |> maybe_put(:keep_alive, config.keep_alive, not is_nil(config.keep_alive))
 
     endpoint = config.endpoint || @default_endpoint
     url = "#{endpoint}/api/chat"
@@ -257,8 +244,11 @@ defmodule Lux.LLM.Ollama do
 
     result =
       case do_call(url, payload, headers, config) do
-        {:ok, response_body} -> handle_ollama_response(response_body, config)
-        {:error, reason} -> {:error, "Ollama call failed: #{reason}"}
+        {:ok, response_body} ->
+          handle_chat_response(response_body, payload, tools, headers, config)
+
+        {:error, reason} ->
+          {:error, "Ollama call failed: #{reason}"}
       end
 
     # Record performance metrics
@@ -278,18 +268,8 @@ defmodule Lux.LLM.Ollama do
     end
   end
 
-  defp build_messages(prompt, tools, config) do
-    user_content = %{role: "user", content: prompt}
-
-    tool_defs = build_tools_config(tools)
-
-    if Enum.empty?(tool_defs) do
-      [user_content]
-    else
-      # Send tools via the Ollama tools field, not as system message
-      [user_content]
-    end
-  end
+  defp maybe_put(map, key, value, true), do: Map.put(map, key, value)
+  defp maybe_put(map, _key, _value, false), do: map
 
   defp build_options(config) do
     opts = %{
@@ -305,21 +285,43 @@ defmodule Lux.LLM.Ollama do
   end
 
   defp do_call(url, payload, headers, config) do
-    case Req.post(url,
-           json: payload,
-           headers: headers,
-           timeout: config.timeout,
-           recv_timeout: config.timeout
-         ) do
+    opts =
+      [json: payload, headers: headers, timeout: config.timeout, receive_timeout: config.timeout]
+      |> Keyword.merge(Application.get_env(:lux, __MODULE__, []))
+
+    case Req.post(url, opts) do
       {:ok, %{status: 200, body: body}} -> {:ok, body}
       {:ok, %{status: status, body: body}} -> {:error, "HTTP #{status}: #{inspect(body)}"}
       {:error, reason} -> {:error, inspect(reason)}
     end
   end
 
+  defp handle_chat_response(
+         %{"message" => %{"tool_calls" => calls} = assistant},
+         payload,
+         tools,
+         headers,
+         config
+       )
+       when is_list(calls) and calls != [] do
+    with {:ok, tool_messages, results} <- execute_tool_calls(calls, tools),
+         followup_payload <- %{
+           payload
+           | messages: payload.messages ++ [assistant] ++ tool_messages
+         },
+         {:ok, body} <- do_call("#{config.endpoint}/api/chat", followup_payload, headers, config),
+         {:ok, signal} <- handle_ollama_response(body, config, results) do
+      {:ok, signal}
+    end
+  end
+
+  defp handle_chat_response(body, _payload, _tools, _headers, config),
+    do: handle_ollama_response(body, config, nil)
+
   defp handle_ollama_response(
          %{"message" => %{"content" => content, "tool_calls" => tool_calls}} = resp,
-         _config
+         _config,
+         tool_results
        ) do
     metadata = %{
       model: Map.get(resp, "model"),
@@ -329,49 +331,67 @@ defmodule Lux.LLM.Ollama do
       provider: :ollama
     }
 
-    signal = ResponseSignal.new(%{}, metadata)
-    {:ok, Lux.Signal.new(%{content: content, tool_calls: tool_calls}, signal)}
+    response_payload = %{
+      content: content_map(content),
+      model: resp["model"] || "ollama",
+      finish_reason: if(tool_calls in [nil, []], do: "stop", else: "tool_calls"),
+      tool_calls: tool_calls,
+      tool_calls_results: tool_results
+    }
+
+    %{schema_id: ResponseSignal, payload: response_payload, metadata: metadata}
+    |> Lux.Signal.new()
+    |> ResponseSignal.validate()
   end
 
-  defp handle_ollama_response(%{"message" => %{"content" => content}}, _config)
+  defp handle_ollama_response(
+         %{"message" => %{"content" => content} = message} = resp,
+         config,
+         results
+       )
        when is_binary(content) do
-    {:ok, Lux.Signal.new(%{content: content}, ResponseSignal, %{provider: :ollama})}
+    handle_ollama_response(
+      %{resp | "message" => Map.put(message, "tool_calls", nil)},
+      config,
+      results
+    )
   end
 
-  defp handle_ollama_response(%{"error" => error}), do: {:error, "Ollama error: #{error}"}
-  defp handle_ollama_response(_), do: {:error, "Unexpected Ollama response format"}
+  defp handle_ollama_response(%{"error" => error}, _config, _results),
+    do: {:error, "Ollama error: #{error}"}
+
+  defp handle_ollama_response(_, _config, _results),
+    do: {:error, "Unexpected Ollama response format"}
+
+  defp content_map(nil), do: nil
+  defp content_map(content) when is_map(content), do: content
+  defp content_map(content) when is_binary(content), do: %{"text" => content}
 
   # ---- Tool Call Execution ----
 
-  defp execute_tool_calls(nil), do: {:ok, nil}
-  defp execute_tool_calls([]), do: {:ok, []}
+  defp execute_tool_calls(calls, tools) do
+    modules = Map.new(tools, fn module -> {tool_name(module), module} end)
 
-  defp execute_tool_calls(tool_calls) when is_list(tool_calls) do
-    results = tool_calls |> Enum.map(&execute_tool_call/1) |> Enum.filter(&(&1 != :skip))
-    {:ok, results}
+    Enum.reduce_while(calls, {:ok, [], []}, fn call, {:ok, messages, results} ->
+      with %{"function" => %{"name" => name, "arguments" => raw_args}} <- call,
+           {:ok, args} <- normalize_arguments(raw_args),
+           module when not is_nil(module) <- modules[name],
+           {:ok, result} <- execute_module_tool(module, args) do
+        message = %{role: "tool", tool_name: name, content: Jason.encode!(result)}
+        {:cont, {:ok, messages ++ [message], results ++ [result]}}
+      else
+        error -> {:halt, {:error, "Ollama tool call failed: #{inspect(error)}"}}
+      end
+    end)
   end
 
-  defp execute_tool_call(%{"function" => %{"name" => tool_name, "arguments" => args}}) do
-    try do
-      args = Jason.decode!(args)
-      execute_tool(tool_name, args)
-    rescue
-      _ -> :skip
-    end
-  end
+  defp normalize_arguments(args) when is_map(args), do: {:ok, args}
+  defp normalize_arguments(args) when is_binary(args), do: Jason.decode(args)
+  defp normalize_arguments(_), do: {:error, :invalid_arguments}
 
-  defp execute_tool_call(_), do: :skip
-
-  defp execute_tool(tool_name, args) when is_binary(tool_name) do
-    tool_name
-    |> String.replace("_", ".")
-    |> List.wrap()
-    |> Module.concat()
-    |> Code.ensure_loaded()
-    |> case do
-      {:module, module} -> execute_module_tool(module, args)
-      _ -> :skip
-    end
+  defp tool_name(module) do
+    [definition] = build_tools_config([module])
+    definition.function.name
   end
 
   defp execute_module_tool(module, args) when is_atom(module) do
@@ -391,7 +411,7 @@ defmodule Lux.LLM.Ollama do
     endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
     url = "#{endpoint}/api/tags"
 
-    case Req.get(url) do
+    case Req.get(url, Application.get_env(:lux, __MODULE__, [])) do
       {:ok, %{status: 200, body: %{"models" => models}}} ->
         {:ok, Enum.map(models, &parse_model/1)}
 
@@ -422,7 +442,7 @@ defmodule Lux.LLM.Ollama do
     # Ollama API uses "model" field, not "name"
     payload = %{model: model_name, stream: false}
 
-    case Req.post(url, json: payload) do
+    case Req.post(url, Keyword.merge([json: payload], Application.get_env(:lux, __MODULE__, []))) do
       {:ok, %{status: 200, body: body}} ->
         {:ok, body}
 
@@ -443,22 +463,26 @@ defmodule Lux.LLM.Ollama do
     # Ollama API uses "model" field, not "name"
     payload = %{model: model_name, stream: true}
 
-    case Req.post(url, json: payload, recv: :stream) do
-      {:ok, %{status: 200} = _resp} = _resp ->
+    opts =
+      [json: payload, decode_body: false]
+      |> Keyword.merge(Application.get_env(:lux, __MODULE__, []))
+
+    case Req.post(url, opts) do
+      {:ok, %{status: 200, body: body}} when is_binary(body) ->
+        lines = String.split(body, "\n", trim: true)
+
         {:ok,
          Stream.resource(
-           fn -> :ok end,
-           fn state ->
-             # In a real implementation, this would read from the response stream.
-             # For now, return an empty stream since Req streaming requires special handling.
-             if state == :ok do
-               [{:ok, %{progress: "streaming initialized"}}]
-             else
-               []
-             end
+           fn -> lines end,
+           fn
+             [] -> {:halt, []}
+             [line | rest] -> {[Jason.decode!(line)], rest}
            end,
            fn _ -> :ok end
          )}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, "Pull failed: HTTP #{status}: #{inspect(body)}"}
 
       {:error, reason} ->
         {:error, "Pull failed: #{inspect(reason)}"}
@@ -471,7 +495,10 @@ defmodule Lux.LLM.Ollama do
     endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
     url = "#{endpoint}/api/delete"
 
-    case Req.delete(url, json: %{model: model_name}) do
+    case Req.delete(
+           url,
+           Keyword.merge([json: %{model: model_name}], Application.get_env(:lux, __MODULE__, []))
+         ) do
       {:ok, %{status: 200, body: body}} -> {:ok, body}
       {:ok, %{status: status}} -> {:error, "Delete failed: HTTP #{status}"}
       {:error, reason} -> {:error, "Delete failed: #{inspect(reason)}"}
@@ -486,7 +513,7 @@ defmodule Lux.LLM.Ollama do
 
     payload = %{model: model_name}
 
-    case Req.post(url, json: payload) do
+    case Req.post(url, Keyword.merge([json: payload], Application.get_env(:lux, __MODULE__, []))) do
       {:ok, %{status: 200, body: body}} -> {:ok, body}
       {:ok, %{status: status}} -> {:error, "Show failed: HTTP #{status}"}
       {:error, reason} -> {:error, "Show failed: #{inspect(reason)}"}
@@ -501,7 +528,7 @@ defmodule Lux.LLM.Ollama do
 
     payload = %{source: source, destination: destination}
 
-    case Req.post(url, json: payload) do
+    case Req.post(url, Keyword.merge([json: payload], Application.get_env(:lux, __MODULE__, []))) do
       {:ok, %{status: 200, body: body}} -> {:ok, body}
       {:ok, %{status: status}} -> {:error, "Copy failed: HTTP #{status}"}
       {:error, reason} -> {:error, "Copy failed: #{inspect(reason)}"}
@@ -514,7 +541,7 @@ defmodule Lux.LLM.Ollama do
     endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
     url = "#{endpoint}/api/version"
 
-    case Req.get(url) do
+    case Req.get(url, Application.get_env(:lux, __MODULE__, [])) do
       {:ok, %{status: 200, body: body}} -> {:ok, body}
       {:ok, %{status: status}} -> {:error, "Health check failed: HTTP #{status}"}
       {:error, reason} -> {:error, "Ollama not reachable: #{inspect(reason)}"}

--- a/lux/lib/lux/llm/ollama.ex
+++ b/lux/lib/lux/llm/ollama.ex
@@ -79,7 +79,12 @@ defmodule Lux.LLM.Ollama do
   @perf_key {:lux_ollama_perf, __MODULE__}
 
   @doc "Records a performance metric entry."
-  @spec record_perf(model :: String.t(), prompt_tokens :: integer(), output_tokens :: integer(), duration_ms :: integer()) :: :ok
+  @spec record_perf(
+          model :: String.t(),
+          prompt_tokens :: integer(),
+          output_tokens :: integer(),
+          duration_ms :: integer()
+        ) :: :ok
   def record_perf(model, prompt_tokens, output_tokens, duration_ms) do
     entry = %{
       model: model,
@@ -88,6 +93,7 @@ defmodule Lux.LLM.Ollama do
       duration_ms: duration_ms,
       timestamp: DateTime.utc_now()
     }
+
     current = :persistent_term.get(@perf_key, [])
     :persistent_term.put(@perf_key, [entry | current])
     :ok
@@ -113,10 +119,12 @@ defmodule Lux.LLM.Ollama do
   @spec perf_summary() :: map()
   def perf_summary do
     metrics = performance_metrics()
+
     if Enum.empty?(metrics) do
       %{total_requests: 0, avg_duration_ms: 0, avg_prompt_tokens: 0, avg_output_tokens: 0}
     else
       total = length(metrics)
+
       %{
         total_requests: total,
         avg_duration_ms: Enum.sum(Enum.map(metrics, & &1.duration_ms)) / total,
@@ -145,16 +153,45 @@ defmodule Lux.LLM.Ollama do
     end
   end
 
-  defp tool_to_function(%Lux.Beam{module_name: name, description: description, input_schema: input_schema}) do
-    %{type: "function", function: %{name: String.replace(name, ".", "_"), description: description || "", parameters: input_schema}}
+  defp tool_to_function(%Lux.Beam{
+         module_name: name,
+         description: description,
+         input_schema: input_schema
+       }) do
+    %{
+      type: "function",
+      function: %{
+        name: String.replace(name, ".", "_"),
+        description: description || "",
+        parameters: input_schema
+      }
+    }
   end
 
-  defp tool_to_function(%Lux.Prism{module_name: name, description: description, input_schema: input_schema}) do
-    %{type: "function", function: %{name: String.replace(name, ".", "_"), description: description || "", parameters: input_schema}}
+  defp tool_to_function(%Lux.Prism{
+         module_name: name,
+         description: description,
+         input_schema: input_schema
+       }) do
+    %{
+      type: "function",
+      function: %{
+        name: String.replace(name, ".", "_"),
+        description: description || "",
+        parameters: input_schema
+      }
+    }
   end
 
   defp tool_to_function(%Lux.Lens{module_name: name, description: description, schema: schema}) do
-    %{type: "function", function: %{name: String.replace(name, ".", "_"), description: description || "", parameters: schema}}
+    %{
+      type: "function",
+      function: %{
+        name: String.replace(name, ".", "_"),
+        description: description || "",
+        parameters: schema
+      }
+    }
   end
 
   defp tool_to_function(_), do: []
@@ -163,10 +200,14 @@ defmodule Lux.LLM.Ollama do
 
   @impl true
   def call(prompt, tools, config) when is_list(tools) do
-    config = struct(Config, Map.merge(
-      %{api_key: Application.get_env(:lux, :api_keys, [])[:ollama]},
-      Keyword.into(Map.to_list(config || %{}), %{})
-    ))
+    config =
+      struct(
+        Config,
+        Map.merge(
+          %{api_key: Application.get_env(:lux, :api_keys, [])[:ollama]},
+          Keyword.into(Map.to_list(config || %{}), %{})
+        )
+      )
 
     system_prompt = config.system || "You are a helpful AI assistant powered by Ollama."
 
@@ -208,6 +249,7 @@ defmodule Lux.LLM.Ollama do
       [user_content]
     else
       tool_defs = build_tools_config(tools)
+
       if Enum.empty?(tool_defs) do
         [user_content]
       else
@@ -215,8 +257,9 @@ defmodule Lux.LLM.Ollama do
         You have access to the following tools. When appropriate, use them to help answer the user's question.
 
         Tool definitions:
-        #{Enum.map_join(tool_defs, "\n", &Jason.encode!(&1) |> String.trim_leading("{") |> String.trim_trailing("}"))}
+        #{Enum.map_join(tool_defs, "\n", &(Jason.encode!(&1) |> String.trim_leading("{") |> String.trim_trailing("}")))}
         """
+
         [
           %{role: "system", content: tool_instruction},
           user_content
@@ -239,14 +282,22 @@ defmodule Lux.LLM.Ollama do
   end
 
   defp do_call(url, payload, headers, config) do
-    case Req.post(url, json: payload, headers: headers, timeout: config.timeout, recv_timeout: config.timeout) do
+    case Req.post(url,
+           json: payload,
+           headers: headers,
+           timeout: config.timeout,
+           recv_timeout: config.timeout
+         ) do
       {:ok, %{status: 200, body: body}} -> {:ok, body}
       {:ok, %{status: status, body: body}} -> {:error, "HTTP #{status}: #{inspect(body)}"}
       {:error, reason} -> {:error, inspect(reason)}
     end
   end
 
-  defp handle_ollama_response(%{"message" => %{"content" => content, "tool_calls" => tool_calls}} = resp, _config) do
+  defp handle_ollama_response(
+         %{"message" => %{"content" => content, "tool_calls" => tool_calls}} = resp,
+         _config
+       ) do
     metadata = %{
       model: Map.get(resp, "model"),
       prompt_tokens: Map.get(resp, "prompt_eval_count"),
@@ -259,7 +310,8 @@ defmodule Lux.LLM.Ollama do
     {:ok, Lux.Signal.new(%{}, signal)}
   end
 
-  defp handle_ollama_response(%{"message" => %{"content" => content}}, _config) when is_binary(content) do
+  defp handle_ollama_response(%{"message" => %{"content" => content}}, _config)
+       when is_binary(content) do
     {:ok, Lux.Signal.new(%{content: content}, ResponseSignal, %{provider: :ollama})}
   end
 
@@ -319,8 +371,10 @@ defmodule Lux.LLM.Ollama do
     case Req.get(url) do
       {:ok, %{status: 200, body: %{"models" => models}}} ->
         {:ok, Enum.map(models, &parse_model/1)}
+
       {:ok, %{status: status}} ->
         {:error, "Failed to list models: HTTP #{status}"}
+
       {:error, reason} ->
         {:error, "Failed to connect to Ollama: #{inspect(reason)}"}
     end
@@ -345,9 +399,14 @@ defmodule Lux.LLM.Ollama do
     payload = %{name: model_name, stream: false}
 
     case Req.post(url, json: payload) do
-      {:ok, %{status: 200, body: body}} -> {:ok, body}
-      {:ok, %{status: status, body: body}} -> {:error, "Pull failed: HTTP #{status}: #{inspect(body)}"}
-      {:error, reason} -> {:error, "Pull failed: #{inspect(reason)}"}
+      {:ok, %{status: 200, body: body}} ->
+        {:ok, body}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, "Pull failed: HTTP #{status}: #{inspect(body)}"}
+
+      {:error, reason} ->
+        {:error, "Pull failed: #{inspect(reason)}"}
     end
   end
 
@@ -360,8 +419,12 @@ defmodule Lux.LLM.Ollama do
     payload = %{name: model_name, stream: true}
 
     case Req.post(url, json: payload, recv: :stream) do
-      {:ok, %{status: 200}} = resp -> {:ok, Stream.resource(fn -> resp do -> resp end, fn -> fn acc -> acc end end, fn _ -> :ok end)}
-      {:error, reason} -> {:error, "Pull failed: #{inspect(reason)}"}
+      {:ok, %{status: 200}} = resp ->
+        {:ok,
+         Stream.resource(fn -> resp end, fn resp -> fn chunk -> chunk end end, fn _ -> :ok end)}
+
+      {:error, reason} ->
+        {:error, "Pull failed: #{inspect(reason)}"}
     end
   end
 

--- a/lux/lib/lux/llm/ollama.ex
+++ b/lux/lib/lux/llm/ollama.ex
@@ -45,6 +45,8 @@ defmodule Lux.LLM.Ollama do
     @type t :: %__MODULE__{
             endpoint: String.t(),
             model: String.t(),
+            api_key: String.t() | nil,
+            system: String.t() | nil,
             temperature: float(),
             max_tokens: integer() | nil,
             timeout: integer(),
@@ -58,8 +60,10 @@ defmodule Lux.LLM.Ollama do
             max_retries: integer(),
             retry_delay: integer()
           }
-    defstruct endpoint: @default_endpoint,
-              model: @default_model,
+    defstruct endpoint: "http://localhost:11434",
+              model: "llama3.3",
+              api_key: nil,
+              system: nil,
               temperature: 0.7,
               max_tokens: nil,
               timeout: 120_000,
@@ -70,8 +74,8 @@ defmodule Lux.LLM.Ollama do
               top_k: 40,
               num_ctx: 4096,
               num_predict: nil,
-              max_retries: @max_retries,
-              retry_delay: @retry_delay
+              max_retries: 3,
+              retry_delay: 1000
   end
 
   # ---- Performance Monitoring ----
@@ -134,7 +138,7 @@ defmodule Lux.LLM.Ollama do
     end
   end
 
-  # ---- Tool Conversion (matches OpenRouter pattern) ----
+  # ---- Tool Conversion (matches OpenAI pattern) ----
 
   defp build_tools_config([]), do: []
 
@@ -183,7 +187,11 @@ defmodule Lux.LLM.Ollama do
     }
   end
 
-  defp tool_to_function(%Lux.Lens{module_name: name, description: description, schema: schema}) do
+  defp tool_to_function(%Lux.Lens{
+         module_name: name,
+         description: description,
+         schema: schema
+       }) do
     %{
       type: "function",
       function: %{
@@ -194,17 +202,21 @@ defmodule Lux.LLM.Ollama do
     }
   end
 
-  defp tool_to_function(_), do: []
+  # ---- Chat ----
 
-  # ---- Main API Call ----
-
+  @doc "Calls the Ollama API with the given prompt, tools, and config."
   @impl true
+  @spec call(prompt :: String.t(), tools :: list(), config :: map()) ::
+          {:ok, Lux.Signal.t()} | {:error, String.t()}
   def call(prompt, tools, config) when is_list(tools) do
     config =
       struct(
         Config,
         Map.merge(
-          %{api_key: Application.get_env(:lux, :api_keys, [])[:ollama]},
+          %{
+            api_key: Application.get_env(:lux, :api_keys, [])[:ollama],
+            model: Application.get_env(:lux, Lux.LLM.Ollama, [])[:default_model] || @default_model
+          },
           Keyword.into(Map.to_list(config || %{}), %{})
         )
       )
@@ -216,12 +228,17 @@ defmodule Lux.LLM.Ollama do
       | build_messages(prompt, tools, config)
     ]
 
+    tool_defs = build_tools_config(tools)
+
     payload = %{
       model: config.model,
       messages: messages,
       stream: false,
       options: build_options(config)
     }
+
+    # Add tools field if tool definitions exist (Ollama API contract)
+    payload = if Enum.empty?(tool_defs), do: payload, else: Map.put(payload, :tools, tool_defs)
 
     if config.format do
       payload = Map.put(payload, :format, config.format)
@@ -236,35 +253,41 @@ defmodule Lux.LLM.Ollama do
 
     headers = [{"Content-Type", "application/json"}]
 
-    case do_call(url, payload, headers, config) do
-      {:ok, response_body} -> handle_ollama_response(response_body, config)
-      {:error, reason} -> {:error, "Ollama call failed: #{reason}"}
+    start_time = System.monotonic_time(:millisecond)
+
+    result =
+      case do_call(url, payload, headers, config) do
+        {:ok, response_body} -> handle_ollama_response(response_body, config)
+        {:error, reason} -> {:error, "Ollama call failed: #{reason}"}
+      end
+
+    # Record performance metrics
+    case result do
+      {:ok, signal} ->
+        metadata = ResponseSignal.metadata(signal)
+        duration = System.monotonic_time(:millisecond) - start_time
+        prompt_tokens = Map.get(metadata, :prompt_tokens, 0)
+        output_tokens = Map.get(metadata, :output_tokens, 0)
+        record_perf(config.model, prompt_tokens, output_tokens, duration)
+        result
+
+      {:error, _} ->
+        duration = System.monotonic_time(:millisecond) - start_time
+        record_perf(config.model, 0, 0, duration)
+        result
     end
   end
 
   defp build_messages(prompt, tools, config) do
     user_content = %{role: "user", content: prompt}
 
-    if Enum.empty?(tools) do
+    tool_defs = build_tools_config(tools)
+
+    if Enum.empty?(tool_defs) do
       [user_content]
     else
-      tool_defs = build_tools_config(tools)
-
-      if Enum.empty?(tool_defs) do
-        [user_content]
-      else
-        tool_instruction = """
-        You have access to the following tools. When appropriate, use them to help answer the user's question.
-
-        Tool definitions:
-        #{Enum.map_join(tool_defs, "\n", &(Jason.encode!(&1) |> String.trim_leading("{") |> String.trim_trailing("}")))}
-        """
-
-        [
-          %{role: "system", content: tool_instruction},
-          user_content
-        ]
-      end
+      # Send tools via the Ollama tools field, not as system message
+      [user_content]
     end
   end
 
@@ -301,13 +324,13 @@ defmodule Lux.LLM.Ollama do
     metadata = %{
       model: Map.get(resp, "model"),
       prompt_tokens: Map.get(resp, "prompt_eval_count"),
-      completion_tokens: Map.get(resp, "eval_count"),
+      output_tokens: Map.get(resp, "eval_count"),
       total_time: Map.get(resp, "total_duration"),
       provider: :ollama
     }
 
     signal = ResponseSignal.new(%{}, metadata)
-    {:ok, Lux.Signal.new(%{}, signal)}
+    {:ok, Lux.Signal.new(%{content: content, tool_calls: tool_calls}, signal)}
   end
 
   defp handle_ollama_response(%{"message" => %{"content" => content}}, _config)
@@ -328,9 +351,9 @@ defmodule Lux.LLM.Ollama do
     {:ok, results}
   end
 
-  defp execute_tool_call(%{"function" => %{"name" => tool_name, "arguments" => args_str}}) do
+  defp execute_tool_call(%{"function" => %{"name" => tool_name, "arguments" => args}}) do
     try do
-      args = Jason.decode!(args_str)
+      args = Jason.decode!(args)
       execute_tool(tool_name, args)
     rescue
       _ -> :skip
@@ -396,7 +419,8 @@ defmodule Lux.LLM.Ollama do
     endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
     url = "#{endpoint}/api/pull"
 
-    payload = %{name: model_name, stream: false}
+    # Ollama API uses "model" field, not "name"
+    payload = %{model: model_name, stream: false}
 
     case Req.post(url, json: payload) do
       {:ok, %{status: 200, body: body}} ->
@@ -416,12 +440,25 @@ defmodule Lux.LLM.Ollama do
     endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
     url = "#{endpoint}/api/pull"
 
-    payload = %{name: model_name, stream: true}
+    # Ollama API uses "model" field, not "name"
+    payload = %{model: model_name, stream: true}
 
     case Req.post(url, json: payload, recv: :stream) do
-      {:ok, %{status: 200}} = resp ->
+      {:ok, %{status: 200} = _resp} = _resp ->
         {:ok,
-         Stream.resource(fn -> resp end, fn resp -> fn chunk -> chunk end end, fn _ -> :ok end)}
+         Stream.resource(
+           fn -> :ok end,
+           fn state ->
+             # In a real implementation, this would read from the response stream.
+             # For now, return an empty stream since Req streaming requires special handling.
+             if state == :ok do
+               [{:ok, %{progress: "streaming initialized"}}]
+             else
+               []
+             end
+           end,
+           fn _ -> :ok end
+         )}
 
       {:error, reason} ->
         {:error, "Pull failed: #{inspect(reason)}"}
@@ -434,7 +471,7 @@ defmodule Lux.LLM.Ollama do
     endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
     url = "#{endpoint}/api/delete"
 
-    case Req.delete(url, json: %{name: model_name}) do
+    case Req.delete(url, json: %{model: model_name}) do
       {:ok, %{status: 200, body: body}} -> {:ok, body}
       {:ok, %{status: status}} -> {:error, "Delete failed: HTTP #{status}"}
       {:error, reason} -> {:error, "Delete failed: #{inspect(reason)}"}
@@ -447,7 +484,7 @@ defmodule Lux.LLM.Ollama do
     endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
     url = "#{endpoint}/api/show"
 
-    payload = %{name: model_name}
+    payload = %{model: model_name}
 
     case Req.post(url, json: payload) do
       {:ok, %{status: 200, body: body}} -> {:ok, body}

--- a/lux/lib/lux/llm/ollama.ex
+++ b/lux/lib/lux/llm/ollama.ex
@@ -1,0 +1,431 @@
+defmodule Lux.LLM.Ollama do
+  @moduledoc """
+  Ollama Local Model Integration - Complete implementation for bounty #96.
+
+  Provides self-hosted LLM capabilities via the Ollama API, with
+  model management, download/caching, resource controls, and
+  performance monitoring.
+
+  ## Configuration
+
+      config :lux, Lux.LLM.Ollama,
+        api_key: System.get_env("OLLAMA_API_KEY"),
+        endpoint: "http://localhost:11434",
+        default_model: "llama3.3",
+        max_retries: 3,
+        retry_delay: 1000,
+        timeout: 120_000
+
+  ## Usage
+
+      alias Lux.LLM.Ollama
+
+      # Basic call
+      {:ok, response} = Ollama.call("What is Elixir?", [], %{})
+
+      # With tools
+      {:ok, response} = Ollama.call("Calculate weather", [WeatherLens], %{})
+
+      # With model override
+      {:ok, response} = Ollama.call("Hello", [], %{model: "mistral"})
+  """
+
+  @behaviour Lux.LLM
+
+  alias Lux.LLM.ResponseSignal
+  require Logger
+
+  @default_endpoint "http://localhost:11434"
+  @default_model "llama3.3"
+  @max_retries 3
+  @retry_delay 1000
+
+  defmodule Config do
+    @moduledoc "Configuration for Ollama integration."
+    @type t :: %__MODULE__{
+            endpoint: String.t(),
+            model: String.t(),
+            temperature: float(),
+            max_tokens: integer() | nil,
+            timeout: integer(),
+            stream: boolean(),
+            keep_alive: String.t() | nil,
+            format: String.t() | nil,
+            top_p: float() | nil,
+            top_k: integer() | nil,
+            num_ctx: integer(),
+            num_predict: integer() | nil,
+            max_retries: integer(),
+            retry_delay: integer()
+          }
+    defstruct endpoint: @default_endpoint,
+              model: @default_model,
+              temperature: 0.7,
+              max_tokens: nil,
+              timeout: 120_000,
+              stream: false,
+              keep_alive: "-1",
+              format: nil,
+              top_p: 0.9,
+              top_k: 40,
+              num_ctx: 4096,
+              num_predict: nil,
+              max_retries: @max_retries,
+              retry_delay: @retry_delay
+  end
+
+  # ---- Performance Monitoring ----
+
+  @perf_key {:lux_ollama_perf, __MODULE__}
+
+  @doc "Records a performance metric entry."
+  @spec record_perf(model :: String.t(), prompt_tokens :: integer(), output_tokens :: integer(), duration_ms :: integer()) :: :ok
+  def record_perf(model, prompt_tokens, output_tokens, duration_ms) do
+    entry = %{
+      model: model,
+      prompt_tokens: prompt_tokens,
+      output_tokens: output_tokens,
+      duration_ms: duration_ms,
+      timestamp: DateTime.utc_now()
+    }
+    current = :persistent_term.get(@perf_key, [])
+    :persistent_term.put(@perf_key, [entry | current])
+    :ok
+  end
+
+  @doc "Returns all performance metrics."
+  @spec performance_metrics() :: [map()]
+  def performance_metrics do
+    case :persistent_term.get(@perf_key, []) do
+      list when is_list(list) -> Enum.reverse(list)
+      _ -> []
+    end
+  end
+
+  @doc "Clears all performance metrics."
+  @spec clear_performance_metrics() :: :ok
+  def clear_performance_metrics do
+    :persistent_term.erase(@perf_key)
+    :ok
+  end
+
+  @doc "Returns average performance summary."
+  @spec perf_summary() :: map()
+  def perf_summary do
+    metrics = performance_metrics()
+    if Enum.empty?(metrics) do
+      %{total_requests: 0, avg_duration_ms: 0, avg_prompt_tokens: 0, avg_output_tokens: 0}
+    else
+      total = length(metrics)
+      %{
+        total_requests: total,
+        avg_duration_ms: Enum.sum(Enum.map(metrics, & &1.duration_ms)) / total,
+        avg_prompt_tokens: Enum.sum(Enum.map(metrics, & &1.prompt_tokens)) / total,
+        avg_output_tokens: Enum.sum(Enum.map(metrics, & &1.output_tokens)) / total
+      }
+    end
+  end
+
+  # ---- Tool Conversion (matches OpenRouter pattern) ----
+
+  defp build_tools_config([]), do: []
+
+  defp build_tools_config(tools) do
+    Enum.flat_map(tools, &tool_to_function/1)
+  end
+
+  defp tool_to_function({:python, _path}), do: []
+
+  defp tool_to_function(tool_module) when is_atom(tool_module) and not is_nil(tool_module) do
+    cond do
+      Lux.prism?(tool_module) -> tool_to_function(Lux.Prism.view(tool_module))
+      Lux.beam?(tool_module) -> tool_to_function(Lux.Beam.view(tool_module))
+      Lux.lens?(tool_module) -> tool_to_function(Lux.Lens.view(tool_module))
+      true -> []
+    end
+  end
+
+  defp tool_to_function(%Lux.Beam{module_name: name, description: description, input_schema: input_schema}) do
+    %{type: "function", function: %{name: String.replace(name, ".", "_"), description: description || "", parameters: input_schema}}
+  end
+
+  defp tool_to_function(%Lux.Prism{module_name: name, description: description, input_schema: input_schema}) do
+    %{type: "function", function: %{name: String.replace(name, ".", "_"), description: description || "", parameters: input_schema}}
+  end
+
+  defp tool_to_function(%Lux.Lens{module_name: name, description: description, schema: schema}) do
+    %{type: "function", function: %{name: String.replace(name, ".", "_"), description: description || "", parameters: schema}}
+  end
+
+  defp tool_to_function(_), do: []
+
+  # ---- Main API Call ----
+
+  @impl true
+  def call(prompt, tools, config) when is_list(tools) do
+    config = struct(Config, Map.merge(
+      %{api_key: Application.get_env(:lux, :api_keys, [])[:ollama]},
+      Keyword.into(Map.to_list(config || %{}), %{})
+    ))
+
+    system_prompt = config.system || "You are a helpful AI assistant powered by Ollama."
+
+    messages = [
+      %{role: "system", content: system_prompt}
+      | build_messages(prompt, tools, config)
+    ]
+
+    payload = %{
+      model: config.model,
+      messages: messages,
+      stream: false,
+      options: build_options(config)
+    }
+
+    if config.format do
+      payload = Map.put(payload, :format, config.format)
+    end
+
+    if config.keep_alive do
+      payload = Map.put(payload, :keep_alive, config.keep_alive)
+    end
+
+    endpoint = config.endpoint || @default_endpoint
+    url = "#{endpoint}/api/chat"
+
+    headers = [{"Content-Type", "application/json"}]
+
+    case do_call(url, payload, headers, config) do
+      {:ok, response_body} -> handle_ollama_response(response_body, config)
+      {:error, reason} -> {:error, "Ollama call failed: #{reason}"}
+    end
+  end
+
+  defp build_messages(prompt, tools, config) do
+    user_content = %{role: "user", content: prompt}
+
+    if Enum.empty?(tools) do
+      [user_content]
+    else
+      tool_defs = build_tools_config(tools)
+      if Enum.empty?(tool_defs) do
+        [user_content]
+      else
+        tool_instruction = """
+        You have access to the following tools. When appropriate, use them to help answer the user's question.
+
+        Tool definitions:
+        #{Enum.map_join(tool_defs, "\n", &Jason.encode!(&1) |> String.trim_leading("{") |> String.trim_trailing("}"))}
+        """
+        [
+          %{role: "system", content: tool_instruction},
+          user_content
+        ]
+      end
+    end
+  end
+
+  defp build_options(config) do
+    opts = %{
+      temperature: config.temperature,
+      top_p: config.top_p,
+      top_k: config.top_k,
+      num_ctx: config.num_ctx
+    }
+
+    opts = if config.max_tokens, do: Map.put(opts, :num_predict, config.max_tokens), else: opts
+    opts = if config.num_predict, do: Map.put(opts, :num_predict, config.num_predict), else: opts
+    opts
+  end
+
+  defp do_call(url, payload, headers, config) do
+    case Req.post(url, json: payload, headers: headers, timeout: config.timeout, recv_timeout: config.timeout) do
+      {:ok, %{status: 200, body: body}} -> {:ok, body}
+      {:ok, %{status: status, body: body}} -> {:error, "HTTP #{status}: #{inspect(body)}"}
+      {:error, reason} -> {:error, inspect(reason)}
+    end
+  end
+
+  defp handle_ollama_response(%{"message" => %{"content" => content, "tool_calls" => tool_calls}} = resp, _config) do
+    metadata = %{
+      model: Map.get(resp, "model"),
+      prompt_tokens: Map.get(resp, "prompt_eval_count"),
+      completion_tokens: Map.get(resp, "eval_count"),
+      total_time: Map.get(resp, "total_duration"),
+      provider: :ollama
+    }
+
+    signal = ResponseSignal.new(%{}, metadata)
+    {:ok, Lux.Signal.new(%{}, signal)}
+  end
+
+  defp handle_ollama_response(%{"message" => %{"content" => content}}, _config) when is_binary(content) do
+    {:ok, Lux.Signal.new(%{content: content}, ResponseSignal, %{provider: :ollama})}
+  end
+
+  defp handle_ollama_response(%{"error" => error}), do: {:error, "Ollama error: #{error}"}
+  defp handle_ollama_response(_), do: {:error, "Unexpected Ollama response format"}
+
+  # ---- Tool Call Execution ----
+
+  defp execute_tool_calls(nil), do: {:ok, nil}
+  defp execute_tool_calls([]), do: {:ok, []}
+
+  defp execute_tool_calls(tool_calls) when is_list(tool_calls) do
+    results = tool_calls |> Enum.map(&execute_tool_call/1) |> Enum.filter(&(&1 != :skip))
+    {:ok, results}
+  end
+
+  defp execute_tool_call(%{"function" => %{"name" => tool_name, "arguments" => args_str}}) do
+    try do
+      args = Jason.decode!(args_str)
+      execute_tool(tool_name, args)
+    rescue
+      _ -> :skip
+    end
+  end
+
+  defp execute_tool_call(_), do: :skip
+
+  defp execute_tool(tool_name, args) when is_binary(tool_name) do
+    tool_name
+    |> String.replace("_", ".")
+    |> List.wrap()
+    |> Module.concat()
+    |> Code.ensure_loaded()
+    |> case do
+      {:module, module} -> execute_module_tool(module, args)
+      _ -> :skip
+    end
+  end
+
+  defp execute_module_tool(module, args) when is_atom(module) do
+    cond do
+      Lux.prism?(module) -> module.handler(args, nil)
+      Lux.beam?(module) -> module.run(args, nil)
+      Lux.lens?(module) -> module.focus(args)
+      true -> :skip
+    end
+  end
+
+  # ---- Model Management ----
+
+  @doc "Lists available models from Ollama."
+  @spec list_models() :: {:ok, [map()]} | {:error, String.t()}
+  def list_models do
+    endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
+    url = "#{endpoint}/api/tags"
+
+    case Req.get(url) do
+      {:ok, %{status: 200, body: %{"models" => models}}} ->
+        {:ok, Enum.map(models, &parse_model/1)}
+      {:ok, %{status: status}} ->
+        {:error, "Failed to list models: HTTP #{status}"}
+      {:error, reason} ->
+        {:error, "Failed to connect to Ollama: #{inspect(reason)}"}
+    end
+  end
+
+  defp parse_model(%{"name" => name, "size" => size, "digest" => digest} = m) do
+    %{
+      name: name,
+      size_bytes: size,
+      digest: digest,
+      modified_at: Map.get(m, "modified_at"),
+      details: Map.get(m, "details", %{})
+    }
+  end
+
+  @doc "Pulls (downloads) a model from the Ollama library."
+  @spec pull_model(String.t()) :: {:ok, map()} | {:error, String.t()}
+  def pull_model(model_name) do
+    endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
+    url = "#{endpoint}/api/pull"
+
+    payload = %{name: model_name, stream: false}
+
+    case Req.post(url, json: payload) do
+      {:ok, %{status: 200, body: body}} -> {:ok, body}
+      {:ok, %{status: status, body: body}} -> {:error, "Pull failed: HTTP #{status}: #{inspect(body)}"}
+      {:error, reason} -> {:error, "Pull failed: #{inspect(reason)}"}
+    end
+  end
+
+  @doc "Pulls a model with progress streaming."
+  @spec pull_model_stream(String.t()) :: {:ok, Stream.t()} | {:error, String.t()}
+  def pull_model_stream(model_name) do
+    endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
+    url = "#{endpoint}/api/pull"
+
+    payload = %{name: model_name, stream: true}
+
+    case Req.post(url, json: payload, recv: :stream) do
+      {:ok, %{status: 200}} = resp -> {:ok, Stream.resource(fn -> resp do -> resp end, fn -> fn acc -> acc end end, fn _ -> :ok end)}
+      {:error, reason} -> {:error, "Pull failed: #{inspect(reason)}"}
+    end
+  end
+
+  @doc "Deletes a model locally."
+  @spec delete_model(String.t()) :: {:ok, map()} | {:error, String.t()}
+  def delete_model(model_name) do
+    endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
+    url = "#{endpoint}/api/delete"
+
+    case Req.delete(url, json: %{name: model_name}) do
+      {:ok, %{status: 200, body: body}} -> {:ok, body}
+      {:ok, %{status: status}} -> {:error, "Delete failed: HTTP #{status}"}
+      {:error, reason} -> {:error, "Delete failed: #{inspect(reason)}"}
+    end
+  end
+
+  @doc "Shows model information."
+  @spec show_model(String.t()) :: {:ok, map()} | {:error, String.t()}
+  def show_model(model_name) do
+    endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
+    url = "#{endpoint}/api/show"
+
+    payload = %{name: model_name}
+
+    case Req.post(url, json: payload) do
+      {:ok, %{status: 200, body: body}} -> {:ok, body}
+      {:ok, %{status: status}} -> {:error, "Show failed: HTTP #{status}"}
+      {:error, reason} -> {:error, "Show failed: #{inspect(reason)}"}
+    end
+  end
+
+  @doc "Copies a model to a new name."
+  @spec copy_model(String.t(), String.t()) :: {:ok, map()} | {:error, String.t()}
+  def copy_model(source, destination) do
+    endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
+    url = "#{endpoint}/api/copy"
+
+    payload = %{source: source, destination: destination}
+
+    case Req.post(url, json: payload) do
+      {:ok, %{status: 200, body: body}} -> {:ok, body}
+      {:ok, %{status: status}} -> {:error, "Copy failed: HTTP #{status}"}
+      {:error, reason} -> {:error, "Copy failed: #{inspect(reason)}"}
+    end
+  end
+
+  @doc "Checks if Ollama is reachable."
+  @spec health_check() :: {:ok, map()} | {:error, String.t()}
+  def health_check do
+    endpoint = Application.get_env(:lux, Lux.LLM.Ollama, [])[:endpoint] || @default_endpoint
+    url = "#{endpoint}/api/version"
+
+    case Req.get(url) do
+      {:ok, %{status: 200, body: body}} -> {:ok, body}
+      {:ok, %{status: status}} -> {:error, "Health check failed: HTTP #{status}"}
+      {:error, reason} -> {:error, "Ollama not reachable: #{inspect(reason)}"}
+    end
+  end
+
+  @doc "Returns the default endpoint."
+  @spec default_endpoint() :: String.t()
+  def default_endpoint, do: @default_endpoint
+
+  @doc "Returns the default model."
+  @spec default_model() :: String.t()
+  def default_model, do: @default_model
+end

--- a/lux/test/lux/llm/ollama_test.exs
+++ b/lux/test/lux/llm/ollama_test.exs
@@ -1,0 +1,52 @@
+defmodule Lux.LLM.OllamaTest do
+  use ExUnit.Case, async: true
+
+  describe "Config defaults" do
+    test "has correct default endpoint" do
+      assert Lux.LLM.Ollama.default_endpoint() == "http://localhost:11434"
+    end
+
+    test "has correct default model" do
+      assert Lux.LLM.Ollama.default_model() == "llama3.3"
+    end
+  end
+
+  describe "performance metrics" do
+    setup do
+      Lux.LLM.Ollama.clear_performance_metrics()
+    end
+
+    test "records and retrieves perf metrics" do
+      Lux.LLM.Ollama.record_perf("llama3.3", 100, 200, 5000)
+      metrics = Lux.LLM.Ollama.performance_metrics()
+      assert length(metrics) == 1
+      assert hd(metrics).model == "llama3.3"
+      assert hd(metrics).prompt_tokens == 100
+      assert hd(metrics).output_tokens == 200
+      assert hd(metrics).duration_ms == 5000
+    end
+
+    test "perf_summary returns correct averages" do
+      Lux.LLM.Ollama.record_perf("llama3.3", 100, 200, 5000)
+      Lux.LLM.Ollama.record_perf("llama3.3", 200, 300, 3000)
+      summary = Lux.LLM.Ollama.perf_summary()
+      assert summary.total_requests == 2
+      assert summary.avg_duration_ms == 4000.0
+      assert summary.avg_prompt_tokens == 150.0
+      assert summary.avg_output_tokens == 250.0
+    end
+
+    test "perf_summary returns zeros when empty" do
+      summary = Lux.LLM.Ollama.perf_summary()
+      assert summary.total_requests == 0
+      assert summary.avg_duration_ms == 0
+    end
+  end
+
+  describe "health_check" do
+    test "returns error when Ollama is not running" do
+      result = Lux.LLM.Ollama.health_check()
+      assert {:error, _} = result
+    end
+  end
+end

--- a/lux/test/lux/llm/ollama_test.exs
+++ b/lux/test/lux/llm/ollama_test.exs
@@ -1,24 +1,38 @@
 defmodule Lux.LLM.OllamaTest do
   use ExUnit.Case, async: true
 
+  alias Lux.LLM.Ollama
+
+  setup do
+    Ollama.clear_performance_metrics()
+    :ok
+  end
+
   describe "Config defaults" do
     test "has correct default endpoint" do
-      assert Lux.LLM.Ollama.default_endpoint() == "http://localhost:11434"
+      assert Ollama.default_endpoint() == "http://localhost:11434"
     end
 
     test "has correct default model" do
-      assert Lux.LLM.Ollama.default_model() == "llama3.3"
+      assert Ollama.default_model() == "llama3.3"
+    end
+
+    test "Config struct uses literal defaults, not outer module attributes" do
+      config = %Ollama.Config{}
+      assert config.endpoint == "http://localhost:11434"
+      assert config.model == "llama3.3"
+      assert config.max_retries == 3
+      assert config.retry_delay == 1000
+      assert config.timeout == 120_000
+      assert config.api_key == nil
+      assert config.system == nil
     end
   end
 
   describe "performance metrics" do
-    setup do
-      Lux.LLM.Ollama.clear_performance_metrics()
-    end
-
     test "records and retrieves perf metrics" do
-      Lux.LLM.Ollama.record_perf("llama3.3", 100, 200, 5000)
-      metrics = Lux.LLM.Ollama.performance_metrics()
+      Ollama.record_perf("llama3.3", 100, 200, 5000)
+      metrics = Ollama.performance_metrics()
       assert length(metrics) == 1
       assert hd(metrics).model == "llama3.3"
       assert hd(metrics).prompt_tokens == 100
@@ -27,9 +41,9 @@ defmodule Lux.LLM.OllamaTest do
     end
 
     test "perf_summary returns correct averages" do
-      Lux.LLM.Ollama.record_perf("llama3.3", 100, 200, 5000)
-      Lux.LLM.Ollama.record_perf("llama3.3", 200, 300, 3000)
-      summary = Lux.LLM.Ollama.perf_summary()
+      Ollama.record_perf("llama3.3", 100, 200, 5000)
+      Ollama.record_perf("llama3.3", 200, 300, 3000)
+      summary = Ollama.perf_summary()
       assert summary.total_requests == 2
       assert summary.avg_duration_ms == 4000.0
       assert summary.avg_prompt_tokens == 150.0
@@ -37,7 +51,7 @@ defmodule Lux.LLM.OllamaTest do
     end
 
     test "perf_summary returns zeros when empty" do
-      summary = Lux.LLM.Ollama.perf_summary()
+      summary = Ollama.perf_summary()
       assert summary.total_requests == 0
       assert summary.avg_duration_ms == 0
     end
@@ -45,8 +59,50 @@ defmodule Lux.LLM.OllamaTest do
 
   describe "health_check" do
     test "returns error when Ollama is not running" do
-      result = Lux.LLM.Ollama.health_check()
+      result = Ollama.health_check()
       assert {:error, _} = result
+    end
+  end
+
+  describe "tool conversion" do
+    test "build_tools_config returns empty for empty list" do
+      # build_tools_config is private, test via module introspection
+      assert Ollama.__info__(:modules) |> is_list()
+    end
+
+    test "tool_to_function handles nil module" do
+      # Private function test - verify the module compiles without errors
+      # and the tool conversion path exists
+      assert is_function(&Ollama.build_tools_config/1, 1)
+    end
+  end
+
+  describe "model management API contracts" do
+    test "list_models returns error when Ollama is not running" do
+      result = Ollama.list_models()
+      assert {:error, _} = result
+    end
+
+    test "pull_model uses correct 'model' field (not 'name')" do
+      # Verify the function exists and has correct arity
+      assert is_function(&Ollama.pull_model/1, 1)
+    end
+
+    test "delete_model uses correct 'model' field" do
+      assert is_function(&Ollama.delete_model/1, 1)
+    end
+
+    test "show_model uses correct 'model' field" do
+      assert is_function(&Ollama.show_model/1, 1)
+    end
+  end
+
+  describe "compile verification" do
+    test "module compiles without errors" do
+      # This test verifies the module compiles correctly
+      # particularly that nested Config module does not reference outer @attrs
+      assert Ollama.default_endpoint() == "http://localhost:11434"
+      assert Ollama.default_model() == "llama3.3"
     end
   end
 end

--- a/lux/test/lux/llm/ollama_test.exs
+++ b/lux/test/lux/llm/ollama_test.exs
@@ -1,108 +1,178 @@
+defmodule Lux.LLM.OllamaTest.Tool do
+  use Lux.Prism,
+    name: "Ollama Test Tool",
+    description: "Returns its arguments",
+    input_schema: %{type: :object, properties: %{value: %{type: :string}}},
+    output_schema: %{type: :object, properties: %{value: %{type: :string}}}
+
+  def handler(args, _context), do: {:ok, args}
+end
+
 defmodule Lux.LLM.OllamaTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Lux.LLM.Ollama
+  alias Lux.LLM.OllamaTest.Tool
 
   setup do
+    previous = Application.get_env(:lux, Ollama)
+    Application.put_env(:lux, Ollama, plug: {Req.Test, __MODULE__})
     Ollama.clear_performance_metrics()
+    Req.Test.verify_on_exit!()
+
+    on_exit(fn ->
+      if previous,
+        do: Application.put_env(:lux, Ollama, previous),
+        else: Application.delete_env(:lux, Ollama)
+
+      Ollama.clear_performance_metrics()
+    end)
+
     :ok
   end
 
-  describe "Config defaults" do
-    test "has correct default endpoint" do
-      assert Ollama.default_endpoint() == "http://localhost:11434"
-    end
-
-    test "has correct default model" do
-      assert Ollama.default_model() == "llama3.3"
-    end
-
-    test "Config struct uses literal defaults, not outer module attributes" do
-      config = %Ollama.Config{}
-      assert config.endpoint == "http://localhost:11434"
-      assert config.model == "llama3.3"
-      assert config.max_retries == 3
-      assert config.retry_delay == 1000
-      assert config.timeout == 120_000
-      assert config.api_key == nil
-      assert config.system == nil
-    end
+  test "builds a usable Config with all call fields" do
+    config = %Ollama.Config{}
+    assert config.endpoint == "http://localhost:11434"
+    assert config.model == "llama3.3"
+    assert config.api_key == nil
+    assert config.system == nil
   end
 
-  describe "performance metrics" do
-    test "records and retrieves perf metrics" do
-      Ollama.record_perf("llama3.3", 100, 200, 5000)
-      metrics = Ollama.performance_metrics()
-      assert length(metrics) == 1
-      assert hd(metrics).model == "llama3.3"
-      assert hd(metrics).prompt_tokens == 100
-      assert hd(metrics).output_tokens == 200
-      assert hd(metrics).duration_ms == 5000
-    end
+  test "chat sends format, keep_alive and resource options and records metrics" do
+    Req.Test.expect(__MODULE__, fn conn ->
+      assert conn.method == "POST"
+      assert conn.request_path == "/api/chat"
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      payload = Jason.decode!(body)
 
-    test "perf_summary returns correct averages" do
-      Ollama.record_perf("llama3.3", 100, 200, 5000)
-      Ollama.record_perf("llama3.3", 200, 300, 3000)
-      summary = Ollama.perf_summary()
-      assert summary.total_requests == 2
-      assert summary.avg_duration_ms == 4000.0
-      assert summary.avg_prompt_tokens == 150.0
-      assert summary.avg_output_tokens == 250.0
-    end
+      assert payload["format"] == "json"
+      assert payload["keep_alive"] == "5m"
+      assert payload["options"]["num_ctx"] == 2048
+      assert payload["options"]["num_predict"] == 64
+      assert payload["options"]["temperature"] == 0.2
 
-    test "perf_summary returns zeros when empty" do
-      summary = Ollama.perf_summary()
-      assert summary.total_requests == 0
-      assert summary.avg_duration_ms == 0
-    end
+      Req.Test.json(conn, %{
+        "model" => "llama3.2",
+        "message" => %{"content" => "hello"},
+        "prompt_eval_count" => 3,
+        "eval_count" => 2
+      })
+    end)
+
+    assert {:ok, signal} =
+             Ollama.call("hi", [], %{
+               model: "llama3.2",
+               format: "json",
+               keep_alive: "5m",
+               num_ctx: 2048,
+               max_tokens: 64,
+               temperature: 0.2
+             })
+
+    assert signal.payload.content == %{"text" => "hello"}
+
+    assert [%{model: "llama3.2", prompt_tokens: 3, output_tokens: 2}] =
+             Ollama.performance_metrics()
   end
 
-  describe "health_check" do
-    test "returns error when Ollama is not running" do
-      result = Ollama.health_check()
-      assert {:error, _} = result
-    end
+  test "executes map arguments and completes assistant-tool-follow-up round trip" do
+    Req.Test.expect(__MODULE__, 2, fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      payload = Jason.decode!(body)
+
+      case payload["messages"] do
+        [_, %{"role" => "user"}] ->
+          assert [%{"type" => "function"}] = payload["tools"]
+
+          Req.Test.json(conn, %{
+            "model" => "llama3.3",
+            "message" => %{
+              "content" => "",
+              "tool_calls" => [
+                %{
+                  "function" => %{
+                    "name" => "Lux_LLM_OllamaTest_Tool",
+                    "arguments" => %{"value" => "map"}
+                  }
+                }
+              ]
+            }
+          })
+
+        messages ->
+          assert %{"role" => "assistant", "tool_calls" => [_]} = Enum.at(messages, 2)
+          assert %{"role" => "tool", "content" => content} = Enum.at(messages, 3)
+          assert Jason.decode!(content) == %{"value" => "map"}
+
+          Req.Test.json(conn, %{
+            "model" => "llama3.3",
+            "message" => %{"content" => "done"},
+            "prompt_eval_count" => 4,
+            "eval_count" => 1
+          })
+      end
+    end)
+
+    assert {:ok, signal} = Ollama.call("use tool", [Tool], %{})
+    assert signal.payload.content == %{"text" => "done"}
+    assert signal.payload.tool_calls_results == [%{"value" => "map"}]
   end
 
-  describe "tool conversion" do
-    test "build_tools_config returns empty for empty list" do
-      # build_tools_config is private, test via module introspection
-      assert Ollama.__info__(:modules) |> is_list()
-    end
+  test "accepts JSON-string tool arguments" do
+    Req.Test.expect(__MODULE__, 2, fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      payload = Jason.decode!(body)
 
-    test "tool_to_function handles nil module" do
-      # Private function test - verify the module compiles without errors
-      # and the tool conversion path exists
-      assert is_function(&Ollama.build_tools_config/1, 1)
-    end
+      if length(payload["messages"]) == 2 do
+        Req.Test.json(conn, %{
+          "model" => "llama3.3",
+          "message" => %{
+            "content" => "",
+            "tool_calls" => [
+              %{
+                "function" => %{
+                  "name" => "Lux_LLM_OllamaTest_Tool",
+                  "arguments" => ~s({"value":"json"})
+                }
+              }
+            ]
+          }
+        })
+      else
+        Req.Test.json(conn, %{"model" => "llama3.3", "message" => %{"content" => "done"}})
+      end
+    end)
+
+    assert {:ok, signal} = Ollama.call("use tool", [Tool], %{})
+    assert signal.payload.tool_calls_results == [%{"value" => "json"}]
   end
 
-  describe "model management API contracts" do
-    test "list_models returns error when Ollama is not running" do
-      result = Ollama.list_models()
-      assert {:error, _} = result
-    end
+  test "model management uses Ollama API fields and parses NDJSON pull progress" do
+    Req.Test.expect(__MODULE__, 2, fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      assert Jason.decode!(body)["model"] == "llama3.2"
 
-    test "pull_model uses correct 'model' field (not 'name')" do
-      # Verify the function exists and has correct arity
-      assert is_function(&Ollama.pull_model/1, 1)
-    end
+      case conn.request_path do
+        "/api/pull" ->
+          if Jason.decode!(body)["stream"] do
+            Plug.Conn.send_resp(
+              conn,
+              200,
+              ~s({"status":"pulling","completed":1}\n{"status":"success"}\n)
+            )
+          else
+            Req.Test.json(conn, %{"status" => "success"})
+          end
+      end
+    end)
 
-    test "delete_model uses correct 'model' field" do
-      assert is_function(&Ollama.delete_model/1, 1)
-    end
+    assert {:ok, %{"status" => "success"}} = Ollama.pull_model("llama3.2")
+    assert {:ok, stream} = Ollama.pull_model_stream("llama3.2")
 
-    test "show_model uses correct 'model' field" do
-      assert is_function(&Ollama.show_model/1, 1)
-    end
-  end
-
-  describe "compile verification" do
-    test "module compiles without errors" do
-      # This test verifies the module compiles correctly
-      # particularly that nested Config module does not reference outer @attrs
-      assert Ollama.default_endpoint() == "http://localhost:11434"
-      assert Ollama.default_model() == "llama3.3"
-    end
+    assert Enum.to_list(stream) == [
+             %{"status" => "pulling", "completed" => 1},
+             %{"status" => "success"}
+           ]
   end
 end


### PR DESCRIPTION
## Summary

Adds a scoped Ollama integration for #96 on the current upstream `main` branch.

## Implemented

- `/api/chat` client with configurable endpoint, model, system prompt and timeout
- `format`, `keep_alive`, `temperature`, `top_p`, `top_k`, `num_ctx`, and token-limit options in the actual request payload
- Ollama tool definitions plus the assistant → tool result → follow-up chat round trip
- Tool arguments accepted as either Ollama maps or JSON strings
- Model list, pull, delete, show, copy, version/health operations
- `/api/pull` uses the `model` field
- NDJSON pull-progress parsing through a valid `Stream.resource/3` lifecycle
- Per-call performance metrics from Ollama token counts and elapsed time
- Deterministic Req tests for chat payload/resource controls, both tool-argument formats, follow-up chat, model pull, and NDJSON progress

## Limitations

- Pull progress is exposed as a lazy stream after the HTTP response body is received; it is not a socket-level incremental transport.
- Automatic retry/backoff is not implemented.
- Metrics use `:persistent_term` and are process-global rather than durable external storage.

## Validation

- `mix format --check-formatted lib/lux/llm/ollama.ex test/lux/llm/ollama_test.exs`: passed.
- `git diff --check`: passed.
- Both changed files parse successfully with `Code.string_to_quoted!/1`.
- `mix compile --no-deps-check` compiled `Lux.LLM.Ollama`, then failed later in unrelated Web3 modules because dependencies were intentionally skipped.
- The focused `mix test test/lux/llm/ollama_test.exs` command was attempted, but ExUnit did not run: this machine has OTP 29 while `.tool-versions` pins Erlang 27.2 / Elixir 1.18.1-otp-27, and rebar3/yamerl failed during dependency compilation. CI on the pinned toolchain is still required.

This PR does not claim that all #96 acceptance criteria or local integration testing are complete until CI executes the deterministic tests.
