### PR TITLE
feat: add telegram bot api core integration lenses (#62)

### DIFF
--- a/lux/lib/lux/integrations/telegram.ex
+++ b/lux/lib/lux/integrations/telegram.ex
@@ -33,17 +33,17 @@ defmodule Lux.Integrations.Telegram do
   Adds Telegram bot token to the URL.
   Used with Req.
   """
-  @spec add_auth_header(Plug.Conn.t()) :: Plug.Conn.t()
-  def add_auth_header(%Plug.Conn{} = conn) do
+  @spec add_auth_header(Lux.Lens.t()) :: Lux.Lens.t()
+  def add_auth_header(%Lux.Lens{} = lens) do
     token = Lux.Config.telegram_bot_token()
-    path = conn.request_path
+    url = lens.url
     
     # Extract and replace bot token placeholder if needed
-    updated_path = if String.contains?(path, "/bot/"), do: 
-      String.replace(path, "/bot/", "/bot#{token}/"), 
+    updated_url = if String.contains?(url, "/bot/"), do: 
+      String.replace(url, "/bot/", "/bot#{token}/"), 
     else: 
-      path
+      url
       
-    %{conn | request_path: updated_path}
+    %{lens | url: updated_url}
   end
 end 

--- a/lux/lib/lux/lenses/telegram/media/send_document.ex
+++ b/lux/lib/lux/lenses/telegram/media/send_document.ex
@@ -1,0 +1,47 @@
+defmodule Lux.Lenses.Telegram.Media.SendDocument do
+  @moduledoc \"\"\"
+  A lens for sending documents via Telegram Bot API.
+  Currently supports sending documents by URL or file_id.
+  \"\"\"
+
+  alias Lux.Integrations.Telegram
+
+  use Lux.Lens,
+    name: "Send Telegram Document",
+    description: "Sends a document to a chat.",
+    url: "https://api.telegram.org/bot/sendDocument",
+    method: :post,
+    headers: Telegram.headers(),
+    auth: Telegram.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        chat_id: %{
+          type: :string,
+          description: "Unique identifier for the target chat"
+        },
+        document: %{
+          type: :string,
+          description: "Document to send. Pass a file_id as String to send a document that exists on the Telegram servers, or pass an HTTP URL as a String for Telegram to get a document from the Internet"
+        },
+        caption: %{
+          type: :string,
+          description: "Document caption, 0-1024 characters after entities parsing"
+        }
+      },
+      required: ["chat_id", "document"]
+    }
+
+  @impl true
+  def after_focus(%{"ok" => true, "result" => result}) do
+    {:ok, result}
+  end
+
+  def after_focus(%{"ok" => false, "description" => description} = error) do
+    {:error, error}
+  end
+
+  def after_focus(error) do
+    {:error, error}
+  end
+end

--- a/lux/lib/lux/lenses/telegram/media/send_photo.ex
+++ b/lux/lib/lux/lenses/telegram/media/send_photo.ex
@@ -1,0 +1,51 @@
+defmodule Lux.Lenses.Telegram.Media.SendPhoto do
+  @moduledoc \"\"\"
+  A lens for sending photos via Telegram Bot API.
+  Currently supports sending photos by URL or file_id.
+  \"\"\"
+
+  alias Lux.Integrations.Telegram
+
+  use Lux.Lens,
+    name: "Send Telegram Photo",
+    description: "Sends a photo to a chat.",
+    url: "https://api.telegram.org/bot/sendPhoto",
+    method: :post,
+    headers: Telegram.headers(),
+    auth: Telegram.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        chat_id: %{
+          type: :string,
+          description: "Unique identifier for the target chat"
+        },
+        photo: %{
+          type: :string,
+          description: "Photo to send. Pass a file_id as String to send a photo that exists on the Telegram servers, or pass an HTTP URL as a String for Telegram to get a photo from the Internet"
+        },
+        caption: %{
+          type: :string,
+          description: "Photo caption, 0-1024 characters after entities parsing"
+        },
+        parse_mode: %{
+          type: :string,
+          description: "Mode for parsing entities"
+        }
+      },
+      required: ["chat_id", "photo"]
+    }
+
+  @impl true
+  def after_focus(%{"ok" => true, "result" => result}) do
+    {:ok, result}
+  end
+
+  def after_focus(%{"ok" => false, "description" => description} = error) do
+    {:error, error}
+  end
+
+  def after_focus(error) do
+    {:error, error}
+  end
+end

--- a/lux/lib/lux/lenses/telegram/messages/delete_message.ex
+++ b/lux/lib/lux/lenses/telegram/messages/delete_message.ex
@@ -1,0 +1,42 @@
+defmodule Lux.Lenses.Telegram.Messages.DeleteMessage do
+  @moduledoc \"\"\"
+  A lens for deleting messages via Telegram Bot API.
+  \"\"\"
+
+  alias Lux.Integrations.Telegram
+
+  use Lux.Lens,
+    name: "Delete Telegram Message",
+    description: "Deletes a message previously sent by the bot.",
+    url: "https://api.telegram.org/bot/deleteMessage",
+    method: :post,
+    headers: Telegram.headers(),
+    auth: Telegram.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        chat_id: %{
+          type: :string,
+          description: "Unique identifier for the target chat"
+        },
+        message_id: %{
+          type: :integer,
+          description: "Identifier of the message to delete"
+        }
+      },
+      required: ["chat_id", "message_id"]
+    }
+
+  @impl true
+  def after_focus(%{"ok" => true, "result" => result}) do
+    {:ok, result}
+  end
+
+  def after_focus(%{"ok" => false, "description" => description} = error) do
+    {:error, error}
+  end
+
+  def after_focus(error) do
+    {:error, error}
+  end
+end

--- a/lux/lib/lux/lenses/telegram/messages/edit_message.ex
+++ b/lux/lib/lux/lenses/telegram/messages/edit_message.ex
@@ -1,0 +1,54 @@
+defmodule Lux.Lenses.Telegram.Messages.EditMessage do
+  @moduledoc \"\"\"
+  A lens for editing text messages via Telegram Bot API.
+  \"\"\"
+
+  alias Lux.Integrations.Telegram
+
+  use Lux.Lens,
+    name: "Edit Telegram Message",
+    description: "Edits a text message previously sent by the bot.",
+    url: "https://api.telegram.org/bot/editMessageText",
+    method: :post,
+    headers: Telegram.headers(),
+    auth: Telegram.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        chat_id: %{
+          type: :string,
+          description: "Unique identifier for the target chat"
+        },
+        message_id: %{
+          type: :integer,
+          description: "Identifier of the message to edit"
+        },
+        text: %{
+          type: :string,
+          description: "New text of the message"
+        },
+        parse_mode: %{
+          type: :string,
+          description: "Mode for parsing entities"
+        },
+        reply_markup: %{
+          type: :object,
+          description: "A JSON-serialized object for an inline keyboard."
+        }
+      },
+      required: ["chat_id", "message_id", "text"]
+    }
+
+  @impl true
+  def after_focus(%{"ok" => true, "result" => result}) do
+    {:ok, result}
+  end
+
+  def after_focus(%{"ok" => false, "description" => description} = error) do
+    {:error, error}
+  end
+
+  def after_focus(error) do
+    {:error, error}
+  end
+end

--- a/lux/lib/lux/lenses/telegram/messages/send_message.ex
+++ b/lux/lib/lux/lenses/telegram/messages/send_message.ex
@@ -1,0 +1,50 @@
+defmodule Lux.Lenses.Telegram.Messages.SendMessage do
+  @moduledoc \"\"\"
+  A lens for sending text messages via Telegram Bot API.
+  \"\"\"
+
+  alias Lux.Integrations.Telegram
+
+  use Lux.Lens,
+    name: "Send Telegram Message",
+    description: "Sends a text message to a chat.",
+    url: "https://api.telegram.org/bot/sendMessage",
+    method: :post,
+    headers: Telegram.headers(),
+    auth: Telegram.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        chat_id: %{
+          type: :string,
+          description: "Unique identifier for the target chat"
+        },
+        text: %{
+          type: :string,
+          description: "Text of the message to be sent"
+        },
+        parse_mode: %{
+          type: :string,
+          description: "Mode for parsing entities (e.g. MarkdownV2 or HTML)"
+        },
+        reply_markup: %{
+          type: :object,
+          description: "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+        }
+      },
+      required: ["chat_id", "text"]
+    }
+
+  @impl true
+  def after_focus(%{"ok" => true, "result" => result}) do
+    {:ok, result}
+  end
+
+  def after_focus(%{"ok" => false, "description" => description} = error) do
+    {:error, error}
+  end
+
+  def after_focus(error) do
+    {:error, error}
+  end
+end

--- a/lux/lib/lux/lenses/telegram/webhooks/set_webhook.ex
+++ b/lux/lib/lux/lenses/telegram/webhooks/set_webhook.ex
@@ -1,0 +1,46 @@
+defmodule Lux.Lenses.Telegram.Webhooks.SetWebhook do
+  @moduledoc \"\"\"
+  A lens for setting up a webhook for the Telegram Bot API.
+  \"\"\"
+
+  alias Lux.Integrations.Telegram
+
+  use Lux.Lens,
+    name: "Set Telegram Webhook",
+    description: "Specifies a url and receives incoming updates via an outgoing webhook.",
+    url: "https://api.telegram.org/bot/setWebhook",
+    method: :post,
+    headers: Telegram.headers(),
+    auth: Telegram.auth(),
+    schema: %{
+      type: :object,
+      properties: %{
+        url: %{
+          type: :string,
+          description: "HTTPS URL to send updates to"
+        },
+        secret_token: %{
+          type: :string,
+          description: "A secret token to be sent in a header X-Telegram-Bot-Api-Secret-Token in every webhook request"
+        }
+      },
+      required: ["url"]
+    }
+
+  @impl true
+  def after_focus(%{"ok" => true, "result" => result, "description" => description}) do
+    {:ok, %{result: result, description: description}}
+  end
+
+  def after_focus(%{"ok" => true, "result" => result}) do
+    {:ok, result}
+  end
+
+  def after_focus(%{"ok" => false, "description" => description} = error) do
+    {:error, error}
+  end
+
+  def after_focus(error) do
+    {:error, error}
+  end
+end

--- a/lux/test/unit/lux/lenses/telegram/media/send_document_test.exs
+++ b/lux/test/unit/lux/lenses/telegram/media/send_document_test.exs
@@ -1,0 +1,35 @@
+defmodule Lux.Lenses.Telegram.Media.SendDocumentTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Telegram.Media.SendDocument
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully sends a document" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "POST"
+        assert String.ends_with?(conn.request_path, "/sendDocument")
+        
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "ok" => true,
+          "result" => %{
+            "message_id" => 1,
+            "document" => %{"file_id" => "BQADBA"}
+          }
+        }))
+      end)
+
+      assert {:ok, result} = SendDocument.focus(%{
+        chat_id: "12345",
+        document: "https://example.com/doc.pdf"
+      }, %{})
+
+      assert result["message_id"] == 1
+    end
+  end
+end

--- a/lux/test/unit/lux/lenses/telegram/media/send_photo_test.exs
+++ b/lux/test/unit/lux/lenses/telegram/media/send_photo_test.exs
@@ -1,0 +1,35 @@
+defmodule Lux.Lenses.Telegram.Media.SendPhotoTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Telegram.Media.SendPhoto
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully sends a photo" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "POST"
+        assert String.ends_with?(conn.request_path, "/sendPhoto")
+        
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "ok" => true,
+          "result" => %{
+            "message_id" => 1,
+            "photo" => [%{"file_id" => "AgADBA"}]
+          }
+        }))
+      end)
+
+      assert {:ok, result} = SendPhoto.focus(%{
+        chat_id: "12345",
+        photo: "https://example.com/photo.jpg"
+      }, %{})
+
+      assert result["message_id"] == 1
+    end
+  end
+end

--- a/lux/test/unit/lux/lenses/telegram/messages/delete_message_test.exs
+++ b/lux/test/unit/lux/lenses/telegram/messages/delete_message_test.exs
@@ -1,0 +1,30 @@
+defmodule Lux.Lenses.Telegram.Messages.DeleteMessageTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Telegram.Messages.DeleteMessage
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully deletes a message" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "POST"
+        assert String.ends_with?(conn.request_path, "/deleteMessage")
+        
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "ok" => true,
+          "result" => true
+        }))
+      end)
+
+      assert {:ok, true} = DeleteMessage.focus(%{
+        chat_id: "12345",
+        message_id: 1
+      }, %{})
+    end
+  end
+end

--- a/lux/test/unit/lux/lenses/telegram/messages/edit_message_test.exs
+++ b/lux/test/unit/lux/lenses/telegram/messages/edit_message_test.exs
@@ -1,0 +1,42 @@
+defmodule Lux.Lenses.Telegram.Messages.EditMessageTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Telegram.Messages.EditMessage
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully edits a message" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "POST"
+        assert String.ends_with?(conn.request_path, "/editMessageText")
+        
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        params = Jason.decode!(body)
+        assert params["chat_id"] == "12345"
+        assert params["message_id"] == 1
+        assert params["text"] == "Edited Text"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "ok" => true,
+          "result" => %{
+            "message_id" => 1,
+            "text" => "Edited Text"
+          }
+        }))
+      end)
+
+      assert {:ok, result} = EditMessage.focus(%{
+        chat_id: "12345",
+        message_id: 1,
+        text: "Edited Text"
+      }, %{})
+
+      assert result["text"] == "Edited Text"
+    end
+  end
+end

--- a/lux/test/unit/lux/lenses/telegram/messages/send_message_test.exs
+++ b/lux/test/unit/lux/lenses/telegram/messages/send_message_test.exs
@@ -1,0 +1,67 @@
+defmodule Lux.Lenses.Telegram.Messages.SendMessageTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Telegram.Messages.SendMessage
+
+  setup do
+    Req.Test.verify_on_exit!()
+    # Note: token comes from Lux.Config.telegram_bot_token() in config.
+    # We mock the config in test.envrc usually or application config.
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully sends a message" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "POST"
+        assert String.ends_with?(conn.request_path, "/sendMessage")
+        
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        params = Jason.decode!(body)
+        assert params["chat_id"] == "12345"
+        assert params["text"] == "Hello World"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "ok" => true,
+          "result" => %{
+            "message_id" => 1,
+            "text" => "Hello World"
+          }
+        }))
+      end)
+
+      assert {:ok, result} = SendMessage.focus(%{
+        chat_id: "12345",
+        text: "Hello World"
+      }, %{})
+
+      assert result["message_id"] == 1
+      assert result["text"] == "Hello World"
+    end
+
+    test "handles Telegram API error" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(400, Jason.encode!(%{
+          "ok" => false,
+          "error_code" => 400,
+          "description" => "Bad Request: chat not found"
+        }))
+      end)
+
+      assert {:error, %{"ok" => false, "description" => "Bad Request: chat not found"}} = SendMessage.focus(%{
+        chat_id: "invalid_chat",
+        text: "Hello"
+      }, %{})
+    end
+  end
+
+  describe "schema validation" do
+    test "validates required fields" do
+      lens = SendMessage.view()
+      assert lens.schema.required == ["chat_id", "text"]
+    end
+  end
+end

--- a/lux/test/unit/lux/lenses/telegram/webhooks/set_webhook_test.exs
+++ b/lux/test/unit/lux/lenses/telegram/webhooks/set_webhook_test.exs
@@ -1,0 +1,33 @@
+defmodule Lux.Lenses.Telegram.Webhooks.SetWebhookTest do
+  use UnitAPICase, async: true
+  alias Lux.Lenses.Telegram.Webhooks.SetWebhook
+
+  setup do
+    Req.Test.verify_on_exit!()
+    :ok
+  end
+
+  describe "focus/2" do
+    test "successfully sets a webhook" do
+      Req.Test.expect(Lux.Lens, fn conn ->
+        assert conn.method == "POST"
+        assert String.ends_with?(conn.request_path, "/setWebhook")
+        
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{
+          "ok" => true,
+          "result" => true,
+          "description" => "Webhook was set"
+        }))
+      end)
+
+      assert {:ok, result} = SetWebhook.focus(%{
+        url: "https://example.com/webhook"
+      }, %{})
+
+      assert result[:result] == true
+      assert result[:description] == "Webhook was set"
+    end
+  end
+end


### PR DESCRIPTION
Hey, getting this up for issue #62. 

This adds the core Telegram Bot API integration to Lux using the Lens architecture. 

I basically mapped out the main API endpoints for messaging and media into their own lenses under `lib/lux/lenses/telegram/`:
- `SendMessage`, `EditMessage`, `DeleteMessage` for chat handling (supports inline keyboards/parse mode)
- `SendPhoto` and `SendDocument` for media (works with both existing `file_id`s and HTTPS URLs)
- `SetWebhook` for routing incoming updates

Also tweaked `Lux.Integrations.Telegram.add_auth_header/1` so it accepts the `Lux.Lens` struct natively, pulls the bot token directly from `Lux.Config`, and mounts it onto the request URL seamlessly before `Req` fires.

Wrote unit tests mirroring the Discord integration approach (using `Req.Test.expect/2`), so it intercepts the requests and doesn't make live HTTP calls during CI. 

Let me know if you want any of the parameter schemas tweaked or if you need additional endpoints mapped out!
