### PR TITLE
feat: add Ollama LLM provider for local inference (#96)

### DIFF
--- a/lux/lib/lux/llm/ollama.ex
+++ b/lux/lib/lux/llm/ollama.ex
@@ -1,0 +1,151 @@
+defmodule Lux.LLM.Ollama do
+  @moduledoc """
+  Ollama LLM implementation for local model inference.
+
+  Ollama uses an OpenAI-compatible API running on localhost.
+  Does not require an API key for local usage.
+  """
+
+  @behaviour Lux.LLM
+
+  alias Lux.LLM.ResponseSignal
+
+  require Logger
+
+  @endpoint "http://localhost:11434/v1/chat/completions"
+
+  defmodule Config do
+    @moduledoc """
+    Configuration module for Ollama.
+    """
+    @type t :: %__MODULE__{
+            endpoint: String.t(),
+            model: String.t(),
+            api_key: String.t(),
+            temperature: float(),
+            top_p: float(),
+            max_tokens: integer(),
+            stream: boolean(),
+            receive_timeout: integer(),
+            keep_alive: String.t(),
+            messages: [map()]
+          }
+
+    defstruct endpoint: "http://localhost:11434/v1/chat/completions",
+              model: "llama3.2",
+              api_key: nil,
+              temperature: 0.7,
+              top_p: nil,
+              max_tokens: nil,
+              stream: false,
+              receive_timeout: 120_000,
+              keep_alive: "5m",
+              messages: []
+  end
+
+  @impl true
+  def call(prompt, _tools, config) do
+    config =
+      struct(
+        Config,
+        Map.merge(
+          %{
+            model: (Application.get_env(:lux, :ollama_models) || %{})[:default],
+            api_key: Application.get_env(:lux, :api_keys, [])[:ollama]
+          },
+          config
+        )
+      )
+
+    messages = config.messages ++ build_messages(prompt)
+
+    body =
+      %{
+        model: Lux.Config.resolve(config.model),
+        messages: messages,
+        temperature: config.temperature,
+        stream: config.stream
+      }
+      |> maybe_add(:top_p, config.top_p)
+      |> maybe_add(:max_tokens, config.max_tokens)
+      |> maybe_add(:keep_alive, config.keep_alive)
+
+    headers =
+      if config.api_key do
+        [{"Authorization", "Bearer #{Lux.Config.resolve(config.api_key)}"}, {"Content-Type", "application/json"}]
+      else
+        [{"Content-Type", "application/json"}]
+      end
+
+    [
+      url: config.endpoint,
+      json: body,
+      headers: headers
+    ]
+    |> Keyword.merge(Application.get_env(:lux, __MODULE__, []))
+    |> Req.new()
+    |> Req.post()
+    |> case do
+      {:ok, %{status: 200} = response} ->
+        handle_response(response)
+
+      {:ok, %{status: status, body: %{"error" => %{"message" => message}}}} ->
+        {:error, {status, message}}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, {status, body}}
+
+      {:error, error} ->
+        handle_error(error)
+    end
+  end
+
+  defp build_messages(prompt) do
+    [%{role: "user", content: prompt}]
+  end
+
+  defp maybe_add(body, _key, nil), do: body
+  defp maybe_add(body, key, value), do: Map.put(body, key, value)
+
+  defp handle_response(%{body: body}) do
+    with %{"choices" => [choice | _]} <- body,
+         %{"message" => message, "finish_reason" => finish_reason} <- choice,
+         {:ok, content} <- parse_content(message["content"]) do
+      payload = %{
+        content: content,
+        model: body["model"],
+        finish_reason: finish_reason,
+        tool_calls: nil,
+        tool_calls_results: nil
+      }
+
+      metadata = %{
+        id: body["id"],
+        created: body["created"],
+        usage: body["usage"]
+      }
+
+      %{
+        schema_id: ResponseSignal,
+        payload: payload,
+        metadata: metadata
+      }
+      |> Lux.Signal.new()
+      |> ResponseSignal.validate()
+    end
+  end
+
+  defp parse_content(nil), do: {:ok, nil}
+
+  defp parse_content(content) when is_binary(content) do
+    case Jason.decode(content) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:error, _} -> {:ok, %{"text" => content}}
+    end
+  end
+
+  defp handle_error(error) do
+    Logger.error("Ollama API error: #{inspect(error)}")
+    {:error, "Ollama API error: #{inspect(error)}"}
+  end
+end

--- a/lux/lib/lux/llm/openrouter.ex
+++ b/lux/lib/lux/llm/openrouter.ex
@@ -1,0 +1,160 @@
+defmodule Lux.LLM.OpenRouter do
+  @moduledoc """
+  OpenRouter LLM implementation with access to multiple model providers.
+
+  OpenRouter uses an OpenAI-compatible API and provides access to many
+  LLM providers through a single endpoint.
+  """
+
+  @behaviour Lux.LLM
+
+  alias Lux.LLM.ResponseSignal
+
+  require Logger
+
+  @endpoint "https://openrouter.ai/api/v1/chat/completions"
+
+  defmodule Config do
+    @moduledoc """
+    Configuration module for OpenRouter.
+    """
+    @type t :: %__MODULE__{
+            endpoint: String.t(),
+            model: String.t(),
+            api_key: String.t(),
+            temperature: float(),
+            top_p: float(),
+            max_tokens: integer(),
+            presence_penalty: float(),
+            frequency_penalty: float(),
+            stream: boolean(),
+            receive_timeout: integer(),
+            user: String.t(),
+            messages: [map()]
+          }
+
+    defstruct endpoint: "https://openrouter.ai/api/v1/chat/completions",
+              model: "openrouter/auto",
+              api_key: nil,
+              temperature: 0.7,
+              top_p: nil,
+              max_tokens: nil,
+              presence_penalty: 0.0,
+              frequency_penalty: 1.0,
+              stream: false,
+              receive_timeout: 60_000,
+              user: nil,
+              messages: []
+  end
+
+  @impl true
+  def call(prompt, _tools, config) do
+    config =
+      struct(
+        Config,
+        Map.merge(
+          %{
+            model: (Application.get_env(:lux, :openrouter_models) || %{})[:default],
+            api_key: Application.get_env(:lux, :api_keys, [])[:openrouter]
+          },
+          config
+        )
+      )
+
+    messages = config.messages ++ build_messages(prompt)
+
+    body =
+      %{
+        model: Lux.Config.resolve(config.model),
+        messages: messages,
+        temperature: config.temperature
+      }
+      |> maybe_add(:top_p, config.top_p)
+      |> maybe_add(:max_tokens, config.max_tokens)
+      |> maybe_add(:presence_penalty, config.presence_penalty)
+      |> maybe_add(:frequency_penalty, config.frequency_penalty)
+      |> maybe_add(:stream, config.stream)
+
+    [
+      url: config.endpoint,
+      json: body,
+      headers: [
+        {"Authorization", "Bearer #{Lux.Config.resolve(config.api_key)}"},
+        {"Content-Type", "application/json"},
+        {"HTTP-Referer", "https://github.com/Spectral-Finance/lux"},
+        {"X-Title", "Lux Framework"}
+      ]
+    ]
+    |> Keyword.merge(Application.get_env(:lux, __MODULE__, []))
+    |> Req.new()
+    |> Req.post()
+    |> case do
+      {:ok, %{status: 200} = response} ->
+        handle_response(response)
+
+      {:ok, %{status: 401}} ->
+        {:error, :invalid_api_key}
+
+      {:ok, %{status: 402}} ->
+        {:error, :insufficient_credits}
+
+      {:ok, %{status: status, body: %{"error" => %{"message" => message}}}} ->
+        {:error, {status, message}}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, {status, body}}
+
+      {:error, error} ->
+        handle_error(error)
+    end
+  end
+
+  defp build_messages(prompt) do
+    [%{role: "user", content: prompt}]
+  end
+
+  defp maybe_add(body, _key, nil), do: body
+  defp maybe_add(body, key, value), do: Map.put(body, key, value)
+
+  defp handle_response(%{body: body}) do
+    with %{"choices" => [choice | _]} <- body,
+         %{"message" => message, "finish_reason" => finish_reason} <- choice,
+         {:ok, content} <- parse_content(message["content"]) do
+      payload = %{
+        content: content,
+        model: body["model"],
+        finish_reason: finish_reason,
+        tool_calls: nil,
+        tool_calls_results: nil
+      }
+
+      metadata = %{
+        id: body["id"],
+        created: body["created"],
+        usage: body["usage"]
+      }
+
+      %{
+        schema_id: ResponseSignal,
+        payload: payload,
+        metadata: metadata
+      }
+      |> Lux.Signal.new()
+      |> ResponseSignal.validate()
+    end
+  end
+
+  defp parse_content(nil), do: {:ok, nil}
+
+  defp parse_content(content) when is_binary(content) do
+    case Jason.decode(content) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:error, _} -> {:ok, %{"text" => content}}
+    end
+  end
+
+  defp handle_error(error) do
+    Logger.error("OpenRouter API error: #{inspect(error)}")
+    {:error, "OpenRouter API error: #{inspect(error)}"}
+  end
+end

--- a/lux/test/unit/lux/llm/ollama_test.exs
+++ b/lux/test/unit/lux/llm/ollama_test.exs
@@ -1,0 +1,133 @@
+defmodule Lux.LLM.OllamaTest do
+  use Lux.Test.Support.Case, async: true
+
+  alias Lux.LLM.Ollama
+
+  describe "Ollama /chat/completions" do
+    @tag :external
+    test "returns a response for a simple prompt" do
+      assert {:ok, signal} =
+               Ollama.call("What is the capital of France?", [], %{model: "llama3.2"})
+
+      assert signal.schema_id == "response"
+    end
+
+    @tag :external
+    test "handles unauthorized access" do
+      assert {:error, {:error, _}} =
+               Ollama.call("test", [], %{api_key: "invalid", endpoint: "http://localhost:9999/v1/chat/completions"})
+    end
+  end
+end
+
+  describe "call/3" do
+    test "makes correct API call" do
+      config = %{
+        api_key: "test_key",
+        model: "sonar-pro"
+      }
+
+      Req.Test.expect(Perplexity, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/v1/chat/completions"
+
+        auth_header = Plug.Conn.get_req_header(conn, "authorization")
+        assert ["Bearer test_key"] = auth_header
+
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        decoded_body = Jason.decode!(body)
+
+        assert decoded_body["model"] == "sonar-pro"
+        assert [%{"role" => "user", "content" => "test prompt"}] = decoded_body["messages"]
+
+        Req.Test.json(conn, %{
+          "id" => "test-id-123",
+          "model" => "sonar-pro",
+          "created" => 1_720_000_000,
+          "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 20, "total_tokens" => 30},
+          "citations" => ["https://example.com"],
+          "choices" => [
+            %{
+              "message" => %{
+                "content" => ~s({"answer": "Test response"})
+              },
+              "finish_reason" => "stop"
+            }
+          ]
+        })
+      end)
+
+      assert {:ok,
+              %Signal{
+                schema_id: ResponseSignal,
+                payload: %{
+                  content: %{"answer" => "Test response"},
+                  finish_reason: "stop",
+                  model: "sonar-pro",
+                  tool_calls: nil,
+                  tool_calls_results: nil
+                },
+                sender: nil,
+                recipient: nil,
+                timestamp: _,
+                metadata: %{
+                  id: "test-id-123",
+                  usage: %{"prompt_tokens" => 10, "completion_tokens" => 20, "total_tokens" => 30},
+                  created: 1_720_000_000,
+                  citations: ["https://example.com"]
+                }
+              }} = Perplexity.call("test prompt", [], config)
+    end
+
+    test "handles non-JSON text content" do
+      config = %{
+        api_key: "test_key",
+        model: "sonar-pro"
+      }
+
+      Req.Test.expect(Perplexity, fn conn ->
+        Req.Test.json(conn, %{
+          "id" => "test-id-456",
+          "model" => "sonar-pro",
+          "created" => 1_720_000_001,
+          "usage" => %{"prompt_tokens" => 5, "completion_tokens" => 15, "total_tokens" => 20},
+          "choices" => [
+            %{
+              "message" => %{
+                "content" => "Perplexity is a search engine that uses AI."
+              },
+              "finish_reason" => "stop"
+            }
+          ]
+        })
+      end)
+
+      assert {:ok,
+              %Signal{
+                schema_id: ResponseSignal,
+                payload: %{
+                  content: %{"text" => "Perplexity is a search engine that uses AI."},
+                  finish_reason: "stop",
+                  tool_calls: nil,
+                  tool_calls_results: nil
+                },
+                metadata: %{
+                  id: "test-id-456"
+                }
+              }} = Perplexity.call("What is Perplexity?", [], config)
+    end
+
+    test "returns error on 401" do
+      config = %{
+        api_key: "bad_key",
+        model: "sonar-pro"
+      }
+
+      Req.Test.expect(Perplexity, fn conn ->
+        Plug.Conn.send_resp(conn, 401, ~s({"error": {"message": "Invalid API key"}}))
+      end)
+
+      assert {:error, :invalid_api_key} = Perplexity.call("test", [], config)
+    end
+  end
+end

--- a/lux/test/unit/lux/llm/openrouter_test.exs
+++ b/lux/test/unit/lux/llm/openrouter_test.exs
@@ -1,0 +1,133 @@
+defmodule Lux.LLM.OpenRouterTest do
+  use Lux.Test.Support.Case, async: true
+
+  alias Lux.LLM.OpenRouter
+
+  describe "OpenRouter /chat/completions" do
+    @tag :external
+    test "returns a response for a simple prompt" do
+      assert {:ok, signal} =
+               OpenRouter.call("What is the capital of France?", [], %{model: "openrouter/auto", api_key: "test"})
+
+      assert signal.schema_id == "response"
+    end
+
+    @tag :external
+    test "handles invalid API key" do
+      assert {:error, :invalid_api_key} =
+               OpenRouter.call("test", [], %{api_key: "invalid"})
+    end
+  end
+end
+
+  describe "call/3" do
+    test "makes correct API call" do
+      config = %{
+        api_key: "test_key",
+        model: "sonar-pro"
+      }
+
+      Req.Test.expect(Perplexity, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/v1/chat/completions"
+
+        auth_header = Plug.Conn.get_req_header(conn, "authorization")
+        assert ["Bearer test_key"] = auth_header
+
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        decoded_body = Jason.decode!(body)
+
+        assert decoded_body["model"] == "sonar-pro"
+        assert [%{"role" => "user", "content" => "test prompt"}] = decoded_body["messages"]
+
+        Req.Test.json(conn, %{
+          "id" => "test-id-123",
+          "model" => "sonar-pro",
+          "created" => 1_720_000_000,
+          "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 20, "total_tokens" => 30},
+          "citations" => ["https://example.com"],
+          "choices" => [
+            %{
+              "message" => %{
+                "content" => ~s({"answer": "Test response"})
+              },
+              "finish_reason" => "stop"
+            }
+          ]
+        })
+      end)
+
+      assert {:ok,
+              %Signal{
+                schema_id: ResponseSignal,
+                payload: %{
+                  content: %{"answer" => "Test response"},
+                  finish_reason: "stop",
+                  model: "sonar-pro",
+                  tool_calls: nil,
+                  tool_calls_results: nil
+                },
+                sender: nil,
+                recipient: nil,
+                timestamp: _,
+                metadata: %{
+                  id: "test-id-123",
+                  usage: %{"prompt_tokens" => 10, "completion_tokens" => 20, "total_tokens" => 30},
+                  created: 1_720_000_000,
+                  citations: ["https://example.com"]
+                }
+              }} = Perplexity.call("test prompt", [], config)
+    end
+
+    test "handles non-JSON text content" do
+      config = %{
+        api_key: "test_key",
+        model: "sonar-pro"
+      }
+
+      Req.Test.expect(Perplexity, fn conn ->
+        Req.Test.json(conn, %{
+          "id" => "test-id-456",
+          "model" => "sonar-pro",
+          "created" => 1_720_000_001,
+          "usage" => %{"prompt_tokens" => 5, "completion_tokens" => 15, "total_tokens" => 20},
+          "choices" => [
+            %{
+              "message" => %{
+                "content" => "Perplexity is a search engine that uses AI."
+              },
+              "finish_reason" => "stop"
+            }
+          ]
+        })
+      end)
+
+      assert {:ok,
+              %Signal{
+                schema_id: ResponseSignal,
+                payload: %{
+                  content: %{"text" => "Perplexity is a search engine that uses AI."},
+                  finish_reason: "stop",
+                  tool_calls: nil,
+                  tool_calls_results: nil
+                },
+                metadata: %{
+                  id: "test-id-456"
+                }
+              }} = Perplexity.call("What is Perplexity?", [], config)
+    end
+
+    test "returns error on 401" do
+      config = %{
+        api_key: "bad_key",
+        model: "sonar-pro"
+      }
+
+      Req.Test.expect(Perplexity, fn conn ->
+        Plug.Conn.send_resp(conn, 401, ~s({"error": {"message": "Invalid API key"}}))
+      end)
+
+      assert {:error, :invalid_api_key} = Perplexity.call("test", [], config)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds two new LLM providers:

- **Ollama** (#96): Local LLM inference via `http://localhost:11434/v1/chat/completions`. No API key needed.
- **OpenRouter** (#95): Multi-provider access via `https://openrouter.ai/api/v1/chat/completions`. Supports 200+ models.

Both use OpenAI-compatible API patterns.

Closes #96
Closes #95