### PR TITLE
feat(llm): add OpenRouter provider (#95)

### DIFF
--- a/lux/config/config.exs
+++ b/lux/config/config.exs
@@ -9,6 +9,11 @@ config :lux, :open_ai_models,
 config :lux, :together_ai_models,
   default: "mistralai/Mistral-7B-Instruct-v0.2"
 
+config :lux, :open_router_models,
+  cheapest: "openai/gpt-4o-mini",
+  default: "openai/gpt-4o-mini",
+  smartest: "anthropic/claude-3.5-sonnet"
+
 config :venomous, :snake_manager, %{
   snake_ttl_minutes: 10,
   perpetual_workers: 2,

--- a/lux/config/runtime.exs
+++ b/lux/config/runtime.exs
@@ -19,6 +19,7 @@ if config_env() in [:dev, :test] do
     mira: env!("MIRA_API_KEY", :string!, "missing mira"),
     together: env!("TOGETHER_API_KEY", :string!, "missing together"),
     anthropic: env!("ANTHROPIC_API_KEY", :string!, "missing anthropic"),
+    openrouter: env!("OPENROUTER_API_KEY", :string!, "missing open router"),
     openweather: env!("OPENWEATHER_API_KEY", :string!, "missing open weather"),
     transpose: env!("TRANSPOSE_API_KEY", :string!, "missing transpose"),
     discord: env!("DISCORD_API_KEY", :string!, "missing discord"),

--- a/lux/config/runtime.exs
+++ b/lux/config/runtime.exs
@@ -28,6 +28,7 @@ if config_env() in [:dev, :test] do
     telegram_bot: env!("TELEGRAM_BOT_TOKEN", :string!, required: false),
     integration_openai: env!("INTEGRATION_OPENAI_API_KEY", :string!, "missing open ai"),
     integration_anthropic: env!("INTEGRATION_ANTHROPIC_API_KEY", :string!, "missing anthropic"),
+    integration_openrouter: env!("INTEGRATION_OPENROUTER_API_KEY", :string!, "missing open router"),
     integration_openweather: env!("INTEGRATION_OPENWEATHER_API_KEY", :string!, "missing open weather"),
     integration_transpose: env!("INTEGRATION_TRANSPOSE_API_KEY", :string!, "missing transpose"),
     integration_discord: env!("INTEGRATION_DISCORD_API_KEY", :string!, "missing discord"),

--- a/lux/guides/agents.livemd
+++ b/lux/guides/agents.livemd
@@ -263,6 +263,32 @@ llm_config = %{
 }
 ```
 
+You can also use `Lux.LLM.OpenRouter` as an OpenAI-compatible multi-model gateway supporting fallback arrays, provider routing preferences, dynamic model slugs, site attribution headers, and usage cost accounting in USD:
+
+```elixir
+open_router_config = %{
+  # API configuration
+  api_key: "<OPENROUTER_API_KEY>",
+  model: Application.get_env(:lux, :open_router_models)[:cheapest],
+  
+  # Advanced OpenRouter features
+  models: ["openai/gpt-4o-mini", "anthropic/claude-3.5-sonnet"], # Automatic fallback list
+  provider: %{order: ["OpenAI", "Anthropic"], allow_fallbacks: true},
+  site_url: "https://your-app.com",
+  site_name: "Your App Name",
+  
+  # Dynamic model slug example
+  # model: "~openai/gpt-latest",
+  
+  temperature: 0.7
+}
+
+# Inspect usage costs in USD:
+# {:ok, signal} = Lux.LLM.OpenRouter.call(prompt, [], open_router_config)
+# summary = Lux.LLM.OpenRouter.cost_summary(signal)
+# IO.puts("Total USD spent: #{summary.total_cost}")
+```
+
 ### Structured Responses
 
 Define schemas to get structured responses from your agent:

--- a/lux/lib/lux/llm/open_router.ex
+++ b/lux/lib/lux/llm/open_router.ex
@@ -21,6 +21,25 @@ defmodule Lux.LLM.OpenRouter do
   - **Site attribution headers**: Supports optional `HTTP-Referer` and
     `X-OpenRouter-Title` headers for app identification on OpenRouter leaderboards.
     Configure via `site_url`/`site_name` or `http_referer`/`openrouter_title` keys.
+
+  ## Advanced OpenRouter Features
+
+  - **Model Fallbacks & Provider Routing**: Callers can pass a fallback list of models
+    via `models: ["openai/gpt-4o", "anthropic/claude-3.5-sonnet"]` or provider routing
+    preferences via `provider: %{order: ["OpenAI", "Anthropic"], allow_fallbacks: true}`.
+    Atoms `:cheapest`, `:default`, and `:smartest` are resolved from `config :lux, :open_router_models`.
+
+  - **Retry & Rate-Limit Handling**: Automatically retries HTTP 429 (Too Many Requests)
+    and 503 (No Available Provider) errors by reading the `Retry-After` response header,
+    up to `max_retries` attempts (default: 3).
+
+  - **HTTP 200 Error Envelope Decoding**: OpenRouter can return provider errors after
+    HTTP 200 OK once generation starts. This module decodes `%{"error" => ...}` envelopes
+    in status 200 responses into structured `{:error, {code, message, metadata}}` tuples.
+
+  - **Usage Accounting & Cost Tracking**: Extracts exact cost in USD from the `usage`
+    object (`cost`, `total_cost`, `cost_details`) and includes it in signal metadata.
+    Provides `cost_summary/1` and `within_budget?/2` helpers for budget monitoring.
   """
 
   @behaviour Lux.LLM
@@ -42,7 +61,9 @@ defmodule Lux.LLM.OpenRouter do
     """
     @type t :: %__MODULE__{
             endpoint: String.t(),
-            model: String.t() | nil,
+            model: String.t() | atom() | nil,
+            models: [String.t() | atom()] | nil,
+            provider: map() | nil,
             api_key: String.t() | nil,
             site_url: String.t() | nil,
             site_name: String.t() | nil,
@@ -51,6 +72,7 @@ defmodule Lux.LLM.OpenRouter do
             temperature: float(),
             frequency_penalty: float(),
             receive_timeout: integer(),
+            max_retries: integer(),
             seed: integer() | nil,
             n: integer(),
             json_response: boolean(),
@@ -63,6 +85,8 @@ defmodule Lux.LLM.OpenRouter do
 
     defstruct endpoint: "https://openrouter.ai/api/v1/chat/completions",
               model: nil,
+              models: nil,
+              provider: nil,
               api_key: nil,
               site_url: nil,
               site_name: nil,
@@ -71,6 +95,7 @@ defmodule Lux.LLM.OpenRouter do
               temperature: 0.7,
               frequency_penalty: 0.0,
               receive_timeout: 60_000,
+              max_retries: 3,
               seed: nil,
               n: 1,
               # Defaults to false because OpenRouter is a multi-model gateway
@@ -86,11 +111,7 @@ defmodule Lux.LLM.OpenRouter do
   @impl true
 
   def call(prompt, tools, config) when is_map(config) do
-    default_model =
-      case Application.get_env(:lux, :open_router_models) do
-        models when is_list(models) -> models[:default]
-        _ -> "openai/gpt-4o-mini"
-      end || "openai/gpt-4o-mini"
+    default_model = resolve_model_name(:default) || "openai/gpt-4o-mini"
 
     default_api_key =
       case Application.get_env(:lux, :api_keys) do
@@ -113,15 +134,23 @@ defmodule Lux.LLM.OpenRouter do
     messages = config.messages ++ build_messages(prompt)
     tools_config = build_tools_config(tools)
 
-    resolved_model = Lux.Config.resolve(config.model)
+    resolved_model = resolve_model_name(config.model)
+
+    resolved_models =
+      if is_list(config.models) do
+        Enum.map(config.models, &resolve_model_name/1)
+      else
+        nil
+      end
 
     body =
       %{
-        model: resolved_model,
         messages: messages,
         temperature: config.temperature,
         frequency_penalty: config.frequency_penalty
       }
+      |> maybe_add_model(resolved_model, resolved_models)
+      |> maybe_add_provider(config.provider)
       |> maybe_add_max_tokens(config.max_tokens)
       |> maybe_add_tools(tools_config, config.tool_choice)
       |> maybe_add_response_format(config)
@@ -130,30 +159,42 @@ defmodule Lux.LLM.OpenRouter do
 
     headers = build_headers(config)
 
-    [
-      url: Lux.Config.resolve(config.endpoint || @default_endpoint),
-      json: body,
-      headers: headers,
-      receive_timeout: config.receive_timeout
-    ]
-    |> Keyword.merge(Application.get_env(:lux, __MODULE__, []))
-    |> Req.new()
-    |> Req.post()
-    |> case do
+    req_options =
+      [
+        url: Lux.Config.resolve(config.endpoint || @default_endpoint),
+        json: body,
+        headers: headers,
+        receive_timeout: config.receive_timeout
+      ]
+      |> Keyword.merge(Application.get_env(:lux, __MODULE__, []))
+
+    case post_with_retry(req_options, config.max_retries) do
       {:ok, %{status: 200} = response} ->
         handle_response(response, config)
 
-      {:ok, %{status: 401}} ->
-        {:error, :invalid_api_key}
+      {:ok, %{status: 401, body: body}} ->
+        case decode_error(body) do
+          {:error, {_, msg, meta}} -> {:error, {401, msg || "Invalid API key", meta}}
+          _ -> {:error, :invalid_api_key}
+        end
 
-      {:ok, %{status: status, body: %{"error" => %{"message" => message}}}} ->
-        {:error, {status, message}}
+      {:ok, %{status: status, body: body, headers: resp_headers}} when status in [429, 503] ->
+        {:error, {_, msg, meta}} = decode_error(body)
+        retry_after = get_header_value(resp_headers, "retry-after")
+        ratelimit_remaining = get_header_value(resp_headers, "x-ratelimit-remaining")
 
-      {:ok, %{status: status, body: %{"error" => message}}} when is_binary(message) ->
-        {:error, {status, message}}
+        meta =
+          meta
+          |> Map.put(:retry_after, retry_after)
+          |> Map.put(:ratelimit_remaining, ratelimit_remaining)
+          |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+          |> Map.new()
+
+        {:error, {status, msg, meta}}
 
       {:ok, %{status: status, body: body}} ->
-        {:error, {status, inspect(body)}}
+        {:error, {code, msg, meta}} = decode_error(body)
+        {:error, {status || code, msg, meta}}
 
       {:error, error} ->
         handle_error(error)
@@ -336,6 +377,10 @@ defmodule Lux.LLM.OpenRouter do
     end
   end
 
+  defp handle_response(%{body: %{"error" => _} = body}, _config) do
+    decode_error(body)
+  end
+
   defp handle_response(%{body: body}, _config) when is_map(body) do
     with %{"choices" => [choice | _]} <- body,
          %{"message" => message} <- choice do
@@ -351,11 +396,7 @@ defmodule Lux.LLM.OpenRouter do
           tool_calls_results: tool_calls_results
         }
 
-        usage =
-          case body["usage"] do
-            %{} = u -> u
-            _ -> %{"prompt_tokens" => 0, "completion_tokens" => 0, "total_tokens" => 0}
-          end
+        usage = normalize_usage(body["usage"])
 
         metadata = %{
           id: body["id"],
@@ -490,5 +531,194 @@ defmodule Lux.LLM.OpenRouter do
   defp handle_error(error) do
     Logger.error("OpenRouter API error: #{inspect(error)}")
     {:error, "OpenRouter API error: #{inspect(error)}"}
+  end
+
+  # --- Helpers for Routing, Retries, Cost Accounting, and Error Decoding ---
+
+  defp resolve_model_name(atom) when is_atom(atom) and not is_nil(atom) do
+    case Application.get_env(:lux, :open_router_models) do
+      models when is_list(models) -> models[atom] || to_string(atom)
+      _ -> to_string(atom)
+    end
+  end
+
+  defp resolve_model_name(str) when is_binary(str), do: Lux.Config.resolve(str)
+  defp resolve_model_name(nil), do: nil
+  defp resolve_model_name(other), do: other
+
+  defp maybe_add_model(body, nil, nil), do: Map.put(body, :model, "openai/gpt-4o-mini")
+  defp maybe_add_model(body, model, nil), do: Map.put(body, :model, model)
+  defp maybe_add_model(body, nil, models) when is_list(models), do: Map.put(body, :models, models)
+
+  defp maybe_add_model(body, model, models) when is_list(models) do
+    body
+    |> Map.put(:model, model)
+    |> Map.put(:models, models)
+  end
+
+  defp maybe_add_provider(body, nil), do: body
+  defp maybe_add_provider(body, provider) when is_map(provider), do: Map.put(body, :provider, provider)
+  defp maybe_add_provider(body, _), do: body
+
+  defp post_with_retry(req_options, attempts_left) do
+    case Req.new(req_options) |> Req.post() do
+      {:ok, %{status: status, headers: headers} = response}
+      when status in [429, 503] and attempts_left > 1 ->
+        delay = parse_retry_after(headers)
+        Process.sleep(delay)
+        post_with_retry(req_options, attempts_left - 1)
+
+      other ->
+        other
+    end
+  end
+
+  defp parse_retry_after(headers) do
+    case get_header_value(headers, "retry-after") do
+      nil ->
+        500
+
+      val ->
+        case Integer.parse(to_string(val)) do
+          {sec, _} -> min(sec * 1000, 2000)
+          :error -> 500
+        end
+    end
+  end
+
+  defp get_header_value(headers, name) when is_list(headers) or is_map(headers) do
+    headers
+    |> Enum.find_value(fn
+      {k, v} when is_binary(k) ->
+        if String.downcase(k) == name do
+          if is_list(v), do: List.first(v), else: v
+        end
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp get_header_value(_, _), do: nil
+
+  defp normalize_usage(%{} = u) do
+    cost =
+      case {u["cost"], u["total_cost"]} do
+        {c, _} when is_number(c) -> c * 1.0
+        {_, c} when is_number(c) -> c * 1.0
+        _ -> 0.0
+      end
+
+    %{
+      "prompt_tokens" => u["prompt_tokens"] || 0,
+      "completion_tokens" => u["completion_tokens"] || 0,
+      "total_tokens" => u["total_tokens"] || 0,
+      "cost" => cost,
+      "total_cost" => cost,
+      "cost_details" => u["cost_details"] || %{}
+    }
+  end
+
+  defp normalize_usage(_) do
+    %{
+      "prompt_tokens" => 0,
+      "completion_tokens" => 0,
+      "total_tokens" => 0,
+      "cost" => 0.0,
+      "total_cost" => 0.0,
+      "cost_details" => %{}
+    }
+  end
+
+  @doc """
+  Decodes OpenRouter error envelopes from either HTTP 200 or non-200 responses
+  into a structured `{:error, {code, message, metadata}}` tuple.
+  """
+  def decode_error(%{"error" => %{"code" => code, "message" => message} = err_map}) do
+    metadata = Map.get(err_map, "metadata", %{})
+    {:error, {code, message, metadata}}
+  end
+
+  def decode_error(%{"error" => %{"message" => message} = err_map}) do
+    code = Map.get(err_map, "code", 500)
+    metadata = Map.get(err_map, "metadata", %{})
+    {:error, {code, message, metadata}}
+  end
+
+  def decode_error(%{"error" => message}) when is_binary(message) do
+    {:error, {500, message, %{}}}
+  end
+
+  def decode_error(other) when is_binary(other) do
+    case Jason.decode(other) do
+      {:ok, decoded} -> decode_error(decoded)
+      _ -> {:error, {500, other, %{}}}
+    end
+  end
+
+  def decode_error(other) do
+    {:error, {500, inspect(other), %{}}}
+  end
+
+  @doc """
+  Aggregates cost and token usage statistics across a single `ResponseSignal`
+  or a list of `ResponseSignal` structs (or raw usage maps).
+  """
+  def cost_summary(signals_or_usages) when is_list(signals_or_usages) do
+    Enum.reduce(
+      signals_or_usages,
+      %{
+        total_cost: 0.0,
+        total_tokens: 0,
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        by_model: %{}
+      },
+      fn item, acc ->
+        {usage, model} = extract_usage_and_model(item)
+        cost = Map.get(usage, "cost", 0.0)
+        p_tokens = Map.get(usage, "prompt_tokens", 0)
+        c_tokens = Map.get(usage, "completion_tokens", 0)
+        t_tokens = Map.get(usage, "total_tokens", p_tokens + c_tokens)
+
+        model_key = model || "unknown"
+        current_model_stats = Map.get(acc.by_model, model_key, %{cost: 0.0, calls: 0, tokens: 0})
+        updated_model_stats = %{
+          cost: current_model_stats.cost + cost,
+          calls: current_model_stats.calls + 1,
+          tokens: current_model_stats.tokens + t_tokens
+        }
+
+        %{
+          total_cost: acc.total_cost + cost,
+          total_tokens: acc.total_tokens + t_tokens,
+          prompt_tokens: acc.prompt_tokens + p_tokens,
+          completion_tokens: acc.completion_tokens + c_tokens,
+          by_model: Map.put(acc.by_model, model_key, updated_model_stats)
+        }
+      end
+    )
+  end
+
+  def cost_summary(signal_or_usage), do: cost_summary([signal_or_usage])
+
+  defp extract_usage_and_model(%ResponseSignal{metadata: %{usage: usage}, payload: %{model: model}}),
+    do: {usage, model}
+
+  defp extract_usage_and_model(%ResponseSignal{metadata: %{usage: usage}}), do: {usage, "unknown"}
+  defp extract_usage_and_model(%{"cost" => _} = usage), do: {usage, "unknown"}
+  defp extract_usage_and_model(_), do: {%{}, "unknown"}
+
+  @doc """
+  Checks if a single `ResponseSignal`, usage map, or accumulated cost float
+  is within a specified `max_budget_usd`.
+  """
+  def within_budget?(cost_float, max_budget_usd) when is_number(cost_float) and is_number(max_budget_usd) do
+    cost_float <= max_budget_usd
+  end
+
+  def within_budget?(%{} = signal_or_usage, max_budget_usd) when is_number(max_budget_usd) do
+    summary = cost_summary(signal_or_usage)
+    summary.total_cost <= max_budget_usd
   end
 end

--- a/lux/lib/lux/llm/open_router.ex
+++ b/lux/lib/lux/llm/open_router.ex
@@ -573,7 +573,7 @@ defmodule Lux.LLM.OpenRouter do
         max_delay = Map.get(config, :max_retry_delay, 60_000) || 60_000
 
         if delay > max_delay do
-          response
+          {:ok, response}
         else
           sleeper = Map.get(config, :sleeper) || (&Process.sleep/1)
           sleeper.(delay)

--- a/lux/lib/lux/llm/open_router.ex
+++ b/lux/lib/lux/llm/open_router.ex
@@ -48,6 +48,7 @@ defmodule Lux.LLM.OpenRouter do
   alias Lux.Lens
   alias Lux.LLM.ResponseSignal
   alias Lux.Prism
+  alias Lux.Signal
 
   require Beam
   require Lens
@@ -73,6 +74,8 @@ defmodule Lux.LLM.OpenRouter do
             frequency_penalty: float(),
             receive_timeout: integer(),
             max_retries: integer(),
+            max_retry_delay: integer(),
+            sleeper: (integer() -> any()) | nil,
             seed: integer() | nil,
             n: integer(),
             json_response: boolean(),
@@ -96,6 +99,8 @@ defmodule Lux.LLM.OpenRouter do
               frequency_penalty: 0.0,
               receive_timeout: 60_000,
               max_retries: 3,
+              max_retry_delay: 60_000,
+              sleeper: nil,
               seed: nil,
               n: 1,
               # Defaults to false because OpenRouter is a multi-model gateway
@@ -168,7 +173,7 @@ defmodule Lux.LLM.OpenRouter do
       ]
       |> Keyword.merge(Application.get_env(:lux, __MODULE__, []))
 
-    case post_with_retry(req_options, config.max_retries) do
+    case post_with_retry(req_options, config.max_retries, config) do
       {:ok, %{status: 200} = response} ->
         handle_response(response, config)
 
@@ -560,13 +565,20 @@ defmodule Lux.LLM.OpenRouter do
   defp maybe_add_provider(body, provider) when is_map(provider), do: Map.put(body, :provider, provider)
   defp maybe_add_provider(body, _), do: body
 
-  defp post_with_retry(req_options, attempts_left) do
+  defp post_with_retry(req_options, attempts_left, config) do
     case Req.new(req_options) |> Req.post() do
       {:ok, %{status: status, headers: headers} = response}
       when status in [429, 503] and attempts_left > 1 ->
         delay = parse_retry_after(headers)
-        Process.sleep(delay)
-        post_with_retry(req_options, attempts_left - 1)
+        max_delay = Map.get(config, :max_retry_delay, 60_000) || 60_000
+
+        if delay > max_delay do
+          response
+        else
+          sleeper = Map.get(config, :sleeper) || (&Process.sleep/1)
+          sleeper.(delay)
+          post_with_retry(req_options, attempts_left - 1, config)
+        end
 
       other ->
         other
@@ -580,7 +592,7 @@ defmodule Lux.LLM.OpenRouter do
 
       val ->
         case Integer.parse(to_string(val)) do
-          {sec, _} -> min(sec * 1000, 2000)
+          {sec, _} -> max(sec * 1000, 0)
           :error -> 500
         end
     end
@@ -702,10 +714,10 @@ defmodule Lux.LLM.OpenRouter do
 
   def cost_summary(signal_or_usage), do: cost_summary([signal_or_usage])
 
-  defp extract_usage_and_model(%ResponseSignal{metadata: %{usage: usage}, payload: %{model: model}}),
+  defp extract_usage_and_model(%Signal{metadata: %{usage: usage}, payload: %{model: model}}),
     do: {usage, model}
 
-  defp extract_usage_and_model(%ResponseSignal{metadata: %{usage: usage}}), do: {usage, "unknown"}
+  defp extract_usage_and_model(%Signal{metadata: %{usage: usage}}), do: {usage, "unknown"}
   defp extract_usage_and_model(%{"cost" => _} = usage), do: {usage, "unknown"}
   defp extract_usage_and_model(_), do: {%{}, "unknown"}
 

--- a/lux/lib/lux/llm/open_router.ex
+++ b/lux/lib/lux/llm/open_router.ex
@@ -1,0 +1,494 @@
+defmodule Lux.LLM.OpenRouter do
+  @moduledoc """
+  OpenRouter LLM implementation that supports passing Beams, Prisms, and Lenses as tools.
+
+  OpenRouter provides an OpenAI-compatible interface with custom headers for site
+  attribution (`HTTP-Referer` and `X-OpenRouter-Title`). It acts as a unified
+  gateway supporting hundreds of models from different providers (OpenAI,
+  Anthropic, Meta, Google, etc.) through a single API.
+
+  ## Differences from `Lux.LLM.OpenAI`
+
+  - **`json_response` defaults to `false`**: OpenRouter is a multi-model gateway,
+    and many models do not support `response_format`. Users should explicitly set
+    `json_response: true` when using models that support structured output.
+
+  - **Plain-text content handling**: Unlike the OpenAI provider, `parse_content/1`
+    wraps non-JSON text responses in `%{"text" => content}` instead of returning
+    an error. This is intentional since OpenRouter routes to models that
+    frequently return plain-text responses.
+
+  - **Site attribution headers**: Supports optional `HTTP-Referer` and
+    `X-OpenRouter-Title` headers for app identification on OpenRouter leaderboards.
+    Configure via `site_url`/`site_name` or `http_referer`/`openrouter_title` keys.
+  """
+
+  @behaviour Lux.LLM
+
+  alias Lux.Beam
+  alias Lux.Lens
+  alias Lux.LLM.ResponseSignal
+  alias Lux.Prism
+
+  require Beam
+  require Lens
+  require Logger
+
+  @default_endpoint "https://openrouter.ai/api/v1/chat/completions"
+
+  defmodule Config do
+    @moduledoc """
+    Configuration module for OpenRouter.
+    """
+    @type t :: %__MODULE__{
+            endpoint: String.t(),
+            model: String.t() | nil,
+            api_key: String.t() | nil,
+            site_url: String.t() | nil,
+            site_name: String.t() | nil,
+            http_referer: String.t() | nil,
+            openrouter_title: String.t() | nil,
+            temperature: float(),
+            frequency_penalty: float(),
+            receive_timeout: integer(),
+            seed: integer() | nil,
+            n: integer(),
+            json_response: boolean(),
+            json_schema: map() | atom() | nil,
+            max_tokens: integer() | nil,
+            tool_choice: map() | String.t() | atom() | nil,
+            user: String.t() | nil,
+            messages: [map()]
+          }
+
+    defstruct endpoint: "https://openrouter.ai/api/v1/chat/completions",
+              model: nil,
+              api_key: nil,
+              site_url: nil,
+              site_name: nil,
+              http_referer: nil,
+              openrouter_title: nil,
+              temperature: 0.7,
+              frequency_penalty: 0.0,
+              receive_timeout: 60_000,
+              seed: nil,
+              n: 1,
+              # Defaults to false because OpenRouter is a multi-model gateway
+              # and many models do not support response_format.
+              json_response: false,
+              json_schema: nil,
+              max_tokens: nil,
+              tool_choice: nil,
+              user: nil,
+              messages: []
+  end
+
+  @impl true
+
+  def call(prompt, tools, config) when is_map(config) do
+    default_model =
+      case Application.get_env(:lux, :open_router_models) do
+        models when is_list(models) -> models[:default]
+        _ -> "openai/gpt-4o-mini"
+      end || "openai/gpt-4o-mini"
+
+    default_api_key =
+      case Application.get_env(:lux, :api_keys) do
+        keys when is_list(keys) -> keys[:openrouter]
+        _ -> nil
+      end
+
+    config =
+      struct(
+        Config,
+        Map.merge(
+          %{
+            model: default_model,
+            api_key: default_api_key
+          },
+          config
+        )
+      )
+
+    messages = config.messages ++ build_messages(prompt)
+    tools_config = build_tools_config(tools)
+
+    resolved_model = Lux.Config.resolve(config.model)
+
+    body =
+      %{
+        model: resolved_model,
+        messages: messages,
+        temperature: config.temperature,
+        frequency_penalty: config.frequency_penalty
+      }
+      |> maybe_add_max_tokens(config.max_tokens)
+      |> maybe_add_tools(tools_config, config.tool_choice)
+      |> maybe_add_response_format(config)
+      |> maybe_add_user(config.user)
+      |> maybe_add_n(config.n)
+
+    headers = build_headers(config)
+
+    [
+      url: Lux.Config.resolve(config.endpoint || @default_endpoint),
+      json: body,
+      headers: headers,
+      receive_timeout: config.receive_timeout
+    ]
+    |> Keyword.merge(Application.get_env(:lux, __MODULE__, []))
+    |> Req.new()
+    |> Req.post()
+    |> case do
+      {:ok, %{status: 200} = response} ->
+        handle_response(response, config)
+
+      {:ok, %{status: 401}} ->
+        {:error, :invalid_api_key}
+
+      {:ok, %{status: status, body: %{"error" => %{"message" => message}}}} ->
+        {:error, {status, message}}
+
+      {:ok, %{status: status, body: %{"error" => message}}} when is_binary(message) ->
+        {:error, {status, message}}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, {status, inspect(body)}}
+
+      {:error, error} ->
+        handle_error(error)
+    end
+  end
+
+  defp build_messages(prompt) when is_binary(prompt) do
+    [%{role: "user", content: prompt}]
+  end
+
+  defp build_tools_config([]), do: []
+  defp build_tools_config(tools), do: Enum.map(tools, &tool_to_function/1)
+
+  defp maybe_add_tools(body, [], _tool_choice), do: body
+
+  defp maybe_add_tools(body, tools, tool_choice) do
+    body
+    |> Map.put(:tools, tools)
+    |> Map.put(:tool_choice, format_tool_choice(tool_choice))
+  end
+
+  defp format_tool_choice(:none), do: "none"
+  defp format_tool_choice(:auto), do: "auto"
+
+  defp format_tool_choice(name) when is_binary(name) do
+    %{"type" => "function", "function" => %{"name" => String.replace(name, ".", "_")}}
+  end
+
+  defp format_tool_choice(choice) when is_map(choice), do: choice
+  defp format_tool_choice(_), do: "auto"
+
+  defp maybe_add_max_tokens(body, nil), do: body
+  defp maybe_add_max_tokens(body, max_tokens), do: Map.put(body, :max_tokens, max_tokens)
+
+  defp maybe_add_user(body, nil), do: body
+  defp maybe_add_user(body, user), do: Map.put(body, :user, user)
+
+  defp maybe_add_n(body, nil), do: body
+  defp maybe_add_n(body, 1), do: body
+  defp maybe_add_n(body, n), do: Map.put(body, :n, n)
+
+  defp maybe_add_response_format(body, %Config{json_response: false}), do: body
+
+  defp maybe_add_response_format(body, %Config{json_response: true, json_schema: schema})
+       when is_map(schema) and map_size(schema) > 0 do
+    Map.put(body, :response_format, %{
+      type: "json_schema",
+      json_schema: schema
+    })
+  end
+
+  defp maybe_add_response_format(body, %Config{json_response: true, json_schema: schema})
+       when is_atom(schema) and not is_nil(schema) do
+    Map.put(body, :response_format, %{
+      type: "json_schema",
+      json_schema: %{name: schema.name(), schema: schema.schema()}
+    })
+  end
+
+  defp maybe_add_response_format(body, %Config{json_response: true, json_schema: nil}) do
+    Map.put(
+      %{
+        body
+        | messages:
+            Enum.map(body.messages, fn
+              %{role: "user", content: content} = msg ->
+                %{msg | content: content <> "\n Reply in json format"}
+
+              msg ->
+                msg
+            end)
+      },
+      :response_format,
+      %{type: "json_object"}
+    )
+  end
+
+  defp maybe_add_response_format(body, _), do: body
+
+  defp build_headers(config) do
+    resolved_api_key = Lux.Config.resolve(config.api_key)
+
+    site_url =
+      cond do
+        is_binary(config.http_referer) and config.http_referer != "" -> Lux.Config.resolve(config.http_referer)
+        is_binary(config.site_url) and config.site_url != "" -> Lux.Config.resolve(config.site_url)
+        true -> nil
+      end
+
+    site_name =
+      cond do
+        is_binary(config.openrouter_title) and config.openrouter_title != "" -> Lux.Config.resolve(config.openrouter_title)
+        is_binary(config.site_name) and config.site_name != "" -> Lux.Config.resolve(config.site_name)
+        true -> nil
+      end
+
+    headers = [
+      {"Authorization", "Bearer #{resolved_api_key}"},
+      {"Content-Type", "application/json"}
+    ]
+
+    headers =
+      if is_binary(site_url) and site_url != "" do
+        headers ++ [{"HTTP-Referer", site_url}]
+      else
+        headers
+      end
+
+    headers =
+      if is_binary(site_name) and site_name != "" do
+        headers ++ [{"X-OpenRouter-Title", site_name}]
+      else
+        headers
+      end
+
+    headers
+  end
+
+  def tool_to_function({:python, path}) do
+    path
+    |> Prism.view()
+    |> tool_to_function()
+  end
+
+  def tool_to_function(tool_module) when is_atom(tool_module) and not is_nil(tool_module) do
+    cond do
+      Lux.prism?(tool_module) ->
+        tool_to_function(tool_module.view())
+
+      Lux.beam?(tool_module) ->
+        tool_to_function(tool_module.view())
+
+      Lux.lens?(tool_module) ->
+        tool_to_function(tool_module.view())
+
+      true ->
+        raise "Unsupported tool type: #{inspect(tool_module)}"
+    end
+  end
+
+  def tool_to_function(%Beam{module_name: name, description: description, input_schema: input_schema}) do
+    %{
+      type: "function",
+      function: %{
+        # OpenRouter function names must be [a-zA-Z0-9_-]
+        name: String.replace(name, ".", "_"),
+        description: description || "",
+        parameters: input_schema
+      }
+    }
+  end
+
+  def tool_to_function(%Prism{module_name: name, description: description, input_schema: input_schema}) do
+    %{
+      type: "function",
+      function: %{
+        # OpenRouter function names must be [a-zA-Z0-9_-]
+        name: String.replace(name, ".", "_"),
+        description: description || "",
+        parameters: input_schema
+      }
+    }
+  end
+
+  def tool_to_function(%Lens{module_name: name, description: description, schema: schema}) do
+    %{
+      type: "function",
+      function: %{
+        name: String.replace(name, ".", "_"),
+        description: description || "",
+        parameters: schema
+      }
+    }
+  end
+
+  defp handle_response(%{body: body}, _config) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, decoded} -> handle_response(%{body: decoded}, _config)
+      {:error, _} -> {:error, "Failed to decode response body: #{inspect(body)}"}
+    end
+  end
+
+  defp handle_response(%{body: body}, _config) when is_map(body) do
+    with %{"choices" => [choice | _]} <- body,
+         %{"message" => message} <- choice do
+      finish_reason = Map.get(choice, "finish_reason") || "stop"
+
+      with {:ok, content} <- parse_content(message["content"]),
+           {:ok, tool_calls_results} <- execute_tool_calls(message["tool_calls"]) do
+        payload = %{
+          content: content,
+          model: body["model"],
+          finish_reason: finish_reason,
+          tool_calls: message["tool_calls"],
+          tool_calls_results: tool_calls_results
+        }
+
+        usage =
+          case body["usage"] do
+            %{} = u -> u
+            _ -> %{"prompt_tokens" => 0, "completion_tokens" => 0, "total_tokens" => 0}
+          end
+
+        metadata = %{
+          id: body["id"],
+          created: body["created"],
+          usage: usage,
+          system_fingerprint: body["system_fingerprint"]
+        }
+
+        %{
+          schema_id: ResponseSignal,
+          payload: payload,
+          metadata: metadata
+        }
+        |> Lux.Signal.new()
+        |> ResponseSignal.validate()
+      end
+    else
+      _ -> {:error, "Invalid response payload from OpenRouter"}
+    end
+  end
+
+  def parse_content(content) when is_binary(content) do
+    case Jason.decode(content) do
+      {:ok, structured_output} when is_map(structured_output) ->
+        {:ok, structured_output}
+
+      {:error, _} ->
+        {:ok, %{"text" => content}}
+
+      {:ok, other} ->
+        {:ok, %{"text" => inspect(other)}}
+    end
+  end
+
+  def parse_content(nil), do: {:ok, nil}
+  def parse_content(other), do: {:ok, other}
+
+  def execute_tool_calls(tool_calls) when is_list(tool_calls) do
+    results = Enum.map(tool_calls, &execute_tool_call/1)
+
+    if Enum.all?(results, fn
+         {:ok, _} -> true
+         {:ok, _, _} -> true
+         _ -> false
+       end) do
+      unwrapped =
+        Enum.map(results, fn
+          {:ok, res, _log} -> res
+          {:ok, res} -> res
+        end)
+
+      {:ok, unwrapped}
+    else
+      error = Enum.find(results, &match?({:error, _}, &1)) || {:error, "Tool call execution failed"}
+      error
+    end
+  end
+
+  def execute_tool_calls(nil), do: {:ok, nil}
+
+  def execute_tool_call(%{"function" => %{"name" => tool_name, "arguments" => args}}) when is_binary(args) do
+    case Jason.decode(args) do
+      {:ok, decoded_args} ->
+        try do
+          execute_tool(tool_name, decoded_args, nil)
+        rescue
+          e -> {:error, "Error executing tool #{tool_name}: #{inspect(e)}"}
+        end
+
+      {:error, error} ->
+        {:error, "Failed to decode arguments for tool #{tool_name}: #{inspect(error)}"}
+    end
+  end
+
+  def execute_tool_call(%{"function" => %{"name" => tool_name, "arguments" => args}}) when is_map(args) do
+    try do
+      execute_tool(tool_name, args, nil)
+    rescue
+      e -> {:error, "Error executing tool #{tool_name}: #{inspect(e)}"}
+    end
+  end
+
+  def execute_tool_call(%{"function" => %{"name" => tool_name}}) do
+    {:error, "Missing arguments for tool #{tool_name}"}
+  end
+
+  def execute_tool_call(other) do
+    {:error, "Invalid tool call format: #{inspect(other)}"}
+  end
+
+  def execute_tool(tool_name, args, ctx \\ nil)
+
+  def execute_tool(tool_name, args, ctx) when is_binary(tool_name) do
+    tool_name
+    |> String.replace("_", ".")
+    |> List.wrap()
+    |> Module.concat()
+    |> Code.ensure_loaded()
+    |> case do
+      {:module, module_name} ->
+        execute_tool(module_name, args, ctx)
+
+      {:error, :nofile} ->
+        {:error,
+         "Failed to load tool module #{tool_name}: It doesn't seems to be implemented or reacheable"}
+
+      {:error, error} ->
+        {:error, "Failed to load tool module #{tool_name}: #{inspect(error)}"}
+    end
+  end
+
+  def execute_tool(tool_module, args, ctx) when is_atom(tool_module) do
+    cond do
+      Lux.prism?(tool_module) ->
+        tool_module.handler(args, ctx)
+
+      Lux.beam?(tool_module) ->
+        tool_module.run(args, ctx)
+
+      Lux.lens?(tool_module) ->
+        tool_module.focus(args)
+
+      true ->
+        {:error,
+         """
+         Tool #{tool_module} does not seem to be a valid Beam or Prism
+         as it does not have a registered `handler` or `run` function.
+         """}
+    end
+  end
+
+  defp handle_error(error) do
+    Logger.error("OpenRouter API error: #{inspect(error)}")
+    {:error, "OpenRouter API error: #{inspect(error)}"}
+  end
+end

--- a/lux/test.envrc.example
+++ b/lux/test.envrc.example
@@ -2,3 +2,4 @@
 ALLORA_API_KEY="test-allora-key"
 ALLORA_BASE_URL="https://api.upshot.xyz/v2"
 ALLORA_CHAIN_SLUG="testnet" 
+INTEGRATION_OPENROUTER_API_KEY="test-openrouter-key"

--- a/lux/test/integration/open_router_test.exs
+++ b/lux/test/integration/open_router_test.exs
@@ -1,0 +1,68 @@
+defmodule Lux.Integration.LLM.OpenRouterTest do
+  @moduledoc false
+  use IntegrationCase, async: true
+
+  alias Lux.LLM.OpenRouter
+  alias Lux.LLM.ResponseSignal
+  alias Lux.Signal
+  alias Lux.SignalSchema
+
+  describe "simple text request and response, no tools or structure output" do
+    setup do
+      config = %{
+        api_key: Application.get_env(:lux, :api_keys)[:integration_openrouter],
+        model: Application.get_env(:lux, :open_router_models)[:cheapest],
+        temperature: 0.7
+      }
+
+      %{config: config}
+    end
+
+    test "it still returns a structured response with usage and cost metadata", %{config: config} do
+      assert {:ok,
+              %Signal{
+                id: _,
+                metadata: %{
+                  id: _,
+                  usage: %{
+                    "completion_tokens" => _,
+                    "prompt_tokens" => _,
+                    "total_tokens" => _
+                  },
+                  created: _,
+                  system_fingerprint: _
+                },
+                payload: %{
+                  model: _,
+                  content: %{"text" => _},
+                  tool_calls: nil,
+                  tool_calls_results: nil,
+                  finish_reason: "stop"
+                }
+              } = signal} = OpenRouter.call("Reply with exactly the word Paris and nothing else.", [], config)
+
+      summary = OpenRouter.cost_summary(signal)
+      assert summary.total_tokens > 0
+    end
+  end
+
+  describe "fallback model routing" do
+    setup do
+      config = %{
+        api_key: Application.get_env(:lux, :api_keys)[:integration_openrouter],
+        models: [
+          Application.get_env(:lux, :open_router_models)[:cheapest],
+          Application.get_env(:lux, :open_router_models)[:smartest]
+        ],
+        temperature: 0.7
+      }
+
+      %{config: config}
+    end
+
+    test "supports models fallback array in config", %{config: config} do
+      assert {:ok, %Signal{payload: %{model: _}}} =
+               OpenRouter.call("Reply with exactly OK.", [], config)
+    end
+  end
+end

--- a/lux/test/test_helper.exs
+++ b/lux/test/test_helper.exs
@@ -9,6 +9,7 @@ defmodule UnitAPICase do
   alias Lux.Lenses.Etherscan
   alias Lux.LLM.Anthropic
   alias Lux.LLM.OpenAI
+  alias Lux.LLM.OpenRouter
   alias Lux.LLM.TogetherAI
 
   using do
@@ -25,6 +26,7 @@ defmodule UnitAPICase do
     Application.put_env(:lux, DiscordClient, plug: {Req.Test, DiscordClientMock})
     Application.put_env(:lux, TelegramClient, plug: {Req.Test, TelegramClientMock})
     Application.put_env(:lux, TogetherAI, plug: {Req.Test, TogetherAI})
+    Application.put_env(:lux, OpenRouter, plug: {Req.Test, OpenRouter})
     :ok
   end
 end

--- a/lux/test/unit/lux/llm/open_router_test.exs
+++ b/lux/test/unit/lux/llm/open_router_test.exs
@@ -745,6 +745,61 @@ defmodule Lux.LLM.OpenRouterTest do
       assert metadata.retry_after == "2"
       assert metadata.ratelimit_remaining == "0"
     end
+
+    test "retries on 429 rate limit using injectable sleeper without sleeping" do
+      parent = self()
+
+      config = %OpenRouter.Config{
+        endpoint: "http://localhost/test/openrouter/rate_retry",
+        api_key: "test-key",
+        max_retries: 3,
+        max_retry_delay: 60_000,
+        sleeper: fn ms -> send(parent, {:slept, ms}) end
+      }
+
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      Req.Test.stub(OpenRouter, fn conn ->
+        attempt = Agent.get_and_update(counter, fn c -> {c + 1, c + 1} end)
+
+        if attempt < 3 do
+          conn
+          |> Plug.Conn.put_resp_header("retry-after", "5")
+          |> Plug.Conn.send_resp(429, ~s({"error": {"code": 429, "message": "Rate limit"}}))
+        else
+          Req.Test.json(conn, %{
+            "model" => "openai/gpt-4o",
+            "choices" => [
+              %{"message" => %{"content" => "Retried successfully"}, "finish_reason" => "stop"}
+            ]
+          })
+        end
+      end)
+
+      assert {:ok, _signal} = OpenRouter.call("test prompt", [], config)
+      assert_received {:slept, 5000}
+      assert_received {:slept, 5000}
+    end
+
+    test "does not retry when Retry-After exceeds max_retry_delay policy" do
+      config = %OpenRouter.Config{
+        endpoint: "http://localhost/test/openrouter/rate_exceed",
+        api_key: "test-key",
+        max_retries: 3,
+        max_retry_delay: 10_000
+      }
+
+      Req.Test.stub(OpenRouter, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("retry-after", "60")
+        |> Plug.Conn.send_resp(429, ~s({"error": {"code": 429, "message": "Long delay"}}))
+      end)
+
+      assert {:error, {429, "Long delay", metadata}} =
+               OpenRouter.call("test prompt", [], config)
+
+      assert metadata.retry_after == "60"
+    end
   end
 
   describe "usage accounting and cost tracking" do

--- a/lux/test/unit/lux/llm/open_router_test.exs
+++ b/lux/test/unit/lux/llm/open_router_test.exs
@@ -1,0 +1,649 @@
+defmodule Lux.LLM.OpenRouterTest do
+  use UnitAPICase, async: true
+
+  alias Lux.LLM.OpenRouter
+  alias Lux.LLM.ResponseSignal
+  alias Lux.Signal
+
+  require Lux.Beam
+  require Lux.Lens
+  require Lux.Prism
+
+  defmodule TestPrism do
+    @moduledoc false
+    use Lux.Prism,
+      name: "Test Prism",
+      input_schema: %{type: :object, properties: %{value: %{type: :string}}},
+      description: "A test prism"
+
+    def handler(%{"value" => "success"}, _context), do: {:ok, %{result: "success test"}}
+    def handler(%{"value" => "failure"}, _context), do: {:error, "failure test"}
+  end
+
+  defmodule TestBeam do
+    @moduledoc false
+    use Lux.Beam,
+      name: "Test Beam",
+      input_schema: %{type: :object, properties: %{value: %{type: :string}}},
+      description: "A test beam"
+
+    sequence do
+      step(:test, TestPrism, %{})
+    end
+  end
+
+  defmodule ExceptionPrism do
+    @moduledoc false
+    use Lux.Prism,
+      name: "Exception Prism",
+      input_schema: %{type: :object},
+      description: "A prism that raises an error"
+
+    def handler(_params, _context) do
+      raise "tool execution exception test"
+    end
+  end
+
+  defmodule TestLensWithSchema do
+    @moduledoc false
+    use Lux.Lens,
+      name: "WeatherAPI",
+      description: "Gets weather data",
+      schema: %{
+        type: "object",
+        properties: %{
+          location: %{
+            type: "string",
+            description: "City name"
+          },
+          units: %{
+            type: "string",
+            description: "Temperature units"
+          }
+        }
+      }
+  end
+
+  defmodule TestLensWithParams do
+    @moduledoc false
+    use Lux.Lens,
+      name: "ParamsAPI",
+      description: "Gets params data",
+      params: %{
+        type: "object",
+        properties: %{
+          query: %{
+            type: "string",
+            description: "Query parameter"
+          }
+        }
+      }
+  end
+
+  setup do
+    Req.Test.verify_on_exit!()
+  end
+
+  describe "tool_to_function/1" do
+    test "converts a beam to an OpenRouter function" do
+      beam = TestBeam.view()
+
+      function = OpenRouter.tool_to_function(beam)
+
+      assert %{
+               type: "function",
+               function: %{
+                 name: "Lux_LLM_OpenRouterTest_TestBeam",
+                 description: "A test beam",
+                 parameters: %{
+                   type: :object,
+                   properties: %{
+                     value: %{type: :string}
+                   }
+                 }
+               }
+             } = function
+    end
+
+    test "converts a prism to an OpenRouter function" do
+      prism = TestPrism.view()
+
+      function = OpenRouter.tool_to_function(prism)
+
+      assert %{
+               type: "function",
+               function: %{
+                 name: "Lux_LLM_OpenRouterTest_TestPrism",
+                 description: "A test prism",
+                 parameters: %{
+                   type: :object,
+                   properties: %{
+                     value: %{type: :string}
+                   }
+                 }
+               }
+             } = function
+    end
+
+    test "converts a lens with schema to an OpenRouter function" do
+      lens = TestLensWithSchema.view()
+
+      function = OpenRouter.tool_to_function(lens)
+
+      assert %{
+               type: "function",
+               function: %{
+                 name: "Lux_LLM_OpenRouterTest_TestLensWithSchema",
+                 description: "Gets weather data",
+                 parameters: %{
+                   type: "object",
+                   properties: %{
+                     location: %{type: "string", description: "City name"},
+                     units: %{type: "string", description: "Temperature units"}
+                   }
+                 }
+               }
+             } = function
+    end
+
+    test "converts a lens with params to an OpenRouter function" do
+      lens = TestLensWithParams.view()
+
+      function = OpenRouter.tool_to_function(lens)
+
+      assert %{
+               type: "function",
+               function: %{
+                 name: "Lux_LLM_OpenRouterTest_TestLensWithParams",
+                 description: "Gets params data",
+                 parameters: %{
+                   type: "object",
+                   properties: %{
+                     query: %{type: "string", description: "Query parameter"}
+                   }
+                 }
+               }
+             } = function
+    end
+
+    test "converts explicit %Lens{} struct with schema" do
+      lens_schema = %Lux.Lens{
+        name: "ExplicitSchema",
+        module_name: "Explicit.Schema",
+        description: "Schema Lens",
+        schema: %{type: "object", properties: %{field1: %{type: "string"}}}
+      }
+
+      func1 = OpenRouter.tool_to_function(lens_schema)
+      assert func1.function.name == "Explicit_Schema"
+      assert func1.function.parameters == %{type: "object", properties: %{field1: %{type: "string"}}}
+    end
+  end
+
+  describe "call/3" do
+    test "successful API completion with ResponseSignal payload & token usage extraction" do
+      config = %{
+        api_key: "test_key",
+        model: "openai/gpt-4o-mini"
+      }
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/api/v1/chat/completions"
+
+        assert ["Bearer test_key"] = Plug.Conn.get_req_header(conn, "authorization")
+
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        decoded_body = Jason.decode!(body)
+
+        assert decoded_body["model"] == "openai/gpt-4o-mini"
+
+        Req.Test.json(conn, %{
+          "id" => "gen-12345",
+          "created" => 1700000000,
+          "model" => "openai/gpt-4o-mini",
+          "choices" => [
+            %{
+              "message" => %{
+                "content" => ~s({"result": "Successful response"})
+              },
+              "finish_reason" => "stop"
+            }
+          ],
+          "usage" => %{
+            "prompt_tokens" => 12,
+            "completion_tokens" => 8,
+            "total_tokens" => 20
+          }
+        })
+      end)
+
+      assert {:ok,
+              %Signal{
+                schema_id: ResponseSignal,
+                payload: %{
+                  content: %{"result" => "Successful response"},
+                  finish_reason: "stop",
+                  model: "openai/gpt-4o-mini",
+                  tool_calls: nil,
+                  tool_calls_results: nil
+                },
+                metadata: %{
+                  id: "gen-12345",
+                  created: 1700000000,
+                  usage: %{
+                    "prompt_tokens" => 12,
+                    "completion_tokens" => 8,
+                    "total_tokens" => 20
+                  }
+                }
+              }} = OpenRouter.call("test prompt", [], config)
+    end
+
+    test "optional headers: HTTP-Referer and X-OpenRouter-Title passed and verified" do
+      config = %{
+        api_key: "test_key",
+        model: "openai/gpt-4o",
+        site_url: "https://my-awesome-site.com",
+        site_name: "My Awesome App"
+      }
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        assert ["https://my-awesome-site.com"] = Plug.Conn.get_req_header(conn, "http-referer")
+        assert ["My Awesome App"] = Plug.Conn.get_req_header(conn, "x-openrouter-title")
+
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o",
+          "choices" => [
+            %{
+              "message" => %{"content" => ~s({"result": "Header test passed"})},
+              "finish_reason" => "stop"
+            }
+          ],
+          "usage" => %{"prompt_tokens" => 5, "completion_tokens" => 5, "total_tokens" => 10}
+        })
+      end)
+
+      assert {:ok, %Signal{payload: %{content: %{"result" => "Header test passed"}}}} =
+               OpenRouter.call("test prompt", [], config)
+    end
+
+    test "optional headers with http_referer and openrouter_title keys" do
+      config = %{
+        api_key: "test_key",
+        model: "openai/gpt-4o",
+        http_referer: "https://referer-site.com",
+        openrouter_title: "Title App"
+      }
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        assert ["https://referer-site.com"] = Plug.Conn.get_req_header(conn, "http-referer")
+        assert ["Title App"] = Plug.Conn.get_req_header(conn, "x-openrouter-title")
+
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o",
+          "choices" => [
+            %{
+              "message" => %{"content" => ~s({"result": "Referer test passed"})},
+              "finish_reason" => "stop"
+            }
+          ]
+        })
+      end)
+
+      assert {:ok, %Signal{}} = OpenRouter.call("test prompt", [], config)
+    end
+
+    test "dynamic model slugs (e.g. ~openai/gpt-latest)" do
+      config = %{
+        api_key: "test_key",
+        model: "~openai/gpt-latest"
+      }
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        decoded_body = Jason.decode!(body)
+
+        assert decoded_body["model"] == "~openai/gpt-latest"
+
+        Req.Test.json(conn, %{
+          "model" => "~openai/gpt-latest",
+          "choices" => [
+            %{
+              "message" => %{"content" => ~s({"result": "Dynamic slug response"})},
+              "finish_reason" => "stop"
+            }
+          ]
+        })
+      end)
+
+      assert {:ok, %Signal{payload: %{model: "~openai/gpt-latest"}}} =
+               OpenRouter.call("test prompt", [], config)
+    end
+
+    test "handles tool execution (Prism tool call)" do
+      config = %{
+        api_key: "test_key",
+        model: "openai/gpt-4o-mini"
+      }
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o-mini",
+          "choices" => [
+            %{
+              "message" => %{
+                "tool_calls" => [
+                  %{
+                    "type" => "function",
+                    "function" => %{
+                      "name" => "#{TestPrism}",
+                      "arguments" => ~s({"value": "success"})
+                    }
+                  }
+                ]
+              },
+              "finish_reason" => "tool_calls"
+            }
+          ]
+        })
+      end)
+
+      assert {:ok,
+              %Signal{
+                schema_id: ResponseSignal,
+                payload: %{
+                  content: nil,
+                  finish_reason: "tool_calls",
+                  model: "openai/gpt-4o-mini",
+                  tool_calls: [
+                    %{
+                      "function" => %{
+                        "arguments" => ~s({"value": "success"}),
+                        "name" => "Elixir.Lux.LLM.OpenRouterTest.TestPrism"
+                      },
+                      "type" => "function"
+                    }
+                  ],
+                  tool_calls_results: [%{result: "success test"}]
+                }
+              }} = OpenRouter.call("test prompt", [TestPrism], config)
+    end
+
+    test "error status handling: 401 invalid API key" do
+      config = %{
+        api_key: "invalid_key",
+        model: "openai/gpt-4o-mini"
+      }
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        Plug.Conn.send_resp(conn, 401, Jason.encode!(%{"error" => %{"message" => "Invalid API key"}}))
+      end)
+
+      assert {:error, :invalid_api_key} = OpenRouter.call("test prompt", [], config)
+    end
+
+    test "error status handling: 400 bad request" do
+      config = %{
+        api_key: "test_key",
+        model: "openai/gpt-4o-mini"
+      }
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        Plug.Conn.send_resp(conn, 400, Jason.encode!(%{"error" => %{"message" => "Unsupported parameters"}}))
+      end)
+
+      assert {:error, {400, "Unsupported parameters"}} = OpenRouter.call("test prompt", [], config)
+    end
+
+    test "adversarial header handling: dynamic tuple resolution and fallback edge cases" do
+      System.put_env("TEST_OPENROUTER_KEY", "env_secret_key")
+      System.put_env("TEST_SITE_URL", "https://env-site.com")
+      System.put_env("TEST_SITE_NAME", "Env App Name")
+
+      config = %{
+        api_key: {:env, "TEST_OPENROUTER_KEY"},
+        model: "openai/gpt-4o",
+        site_url: {:env, "TEST_SITE_URL"},
+        site_name: {:env, "TEST_SITE_NAME"}
+      }
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        assert ["Bearer env_secret_key"] = Plug.Conn.get_req_header(conn, "authorization")
+        assert ["https://env-site.com"] = Plug.Conn.get_req_header(conn, "http-referer")
+        assert ["Env App Name"] = Plug.Conn.get_req_header(conn, "x-openrouter-title")
+
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o",
+          "choices" => [%{"message" => %{"content" => "OK"}, "finish_reason" => "stop"}]
+        })
+      end)
+
+      assert {:ok, %Signal{}} = OpenRouter.call("test prompt", [], config)
+    end
+
+    test "adversarial model slug handling: custom slugs and model: nil fallback" do
+      config = %{
+        api_key: "test_key",
+        model: "meta-llama/llama-3.3-70b-instruct:free"
+      }
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        decoded = Jason.decode!(body)
+        assert decoded["model"] == "meta-llama/llama-3.3-70b-instruct:free"
+
+        Req.Test.json(conn, %{
+          "model" => "meta-llama/llama-3.3-70b-instruct:free",
+          "choices" => [%{"message" => %{"content" => "OK"}, "finish_reason" => "stop"}]
+        })
+      end)
+
+      assert {:ok, %Signal{payload: %{model: "meta-llama/llama-3.3-70b-instruct:free"}}} =
+               OpenRouter.call("test prompt", [], config)
+    end
+
+    test "adversarial token stats: missing usage, zero usage, and null usage field" do
+      config = %{api_key: "test_key", model: "openai/gpt-4o-mini"}
+
+      # Case A: Missing usage key
+      Req.Test.expect(OpenRouter, fn conn ->
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o-mini",
+          "choices" => [%{"message" => %{"content" => "OK"}, "finish_reason" => "stop"}]
+        })
+      end)
+
+      assert {:ok, %Signal{metadata: %{usage: %{"prompt_tokens" => 0, "completion_tokens" => 0, "total_tokens" => 0}}}} =
+               OpenRouter.call("test prompt", [], config)
+
+      # Case B: Null usage key
+      Req.Test.expect(OpenRouter, fn conn ->
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o-mini",
+          "choices" => [%{"message" => %{"content" => "OK"}, "finish_reason" => "stop"}],
+          "usage" => nil
+        })
+      end)
+
+      assert {:ok, %Signal{metadata: %{usage: %{"prompt_tokens" => 0, "completion_tokens" => 0, "total_tokens" => 0}}}} =
+               OpenRouter.call("test prompt", [], config)
+    end
+
+    test "adversarial error handling: 500 internal server error and string error bodies" do
+      config = %{api_key: "test_key", model: "openai/gpt-4o-mini"}
+
+      # Case 500 nested error
+      Req.Test.expect(OpenRouter, fn conn ->
+        Plug.Conn.send_resp(conn, 500, Jason.encode!(%{"error" => %{"message" => "Internal Server Error"}}))
+      end)
+
+      assert {:error, {500, "Internal Server Error"}} = OpenRouter.call("test prompt", [], config)
+
+      # Case 500 raw HTML error body
+      Req.Test.expect(OpenRouter, fn conn ->
+        Plug.Conn.send_resp(conn, 500, "<html>Bad Gateway</html>")
+      end)
+
+      assert {:error, {500, "\"<html>Bad Gateway</html>\""}} = OpenRouter.call("test prompt", [], config)
+    end
+
+    test "adversarial tool execution: missing module and argument JSON decode failure" do
+      config = %{api_key: "test_key", model: "openai/gpt-4o-mini"}
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o-mini",
+          "choices" => [
+            %{
+              "message" => %{
+                "tool_calls" => [
+                  %{
+                    "type" => "function",
+                    "function" => %{
+                      "name" => "NonExistentModule",
+                      "arguments" => "{invalid_json}"
+                    }
+                  }
+                ]
+              },
+              "finish_reason" => "tool_calls"
+            }
+          ]
+        })
+      end)
+
+      assert {:error, msg} = OpenRouter.call("test prompt", [], config)
+      assert msg =~ "Failed to decode arguments for tool NonExistentModule"
+    end
+
+    test "header truthiness guard: empty string http_referer and openrouter_title fall back to site_url and site_name" do
+      config = %{
+        api_key: "test_key",
+        model: "openai/gpt-4o",
+        http_referer: "",
+        site_url: "https://fallback-url.com",
+        openrouter_title: "",
+        site_name: "Fallback App Title"
+      }
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        assert ["https://fallback-url.com"] = Plug.Conn.get_req_header(conn, "http-referer")
+        assert ["Fallback App Title"] = Plug.Conn.get_req_header(conn, "x-openrouter-title")
+
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o",
+          "choices" => [%{"message" => %{"content" => ~s({"result": "OK"})}, "finish_reason" => "stop"}]
+        })
+      end)
+
+      assert {:ok, %Signal{}} = OpenRouter.call("test prompt", [], config)
+    end
+
+    test "plain-text content parsing compatibility with ResponseSignal schema" do
+      config = %{
+        api_key: "test_key",
+        model: "openai/gpt-4o-mini"
+      }
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o-mini",
+          "choices" => [
+            %{
+              "message" => %{
+                "content" => "This is raw unformatted text content from OpenRouter."
+              },
+              "finish_reason" => "stop"
+            }
+          ]
+        })
+      end)
+
+      assert {:ok,
+              %Signal{
+                schema_id: ResponseSignal,
+                payload: %{
+                  content: %{"text" => "This is raw unformatted text content from OpenRouter."},
+                  finish_reason: "stop"
+                }
+              }} = OpenRouter.call("test prompt", [], config)
+    end
+
+    test "tool execution exception rescue prevents process crash" do
+      config = %{
+        api_key: "test_key",
+        model: "openai/gpt-4o-mini"
+      }
+
+      Req.Test.expect(OpenRouter, fn conn ->
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o-mini",
+          "choices" => [
+            %{
+              "message" => %{
+                "tool_calls" => [
+                  %{
+                    "type" => "function",
+                    "function" => %{
+                      "name" => "#{ExceptionPrism}",
+                      "arguments" => ~s({"value": "trigger_exception"})
+                    }
+                  }
+                ]
+              },
+              "finish_reason" => "tool_calls"
+            }
+          ]
+        })
+      end)
+
+      assert {:error, error_msg} = OpenRouter.call("test prompt", [ExceptionPrism], config)
+      assert error_msg =~ "Error executing tool"
+      assert error_msg =~ "tool execution exception test"
+    end
+  end
+
+  describe "parse_content/1" do
+    test "parses valid JSON string into map" do
+      assert {:ok, %{"key" => "value"}} = OpenRouter.parse_content(~s({"key": "value"}))
+    end
+
+    test "wraps plain text string into text map for ResponseSignal schema compatibility" do
+      assert {:ok, %{"text" => "Plain string"}} = OpenRouter.parse_content("Plain string")
+    end
+
+    test "handles nil and map content" do
+      assert {:ok, nil} = OpenRouter.parse_content(nil)
+      assert {:ok, %{"a" => 1}} = OpenRouter.parse_content(%{"a" => 1})
+    end
+  end
+
+  describe "execute_tool_call/1" do
+    test "rescues runtime exceptions raised by tool execution" do
+      tool_call = %{
+        "function" => %{
+          "name" => "#{ExceptionPrism}",
+          "arguments" => %{"value" => "foo"}
+        }
+      }
+
+      assert {:error, msg} = OpenRouter.execute_tool_call(tool_call)
+      assert msg =~ "Error executing tool"
+      assert msg =~ "tool execution exception test"
+    end
+
+    test "safely reports JSON argument decode failure" do
+      tool_call = %{
+        "function" => %{
+          "name" => "SomeTool",
+          "arguments" => "{invalid_json}"
+        }
+      }
+
+      assert {:error, msg} = OpenRouter.execute_tool_call(tool_call)
+      assert msg =~ "Failed to decode arguments for tool SomeTool"
+    end
+  end
+end
+

--- a/lux/test/unit/lux/llm/open_router_test.exs
+++ b/lux/test/unit/lux/llm/open_router_test.exs
@@ -645,5 +645,147 @@ defmodule Lux.LLM.OpenRouterTest do
       assert msg =~ "Failed to decode arguments for tool SomeTool"
     end
   end
+
+  describe "model routing and fallbacks" do
+    test "includes models fallback array and provider preferences in request body" do
+      config = %OpenRouter.Config{
+        endpoint: "http://localhost/test/openrouter/fallback",
+        api_key: "test-key",
+        models: ["openai/gpt-4o", "anthropic/claude-3.5-sonnet"],
+        provider: %{order: ["OpenAI", "Anthropic"], allow_fallbacks: true}
+      }
+
+      Req.Test.stub(OpenRouter, fn conn ->
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        json_body = Jason.decode!(body)
+
+        assert json_body["models"] == ["openai/gpt-4o", "anthropic/claude-3.5-sonnet"]
+        assert json_body["provider"] == %{"order" => ["OpenAI", "Anthropic"], "allow_fallbacks" => true}
+
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o",
+          "choices" => [
+            %{"message" => %{"content" => "Fallback success"}}
+          ]
+        })
+      end)
+
+      assert {:ok, signal} = OpenRouter.call("test prompt", [], config)
+      assert signal.payload.content == %{"text" => "Fallback success"}
+    end
+
+    test "resolves :cheapest, :default, and :smartest model atoms from Application env" do
+      Application.put_env(:lux, :open_router_models,
+        cheapest: "openai/gpt-4o-mini",
+        default: "openai/gpt-4o",
+        smartest: "anthropic/claude-3.5-sonnet"
+      )
+
+      config = %OpenRouter.Config{
+        endpoint: "http://localhost/test/openrouter/cheapest",
+        api_key: "test-key",
+        model: :cheapest
+      }
+
+      Req.Test.stub(OpenRouter, fn conn ->
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        json_body = Jason.decode!(body)
+        assert json_body["model"] == "openai/gpt-4o-mini"
+
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o-mini",
+          "choices" => [
+            %{"message" => %{"content" => "Cheapest model response"}}
+          ]
+        })
+      end)
+
+      assert {:ok, _signal} = OpenRouter.call("test prompt", [], config)
+    end
+  end
+
+  describe "error handling, retry-after, and HTTP 200 error envelope" do
+    test "decodes structured error envelope returned inside HTTP 200 response" do
+      config = %OpenRouter.Config{
+        endpoint: "http://localhost/test/openrouter/error200",
+        api_key: "test-key"
+      }
+
+      Req.Test.stub(OpenRouter, fn conn ->
+        Req.Test.json(conn, %{
+          "error" => %{
+            "code" => 502,
+            "message" => "Provider upstream error after generation began",
+            "metadata" => %{"provider_name" => "OpenAI"}
+          }
+        })
+      end)
+
+      assert {:error, {502, "Provider upstream error after generation began", %{"provider_name" => "OpenAI"}}} =
+               OpenRouter.call("test prompt", [], config)
+    end
+
+    test "handles 429 rate limit response with Retry-After header and metadata" do
+      config = %OpenRouter.Config{
+        endpoint: "http://localhost/test/openrouter/rate429",
+        api_key: "test-key",
+        max_retries: 1
+      }
+
+      Req.Test.stub(OpenRouter, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("retry-after", "2")
+        |> Plug.Conn.put_resp_header("x-ratelimit-remaining", "0")
+        |> Plug.Conn.send_resp(429, ~s({"error": {"code": 429, "message": "Rate limit exceeded"}}))
+      end)
+
+      assert {:error, {429, "Rate limit exceeded", metadata}} =
+               OpenRouter.call("test prompt", [], config)
+
+      assert metadata.retry_after == "2"
+      assert metadata.ratelimit_remaining == "0"
+    end
+  end
+
+  describe "usage accounting and cost tracking" do
+    test "extracts cost and total_cost from response usage map and supports cost_summary/1" do
+      config = %OpenRouter.Config{
+        endpoint: "http://localhost/test/openrouter/cost",
+        api_key: "test-key"
+      }
+
+      Req.Test.stub(OpenRouter, fn conn ->
+        Req.Test.json(conn, %{
+          "model" => "openai/gpt-4o",
+          "choices" => [
+            %{"message" => %{"content" => "Cost tracked"}}
+          ],
+          "usage" => %{
+            "prompt_tokens" => 100,
+            "completion_tokens" => 50,
+            "total_tokens" => 150,
+            "cost" => 0.015,
+            "cost_details" => %{"upstream_inference_cost" => 0.015}
+          }
+        })
+      end)
+
+      assert {:ok, signal} = OpenRouter.call("test prompt", [], config)
+      assert signal.metadata.usage["cost"] == 0.015
+      assert signal.metadata.usage["total_cost"] == 0.015
+      assert signal.metadata.usage["cost_details"] == %{"upstream_inference_cost" => 0.015}
+
+      summary = OpenRouter.cost_summary(signal)
+      assert summary.total_cost == 0.015
+      assert summary.total_tokens == 150
+      assert summary.prompt_tokens == 100
+      assert summary.completion_tokens == 50
+      assert summary.by_model["openai/gpt-4o"].calls == 1
+      assert summary.by_model["openai/gpt-4o"].cost == 0.015
+
+      assert OpenRouter.within_budget?(signal, 0.02)
+      refute OpenRouter.within_budget?(signal, 0.01)
+    end
+  end
 end
 

--- a/test.envrc
+++ b/test.envrc
@@ -20,3 +20,5 @@ WALLET_ADDRESS="0xdeadbeef"
 WALLET_PRIVATE_KEY="0xdeadbeef"
 DISCORD_API_KEY="test-discord-token"
 MIRA_API_KEY="test_api_key"
+OPENROUTER_API_KEY="test-openrouter-key"
+


### PR DESCRIPTION
Pull Request: Add OpenRouter LLM Provider
Summary
This PR adds a native OpenRouter LLM provider to Lux, resolving Issue #95.

[OpenRouter](https://openrouter.ai/) is a unified AI gateway that provides access to hundreds of models from different providers (OpenAI, Anthropic, Meta, Google, etc.) through a single, OpenAI-compatible API. This integration allows Lux users to leverage any model available on OpenRouter with minimal configuration changes.

Changes
New Files
lib/lux/llm/open_router.ex — Full Lux.LLM behaviour implementation for OpenRouter including:

OpenAI-compatible REST interface with OpenRouter-specific headers (HTTP-Referer, X-OpenRouter-Title) for site attribution
Dynamic model slug support (e.g. ~openai/gpt-latest, meta-llama/llama-3.3-70b-instruct:free)
Native token usage extraction (prompt_tokens, completion_tokens, total_tokens) from API responses
Full tool execution pipeline (Beams, Prisms, and Lenses)
Robust error handling with structured error returns for HTTP 401, 400, 500, and network errors
Environment variable resolution via Lux.Config.resolve/1 for secure API key management
ResponseSignal normalization for seamless integration with Prisms and Beams
test/unit/lux/llm/open_router_test.exs — Comprehensive ExUnit test suite with:

Successful completion with ResponseSignal payload and token usage verification
Header injection tests (HTTP-Referer, X-OpenRouter-Title) via both site_url/site_name and http_referer/openrouter_title config keys
Dynamic model slug passthrough validation
Tool execution tests (Prism, Beam, Lens conversions)
Error handling tests (401, 400, 500, HTML error bodies)
Edge cases: missing/null usage fields, empty header fallbacks, plain-text content parsing, exception rescue during tool execution
Configuration
elixir

# config/config.exs or runtime.exs
config :lux, :api_keys,
  openrouter: {:env, "OPENROUTER_API_KEY"}
config :lux, :open_router_models,
  default: "openai/gpt-4o-mini"
Optional Site Attribution Headers
elixir

# These headers improve your app's visibility on OpenRouter leaderboards
config = %{
  api_key: {:env, "OPENROUTER_API_KEY"},
  model: "anthropic/claude-3.5-sonnet",
  site_url: "https://your-app.com",
  site_name: "Your App Name"
}
Lux.LLM.OpenRouter.call("Hello!", [], config)
Testing
All tests use Req.Test HTTP mocks — no real API calls or API keys needed:

bash

mix test test/lux/llm/open_router_test.exs
Checklist
 Implements Lux.LLM behaviour
 Returns normalized Lux.LLM.ResponseSignal signals
 Supports OpenRouter-specific headers (HTTP-Referer, X-OpenRouter-Title)
 Supports dynamic model slugs (e.g. ~openai/gpt-latest)
 Extracts token usage statistics from responses
 Handles Beams, Prisms, and Lenses as tools
 Comprehensive error handling (401, 400, 500, network errors)
 Full ExUnit test suite with HTTP mocks
 No external dependencies added beyond existing Req and Jason
Resolves #95